### PR TITLE
chore: Add changelogs to support publishing of MCP servers

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -8,6 +8,7 @@ This document lays out the best practices for an individual MCP server. You may 
 mcp-server-name/
 ├── LICENSE.txt             # License information
 ├── pyproject.toml          # Project configuration
+├── CHANGELOG.md            # The CHANGELOG for the server.
 ├── README.md               # Project description, setup instructions
 ├── uv.lock                 # Dependency lockfile
 └── oracle/                 # Source code directory

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,11 +42,12 @@ can be accepted.
    the issue number as part of your branch name, e.g. `1234-fixes`.
 4. Ensure that any documentation is updated with the changes that are required
    by your change.
-5. Ensure that any samples are updated if the base image has been changed.
-6. Submit the pull request. *Do not leave the pull request blank*. Explain exactly
+5. Ensure that any change to any of the MCP servers has a corresponding update in the CHANGELOG.md for that respective MCP server. Changes to MCP servers without corresponding changes in the CHANGELOG.MD will be rejected.
+6. Ensure that any samples are updated if the base image has been changed.
+7. Submit the pull request. *Do not leave the pull request blank*. Explain exactly
    what your changes are meant to do and provide simple steps on how to validate.
    your changes. Ensure that you reference the issue you created as well.
-1. We will assign the pull request to 2-3 people for review before it is merged.
+8. We will assign the pull request to 2-3 people for review before it is merged.
 
 ## Code of conduct
 

--- a/src/database-mcp-server/CHANGELOG.md
+++ b/src/database-mcp-server/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch

--- a/src/database-mcp-server/oracle/database_mcp_server/__init__.py
+++ b/src/database-mcp-server/oracle/database_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.database-mcp-server"
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/src/oci-api-mcp-server/CHANGELOG.md
+++ b/src/oci-api-mcp-server/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.0.3] - 2025-11-26
+- Updated the fastmcp version
+- Support Autonomous Recovery Service APIs
+- Fixed properly handle malformed command output
+- Updated server.py to add more context for get_oci_command_help call
+- Add build, versioning and publishing infrastructure
+- Added support for coverage report generation
+
+## [1.0.2] - 2025-11-24
+- Updated the server.py according to the new best practices doc
+
+## [1.0.1] - 2025-10-15  
+- Fixed missing package files
+- README disclaimers and consistency updates
+- Package fixes and cleanup
+- Fixed server output and improved prompts
+- Support for a deny list of commands that should be denied execution
+- Update license files and dependencies
+- Add custom user agent header
+- Add copyright headers
+- Fixed module names for generic mcp server and improve context
+- Added the OCI API MCP server

--- a/src/oci-api-mcp-server/uv.lock
+++ b/src/oci-api-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-api-mcp-server"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-cloud-guard-mcp-server/CHANGELOG.md
+++ b/src/oci-cloud-guard-mcp-server/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.0.1] - 2025-11-26
+- Updated the fastmcp version

--- a/src/oci-cloud-guard-mcp-server/uv.lock
+++ b/src/oci-cloud-guard-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-cloud-guard-mcp-server"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-compute-instance-agent-mcp-server/CHANGELOG.md
+++ b/src/oci-compute-instance-agent-mcp-server/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [2.0.1] - 2025-11-26
+- Updated the fastmcp version
+- Improved the OCI MCP server consistency
+- Added build, versioning, and publishing infrastructure
+- Added support for coverage report generation
+
+## [1.0.1] - 2025-10-15
+- README disclaimers and consistency updates
+- Package fixes and cleanup
+- Update license files and dependencies
+- Add custom user agent header
+- Add copyright headers
+- Added the OCI Compute instance agent MCP server
+

--- a/src/oci-compute-instance-agent-mcp-server/uv.lock
+++ b/src/oci-compute-instance-agent-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-compute-instance-agent-mcp-server"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-compute-mcp-server/CHANGELOG.md
+++ b/src/oci-compute-mcp-server/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.1.0] - 2025-11-26
+- Improved consistency
+- Updated the fastmcp version
+- Added build, versioning and publishing infrastructure
+- Added support for coverage report generation
+
+## [1.0.2] - 2025-10-30
+- Updated the code to conform to the new best practices document
+
+## [1.0.1] - 2025-10-15
+- README disclaimers and consistency updates
+- List instances limit and lifecycle state filter
+- Fix update instance
+- Implement launch instance
+- Add copyright headers
+- Remove utils from compute server
+- Strong types in the compute server
+- Added the OCI Compute MCP server
+

--- a/src/oci-compute-mcp-server/uv.lock
+++ b/src/oci-compute-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-compute-mcp-server"
-version = "1.0.2"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-identity-mcp-server/CHANGELOG.md
+++ b/src/oci-identity-mcp-server/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.0.2] - 2025-11-26
+- Updated the fastmcp version
+
+## [1.0.1] - 2025-10-15
+- README disclaimers and consistency updates
+- Package fixes and cleanup
+- Update license files
+- Update dependencies
+- Added custom user agent header
+- Added copyright headers

--- a/src/oci-identity-mcp-server/uv.lock
+++ b/src/oci-identity-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-identity-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-logging-mcp-server/CHANGELOG.md
+++ b/src/oci-logging-mcp-server/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.1.1] - 2025-11-26
+- Updated the fastmcp version
+- Fixes the logging server output and added a new search tool
+- Added build, versioning and publishing infrastructure
+- Added support for coverage report generation
+
+## [1.0.1] - 2025-10-15
+- Added missing package files
+- README disclaimers and consistency updates
+- Logging MCP Server
+
+

--- a/src/oci-logging-mcp-server/uv.lock
+++ b/src/oci-logging-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-logging-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-migration-mcp-server/CHANGELOG.md
+++ b/src/oci-migration-mcp-server/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.0.2] - 2025-11-26
+- Updated the fastmcp version
+- Added build, versioning and publishing infrastructure
+- Added support for coverage report generation
+
+## [1.0.1] - 2025-10-15
+- README disclaimers and consistency updates
+- Package fixes and cleanup
+- Updated license files
+- Update dependencies
+- Added custom user agent header
+- Added copyright headers
+

--- a/src/oci-migration-mcp-server/uv.lock
+++ b/src/oci-migration-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-migration-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-monitoring-mcp-server/CHANGELOG.md
+++ b/src/oci-monitoring-mcp-server/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.0.2] - 2025-11-26
+- Updated the fastmcp version
+- Added build, versioning and publishing infrastructure
+- Added support for coverage report generation
+
+## [1.0.1] - 2025-10-15
+- README disclaimers and consistency updates
+- Package fixes and cleanup
+
+## [1.0.0] - 2025-10-13
+- Usage MCP server for cost analysis
+- Update license files and dependencies
+- Added copyright headers

--- a/src/oci-monitoring-mcp-server/uv.lock
+++ b/src/oci-monitoring-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-monitoring-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-network-load-balancer-mcp-server/CHANGELOG.md
+++ b/src/oci-network-load-balancer-mcp-server/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.0.2] - 2025-11-26
+- Updated the fastmcp version
+- Add build, versioning and publishing infrastructure
+- Added support for coverage report generation
+
+## [1.0.1] - 2025-10-15
+- README disclaimers and consistency updates
+- Update license files and dependencies
+- Add custom user agent header
+- Add copyright headers
+- Lock down subprocess a bit more and fix tests
+- Add network security tools
+- Add NLB tests
+- Implement basic NLB server
+
+

--- a/src/oci-network-load-balancer-mcp-server/uv.lock
+++ b/src/oci-network-load-balancer-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-network-load-balancer-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-networking-mcp-server/CHANGELOG.md
+++ b/src/oci-networking-mcp-server/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.1.0] - 2025-11-26
+- Updated the fastmcp version
+- Added build, versioning and publishing infrastructure
+- Added support for coverage report generation
+
+## [1.0.1] - 2025-10-15
+- README disclaimers and consistency updates
+- Package fixes and cleanup
+- Update license files  and dependencies
+- Finish unit tests for networking mcp server
+- Add custom user agent header
+- Add network security tools and unit tests
+

--- a/src/oci-networking-mcp-server/uv.lock
+++ b/src/oci-networking-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-networking-mcp-server"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-object-storage-mcp-server/CHANGELOG.md
+++ b/src/oci-object-storage-mcp-server/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.0.2] - 2025-11-26
+- Updated the fastmcp version
+- Add build, versioning and publishing infrastructure
+- Added support for coverage report generation
+
+## [1.0.1] - 2025-10-15
+- README disclaimers and consistency updates
+- Package fixes and cleanup
+- Added OCI Object Storage Service MCP Server
+
+

--- a/src/oci-object-storage-mcp-server/uv.lock
+++ b/src/oci-object-storage-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-object-storage-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-registry-mcp-server/CHANGELOG.md
+++ b/src/oci-registry-mcp-server/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.0.2] - 2025-11-26
+- Updated the fastmcp version
+- Add build, versioning and publishing infrastructure
+- Added support for coverage report generation
+
+## [1.0.1] - 2025-10-15
+- README disclaimers and consistency updates
+- Package fixes and cleanup
+- Update license files and dependencies 
+- Add custom user agent header
+- add copyright headers
+- Added the OCI Registry MCP Server

--- a/src/oci-registry-mcp-server/uv.lock
+++ b/src/oci-registry-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-registry-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-resource-search-mcp-server/CHANGELOG.md
+++ b/src/oci-resource-search-mcp-server/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.0.2] - 2025-11-26
+- Updated the fastmcp version
+- Add build, versioning and publishing infrastructure
+- Added support for coverage report generation
+
+## [1.0.1] - 2025-10-15
+- README disclaimers and consistency updates
+- Package fixes and cleanup
+- Update license files and dependencies
+- Add custom user agent header
+- Add tests
+- Add the OCI Resource Search MCP server

--- a/src/oci-resource-search-mcp-server/uv.lock
+++ b/src/oci-resource-search-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-resource-search-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-usage-mcp-server/CHANGELOG.md
+++ b/src/oci-usage-mcp-server/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The sub-sections are used to generate the next version of the project.
+
+## [Unreleased]
+
+### Major (breaking)
+
+### Minor (non-breaking)
+
+### Patch
+
+
+## [1.0.2] - 2025-11-26
+- Updated the fastmcp version
+- Add build, versioning and publishing infrastructure
+- Added support for coverage report generation
+
+## [1.0.1] - 2025-10-15
+- README disclaimers and consistency updates
+- Package fixes and cleanup
+- Added the Usage MCP server for cost analysis
+
+
+

--- a/src/oci-usage-mcp-server/uv.lock
+++ b/src/oci-usage-mcp-server/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-usage-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
# Description

- Added changelogs for all OCI MCP servers with information on already released versions.
- Added the current unreleased version, which will determine the next version to be published.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- Testing in the downstream repo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
