### PR TITLE
Increase UT coverage for monitoring, object storage, usage, registry, and resource search

### DIFF
--- a/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/server.py
+++ b/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/server.py
@@ -12,10 +12,7 @@ from typing import Annotated, List, Optional, Tuple
 import oci
 from fastmcp import Context, FastMCP
 from oci import Response
-from oci.monitoring.models import (
-    ListMetricsDetails,
-    SummarizeMetricsDataDetails,
-)
+from oci.monitoring.models import ListMetricsDetails, SummarizeMetricsDataDetails
 from oracle.oci_monitoring_mcp_server.alarm_models import (
     AlarmSummary,
     map_alarm_summary,

--- a/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/tests/test_monitoring_models.py
+++ b/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/tests/test_monitoring_models.py
@@ -1,0 +1,239 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from oracle.oci_monitoring_mcp_server.alarm_models import (
+    AlarmOverride,
+    AlarmSummary,
+    Suppression,
+    map_alarm_override,
+    map_alarm_overrides,
+    map_alarm_summary,
+    map_suppression,
+)
+from oracle.oci_monitoring_mcp_server.metric_models import (
+    AggregatedDatapoint,
+    Datapoint,
+)
+from oracle.oci_monitoring_mcp_server.metric_models import (
+    ListMetricsDetails as PListMetricsDetails,
+)
+from oracle.oci_monitoring_mcp_server.metric_models import (
+    Metric,
+    MetricData,
+    MetricDataDetails,
+)
+from oracle.oci_monitoring_mcp_server.metric_models import (
+    SummarizeMetricsDataDetails as PSummarizeMetricsDataDetails,
+)
+from oracle.oci_monitoring_mcp_server.metric_models import (
+    map_aggregated_datapoint,
+    map_aggregated_datapoints,
+    map_datapoint,
+    map_datapoints,
+    map_list_metrics_details,
+    map_metric,
+    map_metric_data,
+    map_metric_data_details,
+)
+
+
+class TestAlarmModels:
+    def test_map_suppression_none(self) -> None:
+        assert map_suppression(None) is None
+
+    def test_map_suppression_values_snake_and_camel(self) -> None:
+        s1 = SimpleNamespace(
+            description="Desc",
+            time_suppress_from=datetime(2024, 1, 1),
+            time_suppress_until=datetime(2024, 1, 2),
+        )
+        mapped1 = map_suppression(s1)
+        assert isinstance(mapped1, Suppression)
+        assert mapped1.description == "Desc"
+        assert mapped1.time_suppress_from == datetime(2024, 1, 1)
+        assert mapped1.time_suppress_until == datetime(2024, 1, 2)
+
+        s2 = SimpleNamespace(
+            description="D",
+            timeSuppressFrom=datetime(2023, 5, 1),
+            timeSuppressUntil=datetime(2023, 5, 2),
+        )
+        mapped2 = map_suppression(s2)
+        assert mapped2.time_suppress_from == datetime(2023, 5, 1)
+        assert mapped2.time_suppress_until == datetime(2023, 5, 2)
+
+    def test_map_alarm_override_none_and_values(self) -> None:
+        assert map_alarm_override(None) is None
+        ov = SimpleNamespace(
+            ruleName="BASE",
+            query="Q",
+            severity="CRITICAL",
+            body="B",
+            pendingDuration="PT5M",
+        )
+        mapped = map_alarm_override(ov)
+        assert isinstance(mapped, AlarmOverride)
+        assert mapped.rule_name == "BASE"
+        assert mapped.query == "Q"
+        assert mapped.severity == "CRITICAL"
+        assert mapped.body == "B"
+        assert mapped.pending_duration == "PT5M"
+
+    def test_map_alarm_overrides_list_and_empty(self) -> None:
+        assert map_alarm_overrides(None) is None
+        assert map_alarm_overrides([]) is None
+        ov = SimpleNamespace(ruleName="BASE")
+        out = map_alarm_overrides([ov, None])
+        assert isinstance(out, list)
+        assert out and out[0].rule_name == "BASE"
+
+    def test_map_alarm_summary(self) -> None:
+        alarm_snake = SimpleNamespace(
+            id="ocid1.alarm.oc1..abc",
+            display_name="High CPU",
+            compartment_id="ocid1.compartment.oc1..xyz",
+            metric_compartment_id="ocid1.compartment.oc1..m",
+            namespace="oci_compute",
+            query="CpuUtilization[1m].mean()>80",
+            severity="CRITICAL",
+            destinations=["ocid1.topic.oc1..t1"],
+            suppression=SimpleNamespace(description="maint"),
+            is_enabled=True,
+            isNotificationsPerMetricDimensionEnabled=False,
+            freeform_tags={"env": "dev"},
+            defined_tags={"NS": {"K": "V"}},
+            lifecycle_state="ACTIVE",
+            overrides=[SimpleNamespace(ruleName="BASE")],
+            rule_name="BASE",
+            notification_version="1.0",
+            notification_title="Title",
+            evaluation_slack_duration="PT3M",
+            alarm_summary="summary",
+            resource_group="rg",
+        )
+        mapped = map_alarm_summary(alarm_snake)
+        assert isinstance(mapped, AlarmSummary)
+        assert mapped.id == "ocid1.alarm.oc1..abc"
+        assert mapped.display_name == "High CPU"
+        assert mapped.compartment_id == "ocid1.compartment.oc1..xyz"
+        assert mapped.metric_compartment_id == "ocid1.compartment.oc1..m"
+        assert mapped.namespace == "oci_compute"
+        assert mapped.query.startswith("CpuUtilization")
+        assert mapped.severity == "CRITICAL"
+        assert mapped.destinations == ["ocid1.topic.oc1..t1"]
+        assert mapped.suppression and mapped.suppression.description == "maint"
+        assert mapped.is_enabled is True
+        assert mapped.is_notifications_per_metric_dimension_enabled is False
+        assert mapped.freeform_tags == {"env": "dev"}
+        assert mapped.defined_tags == {"NS": {"K": "V"}}
+        assert mapped.lifecycle_state == "ACTIVE"
+        assert mapped.overrides and mapped.overrides[0].rule_name == "BASE"
+        assert mapped.rule_name == "BASE"
+        assert mapped.notification_version == "1.0"
+        assert mapped.notification_title == "Title"
+        assert mapped.evaluation_slack_duration == "PT3M"
+        assert mapped.alarm_summary == "summary"
+        assert mapped.resource_group == "rg"
+
+
+class TestMetricModels:
+    def test_map_metric(self) -> None:
+        m = SimpleNamespace(
+            namespace="oci_compute",
+            resource_group="rg",
+            compartment_id="ocid1.compartment.oc1..xyz",
+            name="CpuUtilization",
+            dimensions={"resourceId": "ocid1.instance..."},
+            metadata={"unit": "%"},
+            resolution="1m",
+        )
+        mapped = map_metric(m)
+        assert isinstance(mapped, Metric)
+        assert mapped.name == "CpuUtilization"
+        assert mapped.dimensions == {"resourceId": "ocid1.instance..."}
+        assert mapped.metadata == {"unit": "%"}
+        assert mapped.resolution == "1m"
+
+    def test_map_aggregated_datapoint_and_list(self) -> None:
+        assert map_aggregated_datapoint(None) is None
+        p = SimpleNamespace(timestamp=datetime(2024, 1, 1), value=1.5)
+        mp = map_aggregated_datapoint(p)
+        assert isinstance(mp, AggregatedDatapoint)
+        assert mp.value == 1.5
+        assert map_aggregated_datapoints(None) is None
+        lst = map_aggregated_datapoints([p, None])
+        assert isinstance(lst, list)
+        assert lst and isinstance(lst[0], AggregatedDatapoint)
+
+    def test_map_metric_data(self) -> None:
+        md = SimpleNamespace(
+            namespace="oci_compute",
+            resource_group="rg",
+            compartment_id="ocid1.compartment.oc1..xyz",
+            name="CpuUtilization",
+            dimensions={"k": "v"},
+            metadata={"unit": "%"},
+            resolution="1m",
+            aggregated_datapoints=[
+                SimpleNamespace(timestamp=datetime(2024, 1, 1), value=2.0)
+            ],
+        )
+        mapped = map_metric_data(md)
+        assert isinstance(mapped, MetricData)
+        assert mapped.name == "CpuUtilization"
+        assert mapped.aggregated_datapoints and isinstance(
+            mapped.aggregated_datapoints[0], AggregatedDatapoint
+        )
+
+    def test_map_datapoint_and_list(self) -> None:
+        assert map_datapoint(None) is None
+        d = SimpleNamespace(timestamp=datetime(2024, 1, 1), value=3.3, count=2)
+        md = map_datapoint(d)
+        assert isinstance(md, Datapoint)
+        assert md.count == 2
+        assert map_datapoints(None) is None
+        lst = map_datapoints([d, None])
+        assert isinstance(lst, list)
+        assert lst and isinstance(lst[0], Datapoint)
+
+    def test_map_metric_data_details(self) -> None:
+        mdd = SimpleNamespace(
+            namespace="oci_compute",
+            resource_group="rg",
+            compartment_id="c",
+            name="MetricName",
+            dimensions={"x": "y"},
+            metadata={"unit": "bytes"},
+            datapoints=[SimpleNamespace(timestamp=datetime(2024, 1, 1), value=1.0)],
+        )
+        mapped = map_metric_data_details(mdd)
+        assert isinstance(mapped, MetricDataDetails)
+        assert mapped.datapoints and isinstance(mapped.datapoints[0], Datapoint)
+
+    def test_map_list_metrics_details_with_camel_case_fallback(self) -> None:
+        sdk = SimpleNamespace(namespace="ns", resource_group="rg", name="n")
+        # Add camelCase attrs to be used when snake_case is missing
+        setattr(sdk, "dimensionFilters", {"k": "v"})
+        setattr(sdk, "groupBy", ["namespace"])
+        mapped = map_list_metrics_details(sdk)  # type: ignore[arg-type]
+        assert isinstance(mapped, PListMetricsDetails)
+        assert mapped.dimension_filters == {"k": "v"}
+        assert mapped.group_by == ["namespace"]
+
+    def test_construct_pydantic_summarize_metrics_details(self) -> None:
+        # Not a mapping, but ensures model can be created coherently
+        p = PSummarizeMetricsDataDetails(
+            namespace="ns",
+            resource_group="rg",
+            query="MQL",
+            start_time=datetime(2024, 1, 1),
+            end_time=datetime(2024, 1, 2),
+            resolution="1m",
+        )
+        assert p.query == "MQL"

--- a/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/tests/test_monitoring_tools.py
+++ b/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/tests/test_monitoring_tools.py
@@ -4,19 +4,13 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, Mock, mock_open, patch
 
 import oci
 import pytest
 from fastmcp import Client
-from oracle.oci_monitoring_mcp_server.alarm_models import (
-    AlarmSummary,
-    map_alarm_summary,
-)
-from oracle.oci_monitoring_mcp_server.metric_models import (
-    Metric,
-    map_metric,
-)
+from oracle.oci_monitoring_mcp_server import server
 from oracle.oci_monitoring_mcp_server.scripts import MQL_QUERY_DOC, get_script_content
 from oracle.oci_monitoring_mcp_server.server import mcp
 
@@ -104,8 +98,9 @@ class TestMonitoringTools:
 
         assert result is not None
         for metric in result:
-            assert isinstance(map_metric(metric), Metric)
+            assert isinstance(metric, dict)
             assert metric["compartment_id"] == "compartment1"
+            assert "namespace" in metric
 
     @pytest.mark.asyncio
     @patch("oracle.oci_monitoring_mcp_server.server.get_monitoring_client")
@@ -157,8 +152,9 @@ class TestMonitoringTools:
         result = call_tool_result.structured_content["result"]
 
         for alarm in result:
-            assert alarm is not None
-            assert isinstance(map_alarm_summary(alarm), AlarmSummary)
+            assert isinstance(alarm, dict)
+            assert "id" in alarm
+            assert "display_name" in alarm
 
     @pytest.mark.asyncio
     @patch("oracle.oci_monitoring_mcp_server.server.get_monitoring_client")
@@ -200,8 +196,9 @@ class TestMonitoringTools:
         result = call_tool_result.structured_content["result"]
 
         for alarm in result:
-            assert alarm is not None
-            assert isinstance(map_alarm_summary(alarm), AlarmSummary)
+            assert isinstance(alarm, dict)
+            assert "id" in alarm
+            assert "display_name" in alarm
 
     @pytest.mark.asyncio
     @patch("oracle.oci_monitoring_mcp_server.server.get_monitoring_client")
@@ -217,6 +214,35 @@ class TestMonitoringTools:
         result = call_tool_result.structured_content["result"]
         assert result == "There was no response returned from the Monitoring API"
 
+    @pytest.mark.asyncio
+    @patch("oracle.oci_monitoring_mcp_server.server.get_monitoring_client")
+    async def test_get_metrics_data_empty_response(self, mock_get_client):
+        mock_get_client.return_value = Mock()
+        mock_get_client.return_value.summarize_metrics_data.return_value = None
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "get_metrics_data",
+                {
+                    "query": "CpuUtilization[1m].sum()",
+                    "compartment_id": "compartment1",
+                    "start_time": "2023-01-01T00:00:00Z",
+                    "end_time": "2023-01-01T00:00:00Z",
+                    "namespace": "oci_compute",
+                },
+            )
+        result = call_tool_result.structured_content["result"]
+        assert result == "There was no response returned from the Monitoring API"
+
+
+class TestInternals:
+    def test_prepare_time_parameters(self):
+        start, end = server._prepare_time_parameters("2023-01-01T00:00:00Z", None)
+        assert isinstance(start, datetime)
+        assert isinstance(end, datetime)
+        assert start.tzinfo is not None
+        assert end.tzinfo is not None
+
 
 class TestServer:
     @patch("oracle.oci_monitoring_mcp_server.server.mcp.run")
