### PR TITLE
Update dbtools-mcp-server.py

### DIFF
--- a/src/dbtools-mcp-server/dbtools-mcp-server.py
+++ b/src/dbtools-mcp-server/dbtools-mcp-server.py
@@ -81,24 +81,6 @@ def get_compartment_by_name(compartment_name: str):
 
     return None
 
-def get_compartment_by_name_v2(compartment_name: str):
-    """Internal function to get compartment by name using the query API"""
-    search_details = StructuredSearchDetails(
-        query=f"query compartment resources where displayName = '{compartment_name}'",
-        type="Structured",
-        matching_context_type="NONE"
-    )
-    try:
-        resp = search_client.search_resources(search_details=search_details, tenant_id=config['tenancy']).data
-        if not hasattr(resp, 'items') or len(resp.items) == 0:
-            return None       
-        # being compatible with get_compartment_by_name behavior - retrieving a Compartment
-        compartment = identity_client.get_compartment( compartment_id= resp.items[0].identifier )
-        return compartment.data
-        
-    except Exception as e:
-        return None
-
 @mcp.tool()
 def get_compartment_by_name_tool(name: str) -> str:
     """Return a compartment matching the provided name"""


### PR DESCRIPTION
# Description

**Original Issue**:

The functions utilize the OCI SDK's list_compartments method without pagination, which by default returns only the first 100 results. In tenancies with thousands of compartments, the current implementation may return an error:

````
error: Compartment compartment_name not found
````

This occurs because the user’s compartment is not included in the initial 100 results retrieved (due to lack of pagination). **Note**: the list is sorted alphabetically by name.

**Proposed Fix 1**:

Implement pagination in the `list_compartments` call by incorporating the `page` and `limit` parameters and handling the `next_page` token to fetch all pages of results. This ensures all compartments are retrieved while preserving the current behavior of `list_all_compartments`. The existing `get_compartment_by_name` function remains in use, but now validates results only after retrieving all compartments. This maintains backward compatibility while ensuring accuracy.

**Proposed Fix 2**:

Introduce an alternative implementation for `get_compartment_by_name` (see `get_compartment_by_name_v2`). The existing function remains in use, but this new version provides a new approach for retrieving compartments by name.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To reproduce this issue, ensure the tenancy contains more than 100 compartments. Alternatively, simulate the scenario using the `limit` parameter and setting `only_one_page` to restrict results to a single page.

I have tested using [MCP Inspector](https://modelcontextprotocol.io/legacy/tools/inspector)

- [x] list_all_compartments
- [x] get_compartment_by_name_tool
- [x] list_autonomous_databases

For V2:
I updated the get_compartment_by_name_tool function in the test environment to use the new  `get_compartment_by_name_v2` .

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules




