### PR TITLE
Allow make commands to be run on a single project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
-SUBDIRS ?= $(filter-out src/dbtools-mcp-server src/mysql-mcp-server src/oci-pricing-mcp-server src/oracle-db-doc-mcp-server src/oracle-db-mcp-java-toolkit,$(wildcard src/*))
+SOURCE_FOLDER := src
+# These directories will be excluded from common cmds like build, install, test etc
+EXCLUDED_PROJECTS := dbtools-mcp-server mysql-mcp-server oci-pricing-mcp-server oracle-db-doc-mcp-server oracle-db-mcp-java-toolkit
+EXCLUDED_PROJECT_PATHS = $(addprefix $(SOURCE_FOLDER)/, $(EXCLUDED_PROJECTS))
+# This matches all paths by default. If you want to run a command on a specific package you can specify the `project` variable
+project ?= *
+# These are the directories that will be built
+DIRS := $(wildcard $(SOURCE_FOLDER)/$(project))
+SUBDIRS := $(filter-out $(EXCLUDED_PROJECT_PATHS), $(DIRS))
 
 .PHONY: test format
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ This section will help you set up your environment to prepare it for local devel
     make build
     make install
     ```
+**Note**: If you want to run commands in a single server project, you can add the `project` variable to only run commands for that specific project
+For example: `make project=oci-compute-mcp-server build` will only build the compute mcp server
 
 3. Add desired servers to your MCP client configuration, but run them using the locally installed server package instead
 


### PR DESCRIPTION
# Description

As the project grows it takes longer to build and install all the packages when running commands like `make build` or `make install`. This PR lets us run commands for a single project like `make project=project_name build` so other teams dont need to wait for other projects to build if they are only working on a specific server.

For example:
- `make build` - runs the build command on all the folders in the `src` folder besides the excluded packages
- `make project=oci-compute-mcp-server build` builds just the compute mcp server and nothing else

Fixes # (issue)
- N/A

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Checkout this branch
- Running the make commands should still work as expected
- Running make commands with a specific project should run on that specific project
- Excluded projects should still be honored


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