@@ -228,7 +254,6 @@ class TestServer:
         }
 
         mock_getenv.side_effect = lambda x: mock_env.get(x)
-        import oracle.oci_monitoring_mcp_server.server as server
 
         server.main()
         mock_mcp_run.assert_called_once_with(
@@ -241,7 +266,6 @@ class TestServer:
     @patch("os.getenv")
     def test_main_without_host_and_port(self, mock_getenv, mock_mcp_run):
         mock_getenv.return_value = None
-        import oracle.oci_monitoring_mcp_server.server as server
 
         server.main()
         mock_mcp_run.assert_called_once_with()
@@ -253,7 +277,6 @@ class TestServer:
             "ORACLE_MCP_HOST": "1.2.3.4",
         }
         mock_getenv.side_effect = lambda x: mock_env.get(x)
-        import oracle.oci_monitoring_mcp_server.server as server
 
         server.main()
         mock_mcp_run.assert_called_once_with()
@@ -265,7 +288,6 @@ class TestServer:
             "ORACLE_MCP_PORT": "8888",
         }
         mock_getenv.side_effect = lambda x: mock_env.get(x)
-        import oracle.oci_monitoring_mcp_server.server as server
 
         server.main()
         mock_mcp_run.assert_called_once_with()
@@ -275,3 +297,110 @@ class TestReadFile:
     def test_read_file(self):
         document = get_script_content(MQL_QUERY_DOC)
         assert document is not None
+
+
+class TestGetClient:
+    @patch("oracle.oci_monitoring_mcp_server.server.oci.monitoring.MonitoringClient")
+    @patch(
+        "oracle.oci_monitoring_mcp_server.server.oci.auth.signers.SecurityTokenSigner"
+    )
+    @patch(
+        "oracle.oci_monitoring_mcp_server.server.oci.signer.load_private_key_from_file"
+    )
+    @patch(
+        "oracle.oci_monitoring_mcp_server.server.open",
+        new_callable=mock_open,
+        read_data="SECURITY_TOKEN",
+    )
+    @patch("oracle.oci_monitoring_mcp_server.server.oci.config.from_file")
+    @patch("oracle.oci_monitoring_mcp_server.server.os.getenv")
+    def test_get_monitoring_client_with_profile_env(
+        self,
+        mock_getenv,
+        mock_from_file,
+        mock_open_file,
+        mock_load_private_key,
+        mock_security_token_signer,
+        mock_client,
+    ):
+        # Arrange: provide profile via env var and minimal config dict
+        mock_getenv.side_effect = lambda k, default=None: (
+            "MYPROFILE" if k == "OCI_CONFIG_PROFILE" else default
+        )
+        config = {
+            "key_file": "/abs/path/to/key.pem",
+            "security_token_file": "/abs/path/to/token",
+        }
+        mock_from_file.return_value = config
+        private_key_obj = object()
+        mock_load_private_key.return_value = private_key_obj
+
+        # Act
+        result = server.get_monitoring_client()
+
+        # Assert calls
+        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
+        mock_security_token_signer.assert_called_once_with(
+            "SECURITY_TOKEN", private_key_obj
+        )
+        # Ensure user agent was set on the same config dict passed into client
+        args, _ = mock_client.call_args
+        passed_config = args[0]
+        assert passed_config is config
+        expected_user_agent = f"{server.__project__.split('oracle.', 1)[1].split('-server', 1)[0]}/{server.__version__}"  # noqa
+        assert passed_config.get("additional_user_agent") == expected_user_agent
+        # And we returned the client instance
+        assert result == mock_client.return_value
+
+    @patch("oracle.oci_monitoring_mcp_server.server.oci.monitoring.MonitoringClient")
+    @patch(
+        "oracle.oci_monitoring_mcp_server.server.oci.auth.signers.SecurityTokenSigner"
+    )
+    @patch(
+        "oracle.oci_monitoring_mcp_server.server.oci.signer.load_private_key_from_file"
+    )
+    @patch(
+        "oracle.oci_monitoring_mcp_server.server.open",
+        new_callable=mock_open,
+        read_data="TOK",
+    )
+    @patch("oracle.oci_monitoring_mcp_server.server.oci.config.from_file")
+    @patch("oracle.oci_monitoring_mcp_server.server.os.getenv")
+    def test_get_monitoring_client_uses_default_profile_when_env_missing(
+        self,
+        mock_getenv,
+        mock_from_file,
+        mock_open_file,
+        mock_load_private_key,
+        mock_security_token_signer,
+        mock_client,
+    ):
+        # Arrange: no env var present; from_file should be called with DEFAULT_PROFILE
+        mock_getenv.side_effect = lambda k, default=None: default
+        config = {"key_file": "/k.pem", "security_token_file": "/tkn"}
+        mock_from_file.return_value = config
+        priv = object()
+        mock_load_private_key.return_value = priv
+
+        # Act
+        srv_client = server.get_monitoring_client()
+
+        # Assert: profile defaulted
+        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        # Token file opened and read
+        mock_open_file.assert_called_once_with("/tkn", "r")
+        mock_security_token_signer.assert_called_once()
+        signer_args, _ = mock_security_token_signer.call_args
+        assert signer_args[0] == "TOK"
+        assert signer_args[1] is priv
+        # additional_user_agent set on original config and passed through
+        cc_args, _ = mock_client.call_args
+        assert cc_args[0] is config
+        assert "additional_user_agent" in config
+        assert (
+            isinstance(config["additional_user_agent"], str)
+            and "/" in config["additional_user_agent"]
+        )
+        # Returned object is client instance
+        assert srv_client is mock_client.return_value

