### PR TITLE
(chore) Remove uv.lock from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ env.bak/
 venv.bak/
 
 # Python uv
-uv.lock
 .python-version
 
 # VScode
@@ -21,3 +20,4 @@ uv.lock
 
 # test environments
 .env
+


### PR DESCRIPTION
# Description

- uv.lock should be checked into the repo.
- Added `.coverage` to not add coverage files


