### PR TITLE
Add the NL2SQL tool to the MySQL MCP server. This tool internally use…

### DIFF
--- a/src/mysql-mcp-server/README.md
+++ b/src/mysql-mcp-server/README.md
@@ -21,6 +21,7 @@ A Python-based MCP (Model Context Protocol) server that provides a suite of tool
   - `ragify_column`: Create/populate vector columns for embeddings
   - `ask_ml_rag`: Retrieval-augmented generation from vector stores
   - `heatwave_ask_help`: Answers questions about how to use HeatWave ML
+  - `ask_nl_sql`: Convert natural language questions into SQL queries and execute them automatically
 
 - **Vector Store Management**
   - List files in `secure_file_priv` (local mode)
@@ -213,6 +214,7 @@ python mysql_mcp_server.py
 11. `list_all_compartments()`: List OCI compartments
 12. `object_storage_list_buckets(compartment_name | compartment_id)`: List buckets in a compartment
 13. `object_storage_list_objects(namespace, bucket_name)`: List objects in a bucket
+14. `ask_nl_sql(connection_id, question)`: Convert natural language questions into SQL queries and execute them automatically
 
 ## Security
 
@@ -236,6 +238,7 @@ Here are example prompts you can use to interact with the MCP server, note that 
 ```
 "Generate a summary of error logs"
 "Ask ml_rag: Show me refund policy from the vector store"
+"What is the average delay incurred by flights?"
 ```
 
 ### 3. Object Storage


### PR DESCRIPTION
…s semantic models to convert the user's natural language query into a SQL query and then executes it

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested using the MCP functionality in Cline
I had a schema with a bunch of our ML benchmark datasets
Q -> What percentage of credit card customers committed fraud?
This is what ask_nl_sql tool generated
"sql_query": "SELECT (COUNT(CASE WHEN `Class` = 1 THEN 1 END) / COUNT(*)) * 100 AS `percentage_fraudulent`  FROM `ml_benchmark`.`creditcard_train`;", "is_sql_valid": 1, "sql_response": "null"
MCP now took over. First attempt (FAILED)
SELECT (COUNT(CASE WHEN Class = 1 THEN 1 END) / COUNT(*)) * 100 AS percentage_fraudulent FROM ml_benchmark.creditcard_train;
Error executing SQL: Object of type Decimal is not JSON serializable
Second attempt (FAILED)
SELECT ROUND((COUNT(CASE WHEN Class = 1 THEN 1 END) / COUNT(*)) * 100, 4) AS percentage_fraudulent FROM ml_benchmark.creditcard_train;
Error executing SQL: Object of type Decimal is not JSON serializable
Third attempt (SUCCESS)
SELECT FORMAT((COUNT(CASE WHEN Class = 1 THEN 1 END) / COUNT(*)) * 100, 4) AS percentage_fraudulent FROM ml_benchmark.creditcard_train;
[["0.1700"]]


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