--- a/src/oci-monitoring-mcp-server/pyproject.toml
+++ b/src/oci-monitoring-mcp-server/pyproject.toml
@@ -48,4 +48,4 @@ omit = [
 
 [tool.coverage.report]
 precision = 2
-fail_under = 75
+fail_under = 90

--- a/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/tests/test_object_storage_models.py
+++ b/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/tests/test_object_storage_models.py
@@ -1,0 +1,141 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from oracle.oci_object_storage_mcp_server.models import (
+    Bucket,
+    BucketSummary,
+    CreateBucketDetails,
+    ListObjects,
+    NamespaceMetadata,
+    ObjectSummary,
+    ObjectVersionCollection,
+    ObjectVersionSummary,
+    map_bucket,
+    map_bucket_summary,
+    map_object_summary,
+    map_object_version_summary,
+)
+from pydantic import ValidationError
+
+
+class TestModelMapping:
+    def test_map_object_summary_from_oci_like_object(self):
+        # Use a simple namespace to emulate the OCI SDK object with attributes
+        src = SimpleNamespace(
+            name="obj1",
+            size=123,
+            time_created=datetime(2021, 1, 1, tzinfo=timezone.utc),
+            etag="etag-1",
+            storage_tier="STANDARD",
+            archival_state="ARCHIVED",
+            time_modified=datetime(2021, 1, 2, tzinfo=timezone.utc),
+        )
+
+        mapped = map_object_summary(src)
+        assert isinstance(mapped, ObjectSummary)
+        assert mapped.name == "obj1"
+        assert mapped.size == 123
+        assert mapped.storage_tier == "STANDARD"
+        # json encodes datetimes using isoformat
+        json_text = mapped.json()
+        assert "2021-01-01T00:00:00" in json_text
+        assert "2021-01-02T00:00:00" in json_text
+
+    def test_map_bucket_summary_from_oci_like_object(self):
+        src = SimpleNamespace(
+            namespace="ns1",
+            name="bucket1",
+            compartment_id="ocid1.compartment.oc1..xyz",
+            created_by="ocid1.user.oc1..abc",
+            time_created=datetime(2021, 1, 1, tzinfo=timezone.utc),
+            etag="etag-bkt",
+            freeform_tags={"env": "dev"},
+            defined_tags={"ns": {"k": "v"}},
+        )
+
+        mapped = map_bucket_summary(src)
+        assert isinstance(mapped, BucketSummary)
+        assert mapped.name == "bucket1"
+        assert mapped.namespace == "ns1"
+        assert mapped.freeform_tags == {"env": "dev"}
+
+    def test_map_bucket_from_oci_like_object(self):
+        src = SimpleNamespace(
+            namespace="ns1",
+            name="bucket1",
+            compartment_id="ocid1.compartment.oc1..xyz",
+            metadata={"a": "b"},
+            created_by="ocid1.user.oc1..abc",
+            time_created=datetime(2021, 1, 1, tzinfo=timezone.utc),
+            etag="etag-bkt",
+            public_access_type="NoPublicAccess",
+            storage_tier="Standard",
+            object_events_enabled=False,
+            freeform_tags={"env": "dev"},
+            defined_tags={"ns": {"k": "v"}},
+            kms_key_id="ocid1.key.oc1..key",
+            object_lifecycle_policy_etag="olp-etag",
+            approximate_count=10,
+            approximate_size=2048,
+            replication_enabled=False,
+            is_read_only=False,
+            id="ocid1.bucket.oc1..bucket",
+            versioning="Enabled",
+            auto_tiering="InfrequentAccess",
+        )
+
+        mapped = map_bucket(src)
+        assert isinstance(mapped, Bucket)
+        assert mapped.name == "bucket1"
+        assert mapped.approximate_size == 2048
+        assert mapped.versioning == "Enabled"
+
+    def test_map_object_version_summary_from_oci_like_object(self):
+        src = SimpleNamespace(
+            name="obj1",
+            size=123,
+            md5="md5==",
+            time_created=datetime(2021, 1, 1, tzinfo=timezone.utc),
+            time_modified=datetime(2021, 1, 2, tzinfo=timezone.utc),
+            etag="etag-1",
+            storage_tier="STANDARD",
+            archival_state="ARCHIVED",
+            version_id="ver-1",
+            is_delete_marker=False,
+        )
+
+        mapped = map_object_version_summary(src)
+        assert isinstance(mapped, ObjectVersionSummary)
+        assert mapped.version_id == "ver-1"
+        assert mapped.is_delete_marker is False
+
+
+class TestModelValidation:
+    def test_namespace_metadata_forbids_extra_fields(self):
+        with pytest.raises(ValidationError):
+            NamespaceMetadata(namespace="ns", unknown="x")
+
+    def test_create_bucket_details_forbids_extra_fields(self):
+        with pytest.raises(ValidationError):
+            CreateBucketDetails(name="b", compartment_id="c", unknown="x")
+
+    def test_object_version_collection_forbids_extra_fields(self):
+        items = [ObjectVersionSummary(name="o")]  # minimal valid item
+        with pytest.raises(ValidationError):
+            ObjectVersionCollection(items=items, unknown="x")
+
+    def test_list_objects_allows_extra_fields(self):
+        lo = ListObjects(objects=[ObjectSummary(name="a")], prefixes=["p"], extra=1)
+        # extra field should be preserved due to extra="allow"
+        assert getattr(lo, "extra") == 1
+
+    def test_bucket_model_allows_extra_fields(self):
+        b = Bucket(name="bkt", extra_field="ok")
+        assert getattr(b, "extra_field") == "ok"

--- a/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/tests/test_object_storage_tools.py
+++ b/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/tests/test_object_storage_tools.py
@@ -4,12 +4,12 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
-import json
-from unittest.mock import MagicMock, create_autospec, patch
+from unittest.mock import MagicMock, create_autospec, mock_open, patch
 
 import oci
 import pytest
 from fastmcp import Client
+from oracle.oci_object_storage_mcp_server import server
 from oracle.oci_object_storage_mcp_server.models import (
     Bucket,
     BucketSummary,
@@ -19,15 +19,6 @@ from oracle.oci_object_storage_mcp_server.models import (
     ObjectVersionSummary,
 )
 from oracle.oci_object_storage_mcp_server.server import mcp
-
-
-def parse(double_encoded_text: str):
-    return json.loads(json.loads(double_encoded_text))
-
-
-def parse_array(array_str: str):
-    items = json.loads(array_str)
-    return [json.loads(item) for item in items]
 
 
 class TestObjectStorageTools:
@@ -42,17 +33,12 @@ class TestObjectStorageTools:
         mock_client.get_namespace.return_value = mock_namespace_response
 
         async with Client(mcp) as client:
-            result = (
-                (
-                    await client.call_tool(
-                        "get_namespace", {"compartment_id": "test_compartment"}
-                    )
-                )
-                .content[0]
-                .text
+            response = await client.call_tool(
+                "get_namespace", {"compartment_id": "test_compartment"}
             )
+            result = response.content[0].text
 
-            assert result == "test_namespace"
+        assert result == "test_namespace"
 
     @pytest.mark.asyncio
     @patch("oracle.oci_object_storage_mcp_server.server.get_object_storage_client")
@@ -81,8 +67,8 @@ class TestObjectStorageTools:
                 )
             ).structured_content["result"]
 
-            assert len(result) == 1
-            assert result[0]["name"] == "bucket1"
+        assert len(result) == 1
+        assert result[0]["name"] == "bucket1"
 
     @pytest.mark.asyncio
     @patch("oracle.oci_object_storage_mcp_server.server.get_object_storage_client")
@@ -116,8 +102,8 @@ class TestObjectStorageTools:
                 )
             ).structured_content
 
-            assert result["name"] == "bucket1"
-            assert result["approximate_size"] == 100
+        assert result["name"] == "bucket1"
+        assert result["approximate_size"] == 100
 
     @pytest.mark.asyncio
     @patch("oracle.oci_object_storage_mcp_server.server.get_object_storage_client")
