### PR TITLE
feat: add publish scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,20 @@ combine-coverage:
 	uv run coverage html
 	uv run coverage report --fail-under=69
 
+test-publish:
+	@for dir in $(SUBDIRS); do \
+		cd $$dir && \
+		uv publish --publish-url https://test.pypi.org/legacy/ --check-url=https://test.pypi.org/simple/ && \
+		cd ../..; \
+	done
+
+publish:
+	@for dir in $(SUBDIRS); do \
+		cd $$dir && \
+		uv publish --check-url=https://pypi.org/simple/ && \
+		cd ../..; \
+	done
+
 format:
 	uv tool run --from 'tox==4.30.2' tox -e format
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,33 @@ make lint
 make test
 ```
 
+## Publishing
+
+### Publish & verify test packages
+
+Publish packages to PyPI test registry:
+```bash
+UV_PUBLISH_TOKEN=$(cat /path/to/testpypi/token-file) make test-publish
+```
+
+Verify installation:
+```bash
+uv run --index=https://test.pypi.org/simple <mcp server package>
+```
+example:
+```bash
+uv run --index=https://test.pypi.org/simple oracle.oci-api-mcp-server
+```
+
+### Publish packages
+
+>[!IMPORTANT]
+> NOTE: The `UV_PUBLISH_TOKEN` differs for Test PyPI and PyPI.
+
+```bash
+UV_PUBLISH_TOKEN=$(cat /path/to/pypi/token-file) make publish
+```
+
 ## Contributing
 
 This project welcomes contributions from the community. Before submitting a pull 


### PR DESCRIPTION
# Description

Automates publishing of all OCI MCP servers to PyPI's test and prod registries.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested during the last publish via:

```bash
UV_PUBLISH_TOKEN=$(fetch test token from vault) make test-publish
```
and
```bash
UV_PUBLISH_TOKEN=$(fetch prod token from vault) make publish
```


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
