### PR TITLE
Add ignore for .egg-info

### DIFF
--- a/src/oracle-db-doc-mcp-server/.gitignore
+++ b/src/oracle-db-doc-mcp-server/.gitignore
@@ -1,2 +1,3 @@
 *.log
 index*
+*.egg-info


### PR DESCRIPTION
# Description

Add `*.egg-info` to `.gitignore`. 
Running `make install` on the root directory adds a new egg-info file, which appears as an untracked git file.
This ignores the file on build.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Via GitHub action tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