@@ -154,14 +140,18 @@ class TestObjectStorageTools:
                 )
             ).structured_content["objects"]
 
-            assert len(result) == 1
-            assert result[0]["name"] == "object1"
+        assert len(result) == 1
+        assert result[0]["name"] == "object1"
 
     @pytest.mark.asyncio
     @patch("oracle.oci_object_storage_mcp_server.server.get_object_storage_client")
     async def test_list_object_versions(self, mock_get_client):
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
+
+        mock_namespace_response = create_autospec(oci.response.Response)
+        mock_namespace_response.data = "test_namespace"
+        mock_client.get_namespace.return_value = mock_namespace_response
 
         mock_list_response = create_autospec(oci.response.Response)
         mock_list_response.data = ObjectVersionCollection(
@@ -187,9 +177,98 @@ class TestObjectStorageTools:
                 )
             ).structured_content
 
-            assert len(result["items"]) == 1
-            assert result["items"][0]["name"] == "object1"
-            assert result["items"][0]["version_id"] == "version_1"
+        assert len(result["items"]) == 1
+        assert result["items"][0]["name"] == "object1"
+        assert result["items"][0]["version_id"] == "version_1"
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_object_storage_mcp_server.server.get_object_storage_client")
+    async def test_get_object(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_namespace_response = create_autospec(oci.response.Response)
+        mock_namespace_response.data = "test_namespace"
+        mock_client.get_namespace.return_value = mock_namespace_response
+
+        mock_get_response = create_autospec(oci.response.Response)
+        mock_get_response.data = ObjectSummary(name="object1", size=42)
+        mock_client.get_object.return_value = mock_get_response
+
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "get_object",
+                    {
+                        "bucket_name": "bucket1",
+                        "compartment_id": "test_compartment",
+                        "object_name": "object1",
+                    },
+                )
+            ).structured_content
+
+        assert result["name"] == "object1"
+        assert result["size"] == 42
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_object_storage_mcp_server.server.get_object_storage_client")
+    async def test_upload_object_success(self, mock_get_client, tmp_path):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_namespace_response = create_autospec(oci.response.Response)
+        mock_namespace_response.data = "test_namespace"
+        mock_client.get_namespace.return_value = mock_namespace_response
+
+        p = tmp_path / "file.txt"
+        p.write_bytes(b"hello world")
+
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "upload_object",
+                    {
+                        "bucket_name": "bucket1",
+                        "compartment_id": "test_compartment",
+                        "file_path": str(p),
+                        "object_name": "file.txt",
+                    },
+                )
+            ).structured_content
+
+        assert result["message"] == "Object uploaded successfully"
+        mock_client.put_object.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_object_storage_mcp_server.server.get_object_storage_client")
+    async def test_upload_object_error(self, mock_get_client, tmp_path):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_namespace_response = create_autospec(oci.response.Response)
+        mock_namespace_response.data = "test_namespace"
+        mock_client.get_namespace.return_value = mock_namespace_response
+
+        bad_path = tmp_path / "does_not_exist.bin"
+
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "upload_object",
+                    {
+                        "bucket_name": "bucket1",
+                        "compartment_id": "test_compartment",
+                        "file_path": str(bad_path),
+                        "object_name": "file.bin",
+                    },
+                )
+            ).structured_content
+
+        assert "error" in result
+        assert (
+            "No such file" in result["error"]
+            or "No such file or directory" in result["error"]
+        )
 
 
 class TestServer:
@@ -202,7 +281,6 @@ class TestServer:
         }
 
         mock_getenv.side_effect = lambda x: mock_env.get(x)
-        import oracle.oci_object_storage_mcp_server.server as server
 
         server.main()
         mock_mcp_run.assert_called_once_with(
@@ -227,7 +305,6 @@ class TestServer:
             "ORACLE_MCP_HOST": "1.2.3.4",
         }
         mock_getenv.side_effect = lambda x: mock_env.get(x)
-        import oracle.oci_object_storage_mcp_server.server as server
 
         server.main()
         mock_mcp_run.assert_called_once_with()
@@ -239,7 +316,117 @@ class TestServer:
             "ORACLE_MCP_PORT": "8888",
         }
         mock_getenv.side_effect = lambda x: mock_env.get(x)
-        import oracle.oci_object_storage_mcp_server.server as server
 
         server.main()
         mock_mcp_run.assert_called_once_with()
+
+
+class TestGetClient:
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server.oci.object_storage.ObjectStorageClient"
+    )
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server.oci.auth.signers.SecurityTokenSigner"
+    )
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server.oci.signer.load_private_key_from_file"
+    )
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server.open",
+        new_callable=mock_open,
+        read_data="SECURITY_TOKEN",
+    )
+    @patch("oracle.oci_object_storage_mcp_server.server.oci.config.from_file")
+    @patch("oracle.oci_object_storage_mcp_server.server.os.getenv")
+    def test_get_object_storage_client_with_profile_env(
+        self,
+        mock_getenv,
+        mock_from_file,
+        mock_open_file,
+        mock_load_private_key,
+        mock_security_token_signer,
+        mock_client,
+    ):
+        # Arrange: provide profile via env var and minimal config dict
+        mock_getenv.side_effect = lambda k, default=None: (
+            "MYPROFILE" if k == "OCI_CONFIG_PROFILE" else default
+        )
+        config = {
+            "key_file": "/abs/path/to/key.pem",
+            "security_token_file": "/abs/path/to/token",
+        }
+        mock_from_file.return_value = config
+        private_key_obj = object()
+        mock_load_private_key.return_value = private_key_obj
+
+        # Act
+        result = server.get_object_storage_client()
+
+        # Assert calls
+        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
+        mock_security_token_signer.assert_called_once_with(
+            "SECURITY_TOKEN", private_key_obj
+        )
+        # Ensure user agent was set on the same config dict passed into client
+        args, _ = mock_client.call_args
+        passed_config = args[0]
+        assert passed_config is config
+        expected_user_agent = f"{server.__project__.split('oracle.', 1)[1].split('-server', 1)[0]}/{server.__version__}"  # noqa
+        assert passed_config.get("additional_user_agent") == expected_user_agent
+        # And we returned the client instance
+        assert result == mock_client.return_value
+
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server.oci.object_storage.ObjectStorageClient"
+    )
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server.oci.auth.signers.SecurityTokenSigner"
+    )
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server.oci.signer.load_private_key_from_file"
+    )
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server.open",
+        new_callable=mock_open,
+        read_data="TOK",
+    )
+    @patch("oracle.oci_object_storage_mcp_server.server.oci.config.from_file")
+    @patch("oracle.oci_object_storage_mcp_server.server.os.getenv")
+    def test_get_object_storage_client_uses_default_profile_when_env_missing(
+        self,
+        mock_getenv,
+        mock_from_file,
+        mock_open_file,
+        mock_load_private_key,
+        mock_security_token_signer,
+        mock_client,
+    ):
+        # Arrange: no env var present; from_file should be called with DEFAULT_PROFILE
+        mock_getenv.side_effect = lambda k, default=None: default
+        config = {"key_file": "/k.pem", "security_token_file": "/tkn"}
+        mock_from_file.return_value = config
+        priv = object()
+        mock_load_private_key.return_value = priv
+
+        # Act
+        srv_client = server.get_object_storage_client()
+
+        # Assert: profile defaulted
+        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        # Token file opened and read
+        mock_open_file.assert_called_once_with("/tkn", "r")
+        mock_security_token_signer.assert_called_once()
+        signer_args, _ = mock_security_token_signer.call_args
+        assert signer_args[0] == "TOK"
+        assert signer_args[1] is priv
+        # additional_user_agent set on original config and passed through
+        cc_args, _ = mock_client.call_args
+        assert cc_args[0] is config
+        assert "additional_user_agent" in config
+        assert (
+            isinstance(config["additional_user_agent"], str)
+            and "/" in config["additional_user_agent"]
+        )
+        # Returned object is client instance
+        assert srv_client is mock_client.return_value

--- a/src/oci-object-storage-mcp-server/pyproject.toml
+++ b/src/oci-object-storage-mcp-server/pyproject.toml
@@ -46,4 +46,4 @@ omit = [
 
 [tool.coverage.report]
 precision = 2
-fail_under = 85.78
+fail_under = 90

--- a/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/server.py
+++ b/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/server.py
@@ -30,7 +30,8 @@ def get_ocir_client():
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
     )
 
-    config["additional_user_agent"] = f"{__project__}/{__version__}"
+    user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
+    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])

