### PR TITLE
chore(build): Update Makefile to make build target portable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Update __init__.py
         working-directory: src/${{ matrix.directory }}
         run: |
-          name=$(uv run tomlq -r '.project.name' pyproject.toml)
-          version=$(uv run tomlq -r '.project.version' pyproject.toml)
+          name=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['name'])")
+          version=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           if [ -d oracle/*_mcp_server ]; then
             init_py_file=oracle/*_mcp_server/__init__.py
             echo "\"\"\"\nCopyright (c) 2025, Oracle and/or its affiliates.\nLicensed under the Universal Permissive License v1.0 as shown at\nhttps://oss.oracle.com/licenses/upl.\n\"\"\"\n" > $$init_py_file; \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,4 @@ pytest
 pytest-asyncio
 pytest-cov
 tox
-tomlq
 uv


### PR DESCRIPTION
# Description

1. The `build` target in the Makefile uses `uv` to read the name and version from the `pyproject.toml file`. This requires `jq` to be installed on the system. Some of the CI/CD build images do not come with jq. Hence, removed this dependency and used `python` to get the name and version.
2. The build target also uses the lesser portable `echo` command to print the copyright message with newlines and `"""`. This again causes issues in Linux systems that use the `sh` shell for Makefile, which requires `echo -e` to print escaped characters. Replaced this with printf, which works in all systems.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Testing in MacOS
1. Checkout the PR
2. run `make build`. This should pass and show no changes in any files
3. run `make test`. This should pass.

## Testing in a Linux environment using podman
1. Check out the PR
2. In a separate terminal, install and initialize podman: https://podman.io/docs/installation
3. Start a Linux container using the following command.
4. `podman run -it ghcr.io/oracle/oraclelinux:9-slim@sha256:1950389c3dd619841813520b4e69d7f3112c4c10f713fcb90680703d184c33ad`
5. In another terminal, navigate to the checked-out PR. Note the container ID using the `podman ps` command
6. Copy the source code to the container. In the following example `587d1a9bc8f9` is the container id.
7. `podman cp oracle-mcp 587d1a9bc8f9:/.`
8. Note: The rest of the commands should be executed in the container shell
```bash
microdnf install epel-release && microdnf install python3.13 python3.13-pip make
cd oracle-mcp
rm -rf .venv
python3.13 -m venv .venv
. .venv/bin/activate
pip install -r requirements-dev.txt
make build
cat src/oci-api-mcp-server/oracle/oci_api_mcp_server/__init__.py
"""
Copyright (c) 2025, Oracle and/or its affiliates.
Licensed under the Universal Permissive License v1.0 as shown at
https://oss.oracle.com/licenses/upl.
"""

__project__ = "oracle.oci-api-mcp-server"
__version__ = "1.1.1"
```
9. The above `make build` command in the container should succeed and the `__init__.py` should show the contents with newlines

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