--- a/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/tests/test_registry_models.py
+++ b/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/tests/test_registry_models.py
@@ -1,0 +1,220 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import oci
+import pytest
+from oracle.oci_registry_mcp_server.models import (
+    ContainerRepository,
+    ContainerRepositoryReadme,
+    Request,
+    Response,
+    _oci_to_dict,
+    map_container_repository,
+    map_container_repository_readme,
+    map_request,
+    map_response,
+)
+
+
+class TestContainerRepositoryReadme:
+    def test_map_container_repository_readme_none(self) -> None:
+        assert map_container_repository_readme(None) is None
+
+    def test_map_container_repository_readme_values(self) -> None:
+        readme = SimpleNamespace(content="# Repo", format="TEXT_MARKDOWN")
+        mapped = map_container_repository_readme(readme)
+        assert isinstance(mapped, ContainerRepositoryReadme)
+        assert mapped.content == "# Repo"
+        assert mapped.format == "TEXT_MARKDOWN"
+
+
+class TestContainerRepositoryMapping:
+    def test_map_container_repository_full(self) -> None:
+        ts_created = datetime(2024, 1, 1, 0, 0, 0)
+        ts_last = datetime(2024, 1, 2, 0, 0, 0)
+        repo_input = SimpleNamespace(
+            compartment_id="ocid1.compartment.oc1..xyz",
+            created_by="ocid1.user.oc1..user",
+            display_name="my/repo",
+            id="ocid1.repo.oc1..abc",
+            image_count=10,
+            is_immutable=True,
+            is_public=False,
+            layer_count=42,
+            layers_size_in_bytes=1000,
+            lifecycle_state="AVAILABLE",
+            readme=SimpleNamespace(content="hello", format="TEXT_PLAIN"),
+            time_created=ts_created,
+            time_last_pushed=ts_last,
+            billable_size_in_gbs=3,
+            namespace="mytenancy",
+            freeform_tags={"env": "dev"},
+            defined_tags={"Ops": {"CostCenter": "42"}},
+            system_tags={"orcl-cloud": {"free-tier-retain": True}},
+        )
+
+        mapped = map_container_repository(repo_input)
+        assert isinstance(mapped, ContainerRepository)
+        assert mapped.compartment_id == "ocid1.compartment.oc1..xyz"
+        assert mapped.created_by == "ocid1.user.oc1..user"
+        assert mapped.display_name == "my/repo"
+        assert mapped.id == "ocid1.repo.oc1..abc"
+        assert mapped.image_count == 10
+        assert mapped.is_immutable is True
+        assert mapped.is_public is False
+        assert mapped.layer_count == 42
+        assert mapped.layers_size_in_bytes == 1000
+        assert mapped.lifecycle_state == "AVAILABLE"
+        assert mapped.readme is not None
+        assert mapped.readme.content == "hello"
+        assert mapped.readme.format == "TEXT_PLAIN"
+        assert mapped.time_created == ts_created
+        assert mapped.time_last_pushed == ts_last
+        assert mapped.billable_size_in_gbs == 3
+        assert mapped.namespace == "mytenancy"
+        assert mapped.freeform_tags == {"env": "dev"}
+        assert mapped.defined_tags == {"Ops": {"CostCenter": "42"}}
+        assert mapped.system_tags == {"orcl-cloud": {"free-tier-retain": True}}
+
+
+class TestRequestAndResponseMapping:
+    def test_map_request_none(self) -> None:
+        assert map_request(None) is None
+
+    def test_map_request_values(self) -> None:
+        req = SimpleNamespace(
+            method="GET",
+            url="https://example.com",
+            query_params={"a": 1},
+            header_params={"h": "v"},
+            body=None,
+            response_type="json",
+            enforce_content_headers=True,
+        )
+        mapped = map_request(req)
+        assert isinstance(mapped, Request)
+        assert mapped.method == "GET"
+        assert mapped.url == "https://example.com"
+        assert mapped.query_params == {"a": 1}
+        assert mapped.header_params == {"h": "v"}
+        assert mapped.response_type == "json"
+        assert mapped.enforce_content_headers is True
+
+    def test_map_response_none(self) -> None:
+        assert map_response(None) is None
+
+    def test_map_response_with_header_derivation_and_repo_data(self) -> None:
+        class FakeResponse:
+            pass
+
+        resp = FakeResponse()
+        resp.status = 200
+        # Provide headers that should derive next_page and request_id
+        resp.headers = {"opc-next-page": "np-1", "opc-request-id": "req-123"}
+        # next_page property absent -> should be derived from headers
+        resp.data = oci.artifacts.models.ContainerRepository(
+            display_name="repo1",
+            id="ocid1.repo.oc1..abc",
+            is_public=False,
+            compartment_id="ocid1.compartment.oc1..xyz",
+        )
+        resp.request = SimpleNamespace(method="GET", url="u")
+
+        mapped = map_response(resp)
+        assert isinstance(mapped, Response)
+        assert mapped.status == 200
+        assert mapped.next_page == "np-1"
+        assert mapped.request_id == "req-123"
+        assert mapped.has_next_page is True
+        # Data should be mapped to ContainerRepository model
+        assert isinstance(mapped.data, ContainerRepository)
+        assert mapped.data.display_name == "repo1"
+
+    def test_map_response_with_list_data(self) -> None:
+        class FakeResponse:
+            pass
+
+        sdk_repo = oci.artifacts.models.ContainerRepository(
+            display_name="repo2",
+            id="ocid1.repo.oc1..def",
+            is_public=True,
+            compartment_id="ocid1.compartment.oc1..xyz",
+        )
+        resp = FakeResponse()
+        resp.status = 200
+        resp.headers = {}
+        resp.data = [sdk_repo, "x", 1]
+        resp.request = None
+
+        mapped = map_response(resp)
+        assert isinstance(mapped, Response)
+        assert isinstance(mapped.data, list)
+        # First element should be mapped to our Pydantic model
+        assert isinstance(mapped.data[0], ContainerRepository)
+        assert mapped.data[0].display_name == "repo2"
+        # Other primitive elements should pass through
+        assert mapped.data[1] == "x"
+        assert mapped.data[2] == 1
+
+    def test_map_response_headers_fallback_via_oci_to_dict(self, monkeypatch) -> None:
+        class WeirdHeaders:
+            def __init__(self) -> None:
+                self.k = "v"
+
+        # Force _oci_to_dict path to be exercised so that __dict__ fallback runs
+        import oci.util as oci_util  # type: ignore
+
+        def raise_from_oci_to_dict(_: object):
+            raise RuntimeError("force fallback")
+
+        monkeypatch.setattr(oci_util, "to_dict", raise_from_oci_to_dict, raising=True)
+
+        # Monkeypatch to ensure dict(headers) path fails and fallback is used
+        class FakeResponse:
+            pass
+
+        resp = FakeResponse()
+        resp.status = 200
+        headers_obj = WeirdHeaders()
+        resp.headers = headers_obj
+        resp.data = None
+        resp.request = None
+
+        # Use monkeypatch to make dict() raise when called on headers_obj
+        # We cannot patch builtins.dict, so ensure _oci_to_dict handles __dict__
+        mapped = map_response(resp)
+        assert isinstance(mapped, Response)
+        assert mapped.headers == {"k": "v"}
+
+
+class TestOciToDict:
+    def test_oci_to_dict_none(self) -> None:
+        assert _oci_to_dict(None) is None
+
+    def test_oci_to_dict_passthrough(self) -> None:
+        data = {"a": 1}
+        assert _oci_to_dict(data) == {"a": 1}
+
+    def test_oci_to_dict_fallback_filters_private(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class Dummy:
+            def __init__(self) -> None:
+                self.a = 1
+                self._private = 2
+
+        def raise_from_oci_to_dict(_: object):
+            raise RuntimeError("force fallback")
+
+        import oci.util as oci_util  # type: ignore
+
+        monkeypatch.setattr(oci_util, "to_dict", raise_from_oci_to_dict, raising=True)
+
+        out = _oci_to_dict(Dummy())
+        assert out == {"a": 1}

--- a/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/tests/test_registry_tools.py
+++ b/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/tests/test_registry_tools.py
@@ -4,11 +4,12 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
-from unittest.mock import MagicMock, create_autospec, patch
+from unittest.mock import MagicMock, create_autospec, mock_open, patch
 
 import oci
 import pytest
 from fastmcp import Client
+from oracle.oci_registry_mcp_server import server
 from oracle.oci_registry_mcp_server.server import mcp
 
 
@@ -118,6 +119,77 @@ class TestRegistryTools:
 
             assert result["status"] == 204
 
+    @pytest.mark.asyncio
+    @patch("oracle.oci_registry_mcp_server.server.get_ocir_client")
+    async def test_list_container_repositories_raises(self, mock_get_client):
+        # Cause the tool to raise and ensure the MCP wrapper returns an error payload
+        mock_get_client.side_effect = ValueError("boom")
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "list_container_repositories",
+                {"compartment_id": "ocid1.compartment"},
+                raise_on_error=False,
+            )
+            assert call_tool_result.is_error is True
+            # The error text is present in the first content block
+            assert any(
+                getattr(block, "text", "").find("boom") != -1
+                for block in call_tool_result.content
+            )
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_registry_mcp_server.server.get_ocir_client")
+    async def test_get_container_repository_raises(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_container_repository.side_effect = RuntimeError("oops")
+        mock_get_client.return_value = mock_client
+
+        async with Client(mcp) as client:
+            res = await client.call_tool(
+                "get_container_repository",
+                {"repository_id": "ocid1.repo"},
+                raise_on_error=False,
+            )
+            assert res.is_error is True
+            assert any(getattr(b, "text", "").find("oops") != -1 for b in res.content)
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_registry_mcp_server.server.get_ocir_client")
+    async def test_create_container_repository_raises(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.create_container_repository.side_effect = RuntimeError("fail")
+        mock_get_client.return_value = mock_client
+
+        async with Client(mcp) as client:
+            res = await client.call_tool(
+                "create_container_repository",
+                {
+                    "compartment_id": "ocid1.compartment",
+                    "repository_name": "my/repo",
+                    "is_public": True,
+                },
+                raise_on_error=False,
+            )
+            assert res.is_error is True
+            assert any(getattr(b, "text", "").find("fail") != -1 for b in res.content)
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_registry_mcp_server.server.get_ocir_client")
+    async def test_delete_container_repository_raises(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.delete_container_repository.side_effect = RuntimeError("nope")
+        mock_get_client.return_value = mock_client
+
+        async with Client(mcp) as client:
+            res = await client.call_tool(
+                "delete_container_repository",
+                {"repository_id": "ocid1.repo"},
+                raise_on_error=False,
+            )
+            assert res.is_error is True
+            assert any(getattr(b, "text", "").find("nope") != -1 for b in res.content)
+
 
 class TestServer:
     @patch("oracle.oci_registry_mcp_server.server.mcp.run")
@@ -170,3 +242,106 @@ class TestServer:
 
         server.main()
         mock_mcp_run.assert_called_once_with()
+
+
+class TestGetClient:
+    @patch("oracle.oci_registry_mcp_server.server.oci.artifacts.ArtifactsClient")
+    @patch("oracle.oci_registry_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch(
+        "oracle.oci_registry_mcp_server.server.oci.signer.load_private_key_from_file"
+    )
+    @patch(
+        "oracle.oci_registry_mcp_server.server.open",
+        new_callable=mock_open,
+        read_data="SECURITY_TOKEN",
+    )
+    @patch("oracle.oci_registry_mcp_server.server.oci.config.from_file")
+    @patch("oracle.oci_registry_mcp_server.server.os.getenv")
+    def test_get_ocir_client_with_profile_env(
+        self,
+        mock_getenv,
+        mock_from_file,
+        mock_open_file,
+        mock_load_private_key,
+        mock_security_token_signer,
+        mock_client,
+    ):
+        # Arrange: provide profile via env var and minimal config dict
+        mock_getenv.side_effect = lambda k, default=None: (
+            "MYPROFILE" if k == "OCI_CONFIG_PROFILE" else default
+        )
+        config = {
+            "key_file": "/abs/path/to/key.pem",
+            "security_token_file": "/abs/path/to/token",
+        }
+        mock_from_file.return_value = config
+        private_key_obj = object()
+        mock_load_private_key.return_value = private_key_obj
+
+        # Act
+        result = server.get_ocir_client()
+
+        # Assert calls
+        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
+        mock_security_token_signer.assert_called_once_with(
+            "SECURITY_TOKEN", private_key_obj
+        )
+        # Ensure user agent was set on the same config dict passed into client
+        args, _ = mock_client.call_args
+        passed_config = args[0]
+        assert passed_config is config
+        expected_user_agent = f"{server.__project__.split('oracle.', 1)[1].split('-server', 1)[0]}/{server.__version__}"  # noqa
+        assert passed_config.get("additional_user_agent") == expected_user_agent
+        # And we returned the client instance
+        assert result == mock_client.return_value
+
+    @patch("oracle.oci_registry_mcp_server.server.oci.artifacts.ArtifactsClient")
+    @patch("oracle.oci_registry_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch(
+        "oracle.oci_registry_mcp_server.server.oci.signer.load_private_key_from_file"
+    )
+    @patch(
+        "oracle.oci_registry_mcp_server.server.open",
+        new_callable=mock_open,
+        read_data="TOK",
+    )
+    @patch("oracle.oci_registry_mcp_server.server.oci.config.from_file")
+    @patch("oracle.oci_registry_mcp_server.server.os.getenv")
+    def test_get_ocir_client_uses_default_profile_when_env_missing(
+        self,
+        mock_getenv,
+        mock_from_file,
+        mock_open_file,
+        mock_load_private_key,
+        mock_security_token_signer,
+        mock_client,
+    ):
+        # Arrange: no env var present; from_file should be called with DEFAULT_PROFILE
+        mock_getenv.side_effect = lambda k, default=None: default
+        config = {"key_file": "/k.pem", "security_token_file": "/tkn"}
+        mock_from_file.return_value = config
+        priv = object()
+        mock_load_private_key.return_value = priv
+
+        # Act
+        srv_client = server.get_ocir_client()
+
+        # Assert: profile defaulted
+        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        # Token file opened and read
+        mock_open_file.assert_called_once_with("/tkn", "r")
+        mock_security_token_signer.assert_called_once()
+        signer_args, _ = mock_security_token_signer.call_args
+        assert signer_args[0] == "TOK"
+        assert signer_args[1] is priv
+        # additional_user_agent set on original config and passed through
+        cc_args, _ = mock_client.call_args
+        assert cc_args[0] is config
+        assert "additional_user_agent" in config
+        assert (
+            isinstance(config["additional_user_agent"], str)
+            and "/" in config["additional_user_agent"]
+        )
+        # Returned object is client instance
+        assert srv_client is mock_client.return_value

--- a/src/oci-registry-mcp-server/pyproject.toml
+++ b/src/oci-registry-mcp-server/pyproject.toml
@@ -48,4 +48,4 @@ omit = [
 
 [tool.coverage.report]
 precision = 2
-fail_under = 53
+fail_under = 90

--- a/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/tests/test_resource_search_models.py
+++ b/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/tests/test_resource_search_models.py
@@ -1,0 +1,100 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from oracle.oci_resource_search_mcp_server.models import (
+    ResourceSummary,
+    _oci_to_dict,
+    map_resource_summary,
+    map_search_context,
+)
+
+
+class TestSearchContext:
+    def test_map_search_context_none(self):
+        assert map_search_context(None) is None
+
+    def test_map_search_context_with_highlights(self):
+        sc = SimpleNamespace(highlights={"displayName": ["<h1>match</h1>"]})
+        mapped = map_search_context(sc)
+        assert mapped is not None
+        assert mapped.highlights == {"displayName": ["<h1>match</h1>"]}
+
+
+class TestResourceSummaryMapping:
+    def test_map_resource_summary_full(self):
+        ts = datetime(2024, 1, 2, 3, 4, 5)
+        rs_input = SimpleNamespace(
+            resource_type="instance",
+            identifier="ocid1.instance.oc1..exampleuniqueID",
+            compartment_id="ocid1.compartment.oc1..exampleuniqueID",
+            time_created=ts,
+            display_name="My Instance",
+            availability_domain="AD-1",
+            lifecycle_state="RUNNING",
+            freeform_tags={"Owner": "Dev"},
+            defined_tags={"Operations": {"CostCenter": "42"}},
+            system_tags={"orcl-cloud": {"free-tier-retain": True}},
+            search_context=SimpleNamespace(
+                highlights={"displayName": ["<h1>My Instance</h1>"]}
+            ),
+            identity_context={"keyA": "valueA"},
+            additional_details={"attachedVnic": []},
+        )
+
+        mapped: ResourceSummary = map_resource_summary(rs_input)
+
+        assert mapped.resource_type == "instance"
+        assert mapped.identifier.startswith("ocid1.instance")
+        assert mapped.compartment_id.startswith("ocid1.compartment")
+        assert mapped.time_created == ts
+        assert mapped.display_name == "My Instance"
+        assert mapped.availability_domain == "AD-1"
+        assert mapped.lifecycle_state == "RUNNING"
+        assert mapped.freeform_tags == {"Owner": "Dev"}
+        assert mapped.defined_tags == {"Operations": {"CostCenter": "42"}}
+        assert mapped.system_tags == {"orcl-cloud": {"free-tier-retain": True}}
+        assert mapped.search_context is not None
+        assert mapped.search_context.highlights == {
+            "displayName": ["<h1>My Instance</h1>"]
+        }
+        assert mapped.identity_context == {"keyA": "valueA"}
+        assert mapped.additional_details == {"attachedVnic": []}
+
+    def test_map_resource_summary_without_search_context(self):
+        rs_input = SimpleNamespace(resource_type="volume", identifier="vol-1")
+        mapped = map_resource_summary(rs_input)
+        assert mapped.resource_type == "volume"
+        assert mapped.identifier == "vol-1"
+        assert mapped.search_context is None
+
+
+class TestOciToDict:
+    def test_oci_to_dict_none(self):
+        assert _oci_to_dict(None) is None
+
+    def test_oci_to_dict_pass_through_dict(self):
+        data = {"a": 1, "b": 2}
+        assert _oci_to_dict(data) == {"a": 1, "b": 2}
+
+    def test_oci_to_dict_fallback_private_filtered(self, monkeypatch):
+        class Dummy:
+            def __init__(self):
+                self.a = 1
+                self._private = 2
+
+        def raise_from_oci_to_dict(_):  # force fallback path
+            raise RuntimeError("force fallback")
+
+        # Ensure the function attempts oci.util.to_dict then falls back
+        import oci.util as oci_util  # type: ignore
+
+        monkeypatch.setattr(oci_util, "to_dict", raise_from_oci_to_dict, raising=True)
+
+        out = _oci_to_dict(Dummy())
+        assert out == {"a": 1}

--- a/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/tests/test_resource_search_tools.py
+++ b/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/tests/test_resource_search_tools.py
@@ -4,11 +4,13 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
-from unittest.mock import MagicMock, create_autospec, patch
+from unittest.mock import MagicMock, create_autospec, mock_open, patch
 
 import oci
 import pytest
 from fastmcp import Client
+from fastmcp.exceptions import ToolError
+from oracle.oci_resource_search_mcp_server import server
 from oracle.oci_resource_search_mcp_server.server import mcp
 
 
@@ -127,6 +129,44 @@ class TestResourceSearchTools:
 
     @pytest.mark.asyncio
     @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
+    async def test_search_resources_by_type(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_search_response = create_autospec(oci.response.Response)
+        mock_search_response.data = (
+            oci.resource_search.models.ResourceSummaryCollection(
+                items=[
+                    oci.resource_search.models.ResourceSummary(
+                        identifier="db1",
+                        display_name="DB 1",
+                        resource_type="dbsystem",
+                        lifecycle_state="AVAILABLE",
+                    )
+                ]
+            )
+        )
+        mock_search_response.has_next_page = False
+        mock_search_response.next_page = None
+        mock_client.search_resources.return_value = mock_search_response
+
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "search_resources_by_type",
+                    {
+                        "tenant_id": "tenant1",
+                        "compartment_id": "compartment1",
+                        "resource_type": "DBSystem",
+                    },
+                )
+            ).structured_content["result"]
+
+            assert len(result) == 1
+            assert result[0]["resource_type"] == "dbsystem"
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
     async def test_list_resource_types(self, mock_get_client):
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
@@ -145,6 +185,232 @@ class TestResourceSearchTools:
 
             assert result == ["instance", "volume"]
 
+    @pytest.mark.asyncio
+    @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
+    async def test_list_all_resources_pagination(self, mock_get_client):
+        # Two pages, second response lacks next_page attribute to hit hasattr False branch
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        first = create_autospec(oci.response.Response)
+        first.data = oci.resource_search.models.ResourceSummaryCollection(
+            items=[oci.resource_search.models.ResourceSummary(identifier="r1")]
+        )
+        first.has_next_page = True
+        first.next_page = "token-2"
+
+        second = create_autospec(oci.response.Response)
+        second.data = oci.resource_search.models.ResourceSummaryCollection(
+            items=[oci.resource_search.models.ResourceSummary(identifier="r2")]
+        )
+        second.has_next_page = False
+        # Deliberately no next_page attribute
+        if hasattr(second, "next_page"):
+            delattr(second, "next_page")
+
+        mock_client.search_resources.side_effect = [first, second]
+
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "list_all_resources",
+                    {"tenant_id": "t1", "compartment_id": "c1"},
+                )
+            ).structured_content["result"]
+
+        assert [r["identifier"] for r in result] == ["r1", "r2"]
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
+    async def test_list_resource_types_no_next_page_attr(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        resp = create_autospec(oci.response.Response)
+        resp.data = [oci.resource_search.models.ResourceType(name="instance")]
+        resp.has_next_page = False
+        # Remove next_page to exercise hasattr False
+        if hasattr(resp, "next_page"):
+            delattr(resp, "next_page")
+        mock_client.list_resource_types.return_value = resp
+
+        async with Client(mcp) as client:
+            result = (await client.call_tool("list_resource_types", {})).data
+
+        assert result == ["instance"]
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
+    async def test_search_resources_no_next_page_attr(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        resp = create_autospec(oci.response.Response)
+        resp.data = oci.resource_search.models.ResourceSummaryCollection(
+            items=[oci.resource_search.models.ResourceSummary(identifier="x")]
+        )
+        resp.has_next_page = False
+        if hasattr(resp, "next_page"):
+            delattr(resp, "next_page")
+        mock_client.search_resources.return_value = resp
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "search_resources",
+                    {
+                        "tenant_id": "t1",
+                        "compartment_id": "c1",
+                        "display_name": "name",
+                    },
+                )
+            ).structured_content["result"]
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
+    async def test_search_resources_free_form_no_next_page_attr(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        resp = create_autospec(oci.response.Response)
+        resp.data = oci.resource_search.models.ResourceSummaryCollection(
+            items=[oci.resource_search.models.ResourceSummary(identifier="y")]
+        )
+        resp.has_next_page = False
+        if hasattr(resp, "next_page"):
+            delattr(resp, "next_page")
+        mock_client.search_resources.return_value = resp
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "search_resources_free_form",
+                    {"tenant_id": "t1", "text": "any"},
+                )
+            ).structured_content["result"]
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
+    async def test_search_resources_by_type_no_next_page_attr(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        resp = create_autospec(oci.response.Response)
+        resp.data = oci.resource_search.models.ResourceSummaryCollection(
+            items=[oci.resource_search.models.ResourceSummary(identifier="z")]
+        )
+        resp.has_next_page = False
+        if hasattr(resp, "next_page"):
+            delattr(resp, "next_page")
+        mock_client.search_resources.return_value = resp
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "search_resources_by_type",
+                    {
+                        "tenant_id": "t1",
+                        "compartment_id": "c1",
+                        "resource_type": "instance",
+                    },
+                )
+            ).structured_content["result"]
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
+    async def test_list_all_resources_respects_limit(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        resp = create_autospec(oci.response.Response)
+        resp.data = oci.resource_search.models.ResourceSummaryCollection(
+            items=[
+                oci.resource_search.models.ResourceSummary(identifier="a"),
+                oci.resource_search.models.ResourceSummary(identifier="b"),
+            ]
+        )
+        resp.has_next_page = True
+        resp.next_page = "tok"
+        mock_client.search_resources.return_value = resp
+
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "list_all_resources",
+                    {"tenant_id": "t1", "compartment_id": "c1", "limit": 1},
+                )
+            ).structured_content["result"]
+        # The server appends all items from a page before checking the limit
+        assert len(result) == 2
+        # Only one SDK call occurred because the loop stops paging once len(resources) >= limit
+        mock_client.search_resources.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
+    async def test_list_all_resources_error_path(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.search_resources.side_effect = RuntimeError("boom")
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "list_all_resources",
+                    {"tenant_id": "t1", "compartment_id": "c1"},
+                )
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
+    async def test_search_resources_error_path(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.search_resources.side_effect = RuntimeError("err")
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "search_resources",
+                    {
+                        "tenant_id": "t1",
+                        "compartment_id": "c1",
+                        "display_name": "x",
+                    },
+                )
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
+    async def test_search_resources_free_form_error_path(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.search_resources.side_effect = RuntimeError("ff")
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "search_resources_free_form",
+                    {"tenant_id": "t1", "text": "any"},
+                )
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
+    async def test_search_resources_by_type_error_path(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.search_resources.side_effect = RuntimeError("type")
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "search_resources_by_type",
+                    {
+                        "tenant_id": "t1",
+                        "compartment_id": "c1",
+                        "resource_type": "instance",
+                    },
+                )
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_resource_search_mcp_server.server.get_search_client")
+    async def test_list_resource_types_error_path(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.list_resource_types.side_effect = RuntimeError("oops")
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool("list_resource_types", {})
+
 
 class TestServer:
     @patch("oracle.oci_resource_search_mcp_server.server.mcp.run")
@@ -156,7 +422,6 @@ class TestServer:
         }
 
         mock_getenv.side_effect = lambda x: mock_env.get(x)
-        import oracle.oci_resource_search_mcp_server.server as server
 
         server.main()
         mock_mcp_run.assert_called_once_with(
@@ -169,7 +434,6 @@ class TestServer:
     @patch("os.getenv")
     def test_main_without_host_and_port(self, mock_getenv, mock_mcp_run):
         mock_getenv.return_value = None
-        import oracle.oci_resource_search_mcp_server.server as server
 
         server.main()
         mock_mcp_run.assert_called_once_with()
@@ -197,3 +461,114 @@ class TestServer:
 
         server.main()
         mock_mcp_run.assert_called_once_with()
+
+
+class TestGetClient:
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server.oci.resource_search.ResourceSearchClient"
+    )
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server.oci.auth.signers.SecurityTokenSigner"
+    )
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server.oci.signer.load_private_key_from_file"
+    )
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server.open",
+        new_callable=mock_open,
+        read_data="SECURITY_TOKEN",
+    )
+    @patch("oracle.oci_resource_search_mcp_server.server.oci.config.from_file")
+    @patch("oracle.oci_resource_search_mcp_server.server.os.getenv")
+    def test_get_search_client_with_profile_env(
+        self,
+        mock_getenv,
+        mock_from_file,
+        mock_open_file,
+        mock_load_private_key,
+        mock_security_token_signer,
+        mock_client,
+    ):
+        # Arrange: provide profile via env var and minimal config dict
+        mock_getenv.side_effect = lambda k, default=None: (
+            "MYPROFILE" if k == "OCI_CONFIG_PROFILE" else default
+        )
+        config = {
+            "key_file": "/abs/path/to/key.pem",
+            "security_token_file": "/abs/path/to/token",
+        }
+        mock_from_file.return_value = config
+        private_key_obj = object()
+        mock_load_private_key.return_value = private_key_obj
+
+        # Act
+        result = server.get_search_client()
+
+        # Assert calls
+        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
+        mock_security_token_signer.assert_called_once_with(
+            "SECURITY_TOKEN", private_key_obj
+        )
+        # Ensure user agent was set on the same config dict passed into client
+        args, _ = mock_client.call_args
+        passed_config = args[0]
+        assert passed_config is config
+        expected_user_agent = f"{server.__project__.split('oracle.', 1)[1].split('-server', 1)[0]}/{server.__version__}"  # noqa
+        assert passed_config.get("additional_user_agent") == expected_user_agent
+        # And we returned the client instance
+        assert result == mock_client.return_value
+
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server.oci.resource_search.ResourceSearchClient"
+    )
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server.oci.auth.signers.SecurityTokenSigner"
+    )
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server.oci.signer.load_private_key_from_file"
+    )
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server.open",
+        new_callable=mock_open,
+        read_data="TOK",
+    )
+    @patch("oracle.oci_resource_search_mcp_server.server.oci.config.from_file")
+    @patch("oracle.oci_resource_search_mcp_server.server.os.getenv")
+    def test_get_search_client_uses_default_profile_when_env_missing(
+        self,
+        mock_getenv,
+        mock_from_file,
+        mock_open_file,
+        mock_load_private_key,
+        mock_security_token_signer,
+        mock_client,
+    ):
+        # Arrange: no env var present; from_file should be called with DEFAULT_PROFILE
+        mock_getenv.side_effect = lambda k, default=None: default
+        config = {"key_file": "/k.pem", "security_token_file": "/tkn"}
+        mock_from_file.return_value = config
+        priv = object()
+        mock_load_private_key.return_value = priv
+
+        # Act
+        srv_client = server.get_search_client()
+
+        # Assert: profile defaulted
+        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        # Token file opened and read
+        mock_open_file.assert_called_once_with("/tkn", "r")
+        mock_security_token_signer.assert_called_once()
+        signer_args, _ = mock_security_token_signer.call_args
+        assert signer_args[0] == "TOK"
+        assert signer_args[1] is priv
+        # additional_user_agent set on original config and passed through
+        cc_args, _ = mock_client.call_args
+        assert cc_args[0] is config
+        assert "additional_user_agent" in config
+        assert (
+            isinstance(config["additional_user_agent"], str)
+            and "/" in config["additional_user_agent"]
+        )
+        # Returned object is client instance
+        assert srv_client is mock_client.return_value

--- a/src/oci-resource-search-mcp-server/pyproject.toml
+++ b/src/oci-resource-search-mcp-server/pyproject.toml
@@ -48,4 +48,4 @@ omit = [
 
 [tool.coverage.report]
 precision = 2
-fail_under = 65.66
+fail_under = 90

--- a/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/tests/test_usage_models.py
+++ b/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/tests/test_usage_models.py
@@ -1,0 +1,17 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+import pytest
+
+
+def test_models_module_optional():
+    """If a models.py is introduced later, these tests will start running.
+    Currently this server has no models module, so we skip gracefully.
+    """
+    pytest.importorskip(
+        "oracle.oci_usage_mcp_server.models",
+        reason="No models.py present in oci-usage-mcp-server",
+    )

--- a/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/tests/test_usage_tools.py
+++ b/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/tests/test_usage_tools.py
@@ -4,11 +4,12 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
-from unittest.mock import MagicMock, create_autospec, patch
+from unittest.mock import MagicMock, create_autospec, mock_open, patch
 
 import oci
 import pytest
 from fastmcp import Client
+from oracle.oci_usage_mcp_server import server
 from oracle.oci_usage_mcp_server.server import mcp
 
 
@@ -66,8 +67,6 @@ class TestServer:
         }
 
         mock_getenv.side_effect = lambda x: mock_env.get(x)
-        import oracle.oci_usage_mcp_server.server as server
-
         server.main()
         mock_mcp_run.assert_called_once_with(
             transport="http",
@@ -79,8 +78,6 @@ class TestServer:
     @patch("os.getenv")
     def test_main_without_host_and_port(self, mock_getenv, mock_mcp_run):
         mock_getenv.return_value = None
-        import oracle.oci_usage_mcp_server.server as server
-
         server.main()
         mock_mcp_run.assert_called_once_with()
 
@@ -91,8 +88,6 @@ class TestServer:
             "ORACLE_MCP_HOST": "1.2.3.4",
         }
         mock_getenv.side_effect = lambda x: mock_env.get(x)
-        import oracle.oci_usage_mcp_server.server as server
-
         server.main()
         mock_mcp_run.assert_called_once_with()
 
@@ -103,7 +98,104 @@ class TestServer:
             "ORACLE_MCP_PORT": "8888",
         }
         mock_getenv.side_effect = lambda x: mock_env.get(x)
-        import oracle.oci_usage_mcp_server.server as server
-
         server.main()
         mock_mcp_run.assert_called_once_with()
+
+
+class TestGetClient:
+    @patch("oracle.oci_usage_mcp_server.server.oci.usage_api.UsageapiClient")
+    @patch("oracle.oci_usage_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_usage_mcp_server.server.oci.signer.load_private_key_from_file")
+    @patch(
+        "oracle.oci_usage_mcp_server.server.open",
+        new_callable=mock_open,
+        read_data="SECURITY_TOKEN",
+    )
+    @patch("oracle.oci_usage_mcp_server.server.oci.config.from_file")
+    @patch("oracle.oci_usage_mcp_server.server.os.getenv")
+    def test_get_search_client_with_profile_env(
+        self,
+        mock_getenv,
+        mock_from_file,
+        mock_open_file,
+        mock_load_private_key,
+        mock_security_token_signer,
+        mock_client,
+    ):
+        # Arrange: provide profile via env var and minimal config dict
+        mock_getenv.side_effect = lambda k, default=None: (
+            "MYPROFILE" if k == "OCI_CONFIG_PROFILE" else default
+        )
+        config = {
+            "key_file": "/abs/path/to/key.pem",
+            "security_token_file": "/abs/path/to/token",
+        }
+        mock_from_file.return_value = config
+        private_key_obj = object()
+        mock_load_private_key.return_value = private_key_obj
+
+        # Act
+        result = server.get_usage_client()
+
+        # Assert calls
+        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
+        mock_security_token_signer.assert_called_once_with(
+            "SECURITY_TOKEN", private_key_obj
+        )
+        # Ensure user agent was set on the same config dict passed into client
+        args, _ = mock_client.call_args
+        passed_config = args[0]
+        assert passed_config is config
+        expected_user_agent = f"{server.__project__.split('oracle.', 1)[1].split('-server', 1)[0]}/{server.__version__}"  # noqa
+        assert passed_config.get("additional_user_agent") == expected_user_agent
+        # And we returned the client instance
+        assert result == mock_client.return_value
+
+    @patch("oracle.oci_usage_mcp_server.server.oci.usage_api.UsageapiClient")
+    @patch("oracle.oci_usage_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_usage_mcp_server.server.oci.signer.load_private_key_from_file")
+    @patch(
+        "oracle.oci_usage_mcp_server.server.open",
+        new_callable=mock_open,
+        read_data="TOK",
+    )
+    @patch("oracle.oci_usage_mcp_server.server.oci.config.from_file")
+    @patch("oracle.oci_usage_mcp_server.server.os.getenv")
+    def test_get_search_client_uses_default_profile_when_env_missing(
+        self,
+        mock_getenv,
+        mock_from_file,
+        mock_open_file,
+        mock_load_private_key,
+        mock_security_token_signer,
+        mock_client,
+    ):
+        # Arrange: no env var present; from_file should be called with DEFAULT_PROFILE
+        mock_getenv.side_effect = lambda k, default=None: default
+        config = {"key_file": "/k.pem", "security_token_file": "/tkn"}
+        mock_from_file.return_value = config
+        priv = object()
+        mock_load_private_key.return_value = priv
+
+        # Act
+        srv_client = server.get_usage_client()
+
+        # Assert: profile defaulted
+        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        # Token file opened and read
+        mock_open_file.assert_called_once_with("/tkn", "r")
+        mock_security_token_signer.assert_called_once()
+        signer_args, _ = mock_security_token_signer.call_args
+        assert signer_args[0] == "TOK"
+        assert signer_args[1] is priv
+        # additional_user_agent set on original config and passed through
+        cc_args, _ = mock_client.call_args
+        assert cc_args[0] is config
+        assert "additional_user_agent" in config
+        assert (
+            isinstance(config["additional_user_agent"], str)
+            and "/" in config["additional_user_agent"]
+        )
+        # Returned object is client instance
+        assert srv_client is mock_client.return_value

--- a/src/oci-usage-mcp-server/pyproject.toml
+++ b/src/oci-usage-mcp-server/pyproject.toml
@@ -48,4 +48,4 @@ omit = [
 
 [tool.coverage.report]
 precision = 2
-fail_under = 58.81
+fail_under = 90


### PR DESCRIPTION
# Description

This adds UT coverage > 90% for monitoring, object storage, usage, registry, and resource search

## Type of change

Test additions

# How Has This Been Tested?

- [x] Run `make build && make test` at root of project, verify monitoring, object storage, usage, registry, and resource search tests are > 90% coverage

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
