### PR TITLE
Add E2E tests for cloud guard, identity, faaas, logging, and migration

### DIFF
--- a/src/oci-cloud-guard-mcp-server/oracle/oci_cloud_guard_mcp_server/server.py
+++ b/src/oci-cloud-guard-mcp-server/oracle/oci_cloud_guard_mcp_server/server.py
@@ -27,7 +27,8 @@ mcp = FastMCP(name=__project__)
 
 def get_cloud_guard_client():
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
 
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]

--- a/src/oci-cloud-guard-mcp-server/oracle/oci_cloud_guard_mcp_server/tests/test_cloud_guard_tools.py
+++ b/src/oci-cloud-guard-mcp-server/oracle/oci_cloud_guard_mcp_server/tests/test_cloud_guard_tools.py
@@ -204,7 +204,10 @@ class TestGetClient:
         result = server.get_cloud_guard_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -252,7 +255,10 @@ class TestGetClient:
         srv_client = server.get_cloud_guard_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-compute-instance-agent-mcp-server/oracle/oci_compute_instance_agent_mcp_server/server.py
+++ b/src/oci-compute-instance-agent-mcp-server/oracle/oci_compute_instance_agent_mcp_server/server.py
@@ -36,7 +36,8 @@ mcp = FastMCP(name=__project__)
 def get_compute_instance_agent_client():
     logger.info("entering get_compute_instance_agent_client")
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
 
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]

--- a/src/oci-compute-instance-agent-mcp-server/oracle/oci_compute_instance_agent_mcp_server/tests/test_compute_instance_agent_tools.py
+++ b/src/oci-compute-instance-agent-mcp-server/oracle/oci_compute_instance_agent_mcp_server/tests/test_compute_instance_agent_tools.py
@@ -425,7 +425,10 @@ class TestGetClient:
         result = server.get_compute_instance_agent_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -475,7 +478,10 @@ class TestGetClient:
         srv_client = server.get_compute_instance_agent_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/server.py
+++ b/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/server.py
@@ -38,7 +38,8 @@ mcp = FastMCP(name=__project__)
 def get_compute_client():
     logger.info("entering get_compute_client")
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"

--- a/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/tests/test_compute_tools.py
+++ b/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/tests/test_compute_tools.py
@@ -703,7 +703,10 @@ class TestGetClient:
         result = server.get_compute_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -747,7 +750,10 @@ class TestGetClient:
         srv_client = server.get_compute_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-database-mcp-server/oracle/oci_database_mcp_server/server.py
+++ b/src/oci-database-mcp-server/oracle/oci_database_mcp_server/server.py
@@ -285,7 +285,8 @@ mcp = FastMCP(name=__project__)
 
 def get_database_client(region: str = None):
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"

--- a/src/oci-faaas-mcp-server/oracle/oci_faaas_mcp_server/server.py
+++ b/src/oci-faaas-mcp-server/oracle/oci_faaas_mcp_server/server.py
@@ -32,7 +32,8 @@ def get_faaas_client():
     logger.info("entering get_faaas_client")
 
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
 
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]

--- a/src/oci-faaas-mcp-server/oracle/oci_faaas_mcp_server/tests/test_faaas_tools.py
+++ b/src/oci-faaas-mcp-server/oracle/oci_faaas_mcp_server/tests/test_faaas_tools.py
@@ -357,7 +357,10 @@ class TestGetClient:
         result = server.get_faaas_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -403,7 +406,10 @@ class TestGetClient:
         srv_client = server.get_faaas_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-identity-mcp-server/oracle/oci_identity_mcp_server/server.py
+++ b/src/oci-identity-mcp-server/oracle/oci_identity_mcp_server/server.py
@@ -37,7 +37,8 @@ mcp = FastMCP(name=__project__)
 
 def get_identity_client():
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
@@ -108,7 +109,10 @@ def list_compartments(
 
         if include_root:
             config = oci.config.from_file(
-                profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+                file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+                profile_name=os.getenv(
+                    "OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE
+                ),
             )
             tenancy_id = os.getenv("TENANCY_ID_OVERRIDE", config["tenancy"])
             tenancy_response: oci.response.Response = client.get_compartment(
@@ -173,7 +177,8 @@ def get_current_tenancy() -> Tenancy:
         client = get_identity_client()
 
         config = oci.config.from_file(
-            profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+            file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+            profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
         )
         tenancy_id = os.getenv("TENANCY_ID_OVERRIDE", config["tenancy"])
         response: oci.response.Response = client.get_tenancy(tenancy_id)
@@ -218,7 +223,8 @@ def get_current_user() -> User:
     try:
         client = get_identity_client()
         config = oci.config.from_file(
-            profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+            file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+            profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
         )
 
         # Prefer explicit user from config if present

--- a/src/oci-identity-mcp-server/oracle/oci_identity_mcp_server/tests/test_identity_tools.py
+++ b/src/oci-identity-mcp-server/oracle/oci_identity_mcp_server/tests/test_identity_tools.py
@@ -771,7 +771,10 @@ class TestGetClient:
         result = server.get_identity_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -817,7 +820,10 @@ class TestGetClient:
         srv_client = server.get_identity_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-logging-mcp-server/oracle/oci_logging_mcp_server/server.py
+++ b/src/oci-logging-mcp-server/oracle/oci_logging_mcp_server/server.py
@@ -40,7 +40,8 @@ mcp = FastMCP(name=__project__)
 def get_logging_client():
     logger.info("entering get_logging_client")
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
@@ -55,7 +56,8 @@ def get_logging_client():
 def get_logging_search_client():
     logger.info("entering get_logging_client")
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])

--- a/src/oci-logging-mcp-server/oracle/oci_logging_mcp_server/tests/test_logging_tools.py
+++ b/src/oci-logging-mcp-server/oracle/oci_logging_mcp_server/tests/test_logging_tools.py
@@ -541,7 +541,10 @@ class TestGetClient:
         result = server.get_logging_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -583,7 +586,10 @@ class TestGetClient:
         srv_client = server.get_logging_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()
@@ -631,7 +637,10 @@ class TestGetClient:
         result = server.get_logging_search_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -673,7 +682,10 @@ class TestGetClient:
         srv_client = server.get_logging_search_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/server.py
+++ b/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/server.py
@@ -28,7 +28,8 @@ mcp = FastMCP(name=__project__)
 def get_migration_client():
     logger.info("entering get_migration_client")
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"

--- a/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/tests/test_migration_tools.py
+++ b/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/tests/test_migration_tools.py
@@ -293,7 +293,10 @@ class TestGetClient:
         result = server.get_migration_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -343,7 +346,10 @@ class TestGetClient:
         srv_client = server.get_migration_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/server.py
+++ b/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/server.py
@@ -44,7 +44,8 @@ mcp = FastMCP(
 def get_monitoring_client():
     logger.info("entering get_monitoring_client")
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"

--- a/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/tests/test_monitoring_tools.py
+++ b/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/tests/test_monitoring_tools.py
@@ -339,7 +339,10 @@ class TestGetClient:
         result = server.get_monitoring_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -387,7 +390,10 @@ class TestGetClient:
         srv_client = server.get_monitoring_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/server.py
+++ b/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/server.py
@@ -32,7 +32,8 @@ mcp = FastMCP(name=__project__)
 def get_nlb_client():
     logger.info("entering get_nlb_client")
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"

--- a/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/tests/test_network_load_balancer_tools.py
+++ b/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/tests/test_network_load_balancer_tools.py
@@ -601,7 +601,10 @@ class TestGetClient:
         result = server.get_nlb_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -652,7 +655,10 @@ class TestGetClient:
         srv_client = server.get_nlb_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/server.py
+++ b/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/server.py
@@ -35,7 +35,8 @@ mcp = FastMCP(name=__project__)
 
 def get_networking_client():
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"

--- a/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/tests/test_networking_tools.py
+++ b/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/tests/test_networking_tools.py
@@ -595,7 +595,10 @@ class TestGetClient:
         result = server.get_networking_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -643,7 +646,10 @@ class TestGetClient:
         srv_client = server.get_networking_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/server.py
+++ b/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/server.py
@@ -31,7 +31,8 @@ mcp = FastMCP(name=__project__)
 
 def get_object_storage_client():
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"

--- a/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/tests/test_object_storage_tools.py
+++ b/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/tests/test_object_storage_tools.py
@@ -363,7 +363,10 @@ class TestGetClient:
         result = server.get_object_storage_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -413,7 +416,10 @@ class TestGetClient:
         srv_client = server.get_object_storage_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/server.py
+++ b/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/server.py
@@ -27,7 +27,8 @@ mcp = FastMCP(name=__project__)
 
 def get_ocir_client():
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
 
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]

--- a/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/tests/test_registry_tools.py
+++ b/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/tests/test_registry_tools.py
@@ -282,7 +282,10 @@ class TestGetClient:
         result = server.get_ocir_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -328,7 +331,10 @@ class TestGetClient:
         srv_client = server.get_ocir_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/server.py
+++ b/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/server.py
@@ -27,7 +27,8 @@ mcp = FastMCP(name=__project__)
 def get_search_client():
     logger.info("entering get_search_client")
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
 
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]

--- a/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/tests/test_resource_search_tools.py
+++ b/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/tests/test_resource_search_tools.py
@@ -505,7 +505,10 @@ class TestGetClient:
         result = server.get_search_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -555,7 +558,10 @@ class TestGetClient:
         srv_client = server.get_search_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/server.py
+++ b/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/server.py
@@ -22,7 +22,8 @@ mcp = FastMCP(name=__project__)
 def get_usage_client():
     logger.info("entering get_monitoring_client")
     config = oci.config.from_file(
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"

--- a/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/tests/test_usage_tools.py
+++ b/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/tests/test_usage_tools.py
@@ -138,7 +138,10 @@ class TestGetClient:
         result = server.get_usage_client()
 
         # Assert calls
-        mock_from_file.assert_called_once_with(profile_name="MYPROFILE")
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name="MYPROFILE",
+        )
         mock_open_file.assert_called_once_with("/abs/path/to/token", "r")
         mock_security_token_signer.assert_called_once_with(
             "SECURITY_TOKEN", private_key_obj
@@ -182,7 +185,10 @@ class TestGetClient:
         srv_client = server.get_usage_client()
 
         # Assert: profile defaulted
-        mock_from_file.assert_called_once_with(profile_name=oci.config.DEFAULT_PROFILE)
+        mock_from_file.assert_called_once_with(
+            file_location=oci.config.DEFAULT_LOCATION,
+            profile_name=oci.config.DEFAULT_PROFILE,
+        )
         # Token file opened and read
         mock_open_file.assert_called_once_with("/tkn", "r")
         mock_security_token_signer.assert_called_once()

--- a/tests/e2e/features/mcphost.json
+++ b/tests/e2e/features/mcphost.json
@@ -10,32 +10,34 @@
         "oracle.oci-api-mcp-server"
       ],
       "env": {
-          "HTTP_PROXY": "http://127.0.0.1:5000",
-          "HTTPS_PROXY": "http://127.0.0.1:5000",
-          "OCI_SDK_CERT_BUNDLE": "False",
-          "PYTHONHTTPSVERIFY": "0",
-          "OCI_SKIP_SSL_VERIFICATION": "True",
-          "REQUESTS_CA_BUNDLE": "",
-          "CURL_CA_BUNDLE": ""
+        "OCI_CONFIG_FILE": "${env:OCI_CONFIG_FILE}",
+        "HTTP_PROXY": "http://127.0.0.1:5000",
+        "HTTPS_PROXY": "http://127.0.0.1:5000",
+        "OCI_SDK_CERT_BUNDLE": "False",
+        "PYTHONHTTPSVERIFY": "0",
+        "OCI_SKIP_SSL_VERIFICATION": "True",
+        "REQUESTS_CA_BUNDLE": "",
+        "CURL_CA_BUNDLE": ""
       }
     },
-    "oracle-oci-compute-instance-agent-mcp-server": {
+    "oracle-oci-cloud-guard-mcp-server": {
       "disabled": false,
       "timeout": 60,
       "type": "stdio",
       "command": "uv",
       "args": [
         "run",
-        "oracle.oci-compute-instance-agent-mcp-server"
+        "oracle.oci-cloud-guard-mcp-server"
       ],
       "env": {
-          "HTTP_PROXY": "http://127.0.0.1:5000",
-          "HTTPS_PROXY": "http://127.0.0.1:5000",
-          "OCI_SDK_CERT_BUNDLE": "False",
-          "PYTHONHTTPSVERIFY": "0",
-          "OCI_SKIP_SSL_VERIFICATION": "True",
-          "REQUESTS_CA_BUNDLE": "",
-          "CURL_CA_BUNDLE": ""
+        "OCI_CONFIG_FILE": "${env:OCI_CONFIG_FILE}",
+        "HTTP_PROXY": "http://127.0.0.1:5000",
+        "HTTPS_PROXY": "http://127.0.0.1:5000",
+        "OCI_SDK_CERT_BUNDLE": "False",
+        "PYTHONHTTPSVERIFY": "0",
+        "OCI_SKIP_SSL_VERIFICATION": "True",
+        "REQUESTS_CA_BUNDLE": "",
+        "CURL_CA_BUNDLE": ""
       }
     },
     "oracle-oci-compute-mcp-server": {
@@ -48,32 +50,76 @@
         "oracle.oci-compute-mcp-server"
       ],
       "env": {
-          "HTTP_PROXY": "http://127.0.0.1:5000",
-          "HTTPS_PROXY": "http://127.0.0.1:5000",
-          "OCI_SDK_CERT_BUNDLE": "False",
-          "PYTHONHTTPSVERIFY": "0",
-          "OCI_SKIP_SSL_VERIFICATION": "True",
-          "REQUESTS_CA_BUNDLE": "",
-          "CURL_CA_BUNDLE": ""
+        "OCI_CONFIG_FILE": "${env:OCI_CONFIG_FILE}",
+        "HTTP_PROXY": "http://127.0.0.1:5000",
+        "HTTPS_PROXY": "http://127.0.0.1:5000",
+        "OCI_SDK_CERT_BUNDLE": "False",
+        "PYTHONHTTPSVERIFY": "0",
+        "OCI_SKIP_SSL_VERIFICATION": "True",
+        "REQUESTS_CA_BUNDLE": "",
+        "CURL_CA_BUNDLE": ""
       }
     },
-    "oracle-oci-identity-mcp-server": {
+    "oracle-oci-faaas-mcp-server": {
       "disabled": false,
       "timeout": 60,
       "type": "stdio",
       "command": "uv",
       "args": [
         "run",
-        "oracle.oci-identity-mcp-server"
+        "oracle.oci-faaas-mcp-server"
       ],
       "env": {
-          "HTTP_PROXY": "http://127.0.0.1:5000",
-          "HTTPS_PROXY": "http://127.0.0.1:5000",
-          "OCI_SDK_CERT_BUNDLE": "False",
-          "PYTHONHTTPSVERIFY": "0",
-          "OCI_SKIP_SSL_VERIFICATION": "True",
-          "REQUESTS_CA_BUNDLE": "",
-          "CURL_CA_BUNDLE": ""
+        "OCI_CONFIG_FILE": "${env:OCI_CONFIG_FILE}",
+        "HTTP_PROXY": "http://127.0.0.1:5000",
+        "HTTPS_PROXY": "http://127.0.0.1:5000",
+        "OCI_SDK_CERT_BUNDLE": "False",
+        "PYTHONHTTPSVERIFY": "0",
+        "OCI_SKIP_SSL_VERIFICATION": "True",
+        "REQUESTS_CA_BUNDLE": "",
+        "CURL_CA_BUNDLE": ""
+      }
+    },
+    "oracle-oci-identity-mcp-server": {
+      "disabled": false,
+      "command": "uv",
+      "args": [
+        "run",
+        "python",
+        "-c",
+        "import sys; sys.path.insert(0, 'mocks'); import sitecustomize; from oracle.oci_identity_mcp_server.server import main; main()"
+      ],
+      "env": {
+        "PYTHONPATH": "../../../src/oci-identity-mcp-server:mocks",
+        "PYTHONNOUSERSITE": "0",
+        "OCI_CONFIG_FILE": "${env:OCI_CONFIG_FILE}",
+        "HTTP_PROXY": "http://127.0.0.1:5000",
+        "HTTPS_PROXY": "http://127.0.0.1:5000",
+        "OCI_SDK_CERT_BUNDLE": "False",
+        "PYTHONHTTPSVERIFY": "0",
+        "OCI_SKIP_SSL_VERIFICATION": "True",
+        "REQUESTS_CA_BUNDLE": "",
+        "CURL_CA_BUNDLE": ""
+      }
+    },
+    "oracle-oci-logging-mcp-server": {
+      "disabled": false,
+      "timeout": 60,
+      "type": "stdio",
+      "command": "uv",
+      "args": [
+        "run",
+        "oracle.oci-logging-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_FILE": "${env:OCI_CONFIG_FILE}",
+        "HTTP_PROXY": "http://127.0.0.1:5000",
+        "HTTPS_PROXY": "http://127.0.0.1:5000",
+        "OCI_SDK_CERT_BUNDLE": "False",
+        "PYTHONHTTPSVERIFY": "0",
+        "OCI_SKIP_SSL_VERIFICATION": "True",
+        "REQUESTS_CA_BUNDLE": "",
+        "CURL_CA_BUNDLE": ""
       }
     },
     "oracle-oci-migration-mcp-server": {
@@ -86,70 +132,14 @@
         "oracle.oci-migration-mcp-server"
       ],
       "env": {
-          "HTTP_PROXY": "http://127.0.0.1:5000",
-          "HTTPS_PROXY": "http://127.0.0.1:5000",
-          "OCI_SDK_CERT_BUNDLE": "False",
-          "PYTHONHTTPSVERIFY": "0",
-          "OCI_SKIP_SSL_VERIFICATION": "True",
-          "REQUESTS_CA_BUNDLE": "",
-          "CURL_CA_BUNDLE": ""
-      }
-    },
-    "oracle-oci-monitoring-mcp-server": {
-      "disabled": false,
-      "timeout": 60,
-      "type": "stdio",
-      "command": "uv",
-      "args": [
-        "run",
-        "oracle.oci-monitoring-mcp-server"
-      ],
-      "env": {
-          "HTTP_PROXY": "http://127.0.0.1:5000",
-          "HTTPS_PROXY": "http://127.0.0.1:5000",
-          "OCI_SDK_CERT_BUNDLE": "False",
-          "PYTHONHTTPSVERIFY": "0",
-          "OCI_SKIP_SSL_VERIFICATION": "True",
-          "REQUESTS_CA_BUNDLE": "",
-          "CURL_CA_BUNDLE": ""
-      }
-    },
-    "oracle-oci-network-load-balancer-mcp-server": {
-      "disabled": false,
-      "timeout": 60,
-      "type": "stdio",
-      "command": "uv",
-      "args": [
-        "run",
-        "oracle.oci-network-load-balancer-mcp-server"
-      ],
-      "env": {
-          "HTTP_PROXY": "http://127.0.0.1:5000",
-          "HTTPS_PROXY": "http://127.0.0.1:5000",
-          "OCI_SDK_CERT_BUNDLE": "False",
-          "PYTHONHTTPSVERIFY": "0",
-          "OCI_SKIP_SSL_VERIFICATION": "True",
-          "REQUESTS_CA_BUNDLE": "",
-          "CURL_CA_BUNDLE": ""
-      }
-    },
-    "oracle-oci-networking-mcp-server": {
-      "disabled": false,
-      "timeout": 60,
-      "type": "stdio",
-      "command": "uv",
-      "args": [
-        "run",
-        "oracle.oci-networking-mcp-server"
-      ],
-      "env": {
-          "HTTP_PROXY": "http://127.0.0.1:5000",
-          "HTTPS_PROXY": "http://127.0.0.1:5000",
-          "OCI_SDK_CERT_BUNDLE": "False",
-          "PYTHONHTTPSVERIFY": "0",
-          "OCI_SKIP_SSL_VERIFICATION": "True",
-          "REQUESTS_CA_BUNDLE": "",
-          "CURL_CA_BUNDLE": ""
+        "OCI_CONFIG_FILE": "${env:OCI_CONFIG_FILE}",
+        "HTTP_PROXY": "http://127.0.0.1:5000",
+        "HTTPS_PROXY": "http://127.0.0.1:5000",
+        "OCI_SDK_CERT_BUNDLE": "False",
+        "PYTHONHTTPSVERIFY": "0",
+        "OCI_SKIP_SSL_VERIFICATION": "True",
+        "REQUESTS_CA_BUNDLE": "",
+        "CURL_CA_BUNDLE": ""
       }
     },
     "oracle-oci-object-storage-mcp-server": {
@@ -162,51 +152,14 @@
         "oracle.oci-object-storage-mcp-server"
       ],
       "env": {
-          "HTTP_PROXY": "http://127.0.0.1:5000",
-          "HTTPS_PROXY": "http://127.0.0.1:5000",
-          "OCI_SDK_CERT_BUNDLE": "False",
-          "PYTHONHTTPSVERIFY": "0",
-          "OCI_SKIP_SSL_VERIFICATION": "True",
-          "REQUESTS_CA_BUNDLE": "",
-          "CURL_CA_BUNDLE": ""
-      }
-    },
-    "oracle-oci-registry-mcp-server": {
-      "disabled": false,
-      "timeout": 60,
-      "type": "stdio",
-      "command": "uv",
-      "args": [
-        "run",
-        "oracle.oci-registry-mcp-server"
-      ],
-      "env": {
-          "HTTP_PROXY": "http://127.0.0.1:5000",
-          "HTTPS_PROXY": "http://127.0.0.1:5000",
-          "OCI_SDK_CERT_BUNDLE": "False",
-          "PYTHONHTTPSVERIFY": "0",
-          "OCI_SKIP_SSL_VERIFICATION": "True",
-          "REQUESTS_CA_BUNDLE": "",
-          "CURL_CA_BUNDLE": ""
-      }
-    },
-    "oracle-oci-resource-search-mcp-server": {
-      "disabled": false,
-      "timeout": 60,
-      "type": "stdio",
-      "command": "uv",
-      "args": [
-        "run",
-        "oracle.oci-resource-search-mcp-server"
-      ],
-      "env": {
-          "HTTP_PROXY": "http://127.0.0.1:5000",
-          "HTTPS_PROXY": "http://127.0.0.1:5000",
-          "OCI_SDK_CERT_BUNDLE": "False",
-          "PYTHONHTTPSVERIFY": "0",
-          "OCI_SKIP_SSL_VERIFICATION": "True",
-          "REQUESTS_CA_BUNDLE": "",
-          "CURL_CA_BUNDLE": ""
+        "OCI_CONFIG_FILE": "${env:OCI_CONFIG_FILE}",
+        "HTTP_PROXY": "http://127.0.0.1:5000",
+        "HTTPS_PROXY": "http://127.0.0.1:5000",
+        "OCI_SDK_CERT_BUNDLE": "False",
+        "PYTHONHTTPSVERIFY": "0",
+        "OCI_SKIP_SSL_VERIFICATION": "True",
+        "REQUESTS_CA_BUNDLE": "",
+        "CURL_CA_BUNDLE": ""
       }
     }
   }

--- a/tests/e2e/features/mocks/services/cloud_guard_data.py
+++ b/tests/e2e/features/mocks/services/cloud_guard_data.py
@@ -1,0 +1,51 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+# All mock data keys use camelCase to align with OCI SDK JSON expectations.
+
+PROBLEMS = [
+    {
+        "id": "ocid1.cloudguardproblem.oc1..mock-problem-1",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
+        "detectorRuleId": "ocid1.cloudguarddetectorrule.oc1..mock-rule-1",
+        "regions": ["us-mock-1"],
+        "riskLevel": "HIGH",
+        "riskScore": 73.2,
+        "resourceId": "ocid1.instance.oc1..mock-uuid-1",
+        "resourceName": "Mock-Server-1",
+        "resourceType": "instance",
+        "labels": ["public", "open-ssh"],
+        "timeLastDetected": "2026-01-13T10:00:00Z",
+        "timeFirstDetected": "2026-01-12T09:00:00Z",
+        "lifecycleState": "ACTIVE",
+        "lifecycleDetail": "OPEN",
+        "detectorId": "IAAS_CONFIGURATION_DETECTOR",
+        "targetId": "ocid1.cloudguardtarget.oc1..mock-target-1",
+        "additionalDetails": {"port": "22", "protocol": "tcp"},
+        "description": "Security group allows SSH from 0.0.0.0/0",
+        "recommendation": "Restrict SSH access to known IP ranges",
+    },
+    {
+        "id": "ocid1.cloudguardproblem.oc1..mock-problem-2",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
+        "detectorRuleId": "ocid1.cloudguarddetectorrule.oc1..mock-rule-2",
+        "regions": ["us-mock-1"],
+        "riskLevel": "MEDIUM",
+        "riskScore": 55.0,
+        "resourceId": "ocid1.object.oc1..mock-object-1",
+        "resourceName": "Mock-Bucket-1",
+        "resourceType": "bucket",
+        "labels": ["public-read"],
+        "timeLastDetected": "2026-01-13T11:00:00Z",
+        "timeFirstDetected": "2026-01-12T08:30:00Z",
+        "lifecycleState": "ACTIVE",
+        "lifecycleDetail": "OPEN",
+        "detectorId": "IAAS_ACTIVITY_DETECTOR",
+        "targetId": "ocid1.cloudguardtarget.oc1..mock-target-2",
+        "description": "Bucket allows public reads",
+        "recommendation": "Disable public access for buckets",
+    },
+]

--- a/tests/e2e/features/mocks/services/cloud_guard_routes.py
+++ b/tests/e2e/features/mocks/services/cloud_guard_routes.py
@@ -1,0 +1,43 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from _common import oci_res
+from cloud_guard_data import PROBLEMS
+from flask import Blueprint, jsonify, request
+
+# Cloud Guard API version base path
+cloud_guard_bp = Blueprint("cloud_guard", __name__, url_prefix="/20200131")
+
+
+@cloud_guard_bp.route("/problems", methods=["GET"])
+def list_problems():
+    # Accept typical Cloud Guard filters
+    risk_level = request.args.get("riskLevel")
+    lifecycle_state = request.args.get("lifecycleState")
+    detector_rule_ids = request.args.getlist("detectorRuleIdList")
+    limit = request.args.get("limit", type=int)
+
+    items = PROBLEMS.copy()
+
+    if risk_level:
+        items = [p for p in items if p.get("riskLevel") == risk_level]
+    if lifecycle_state:
+        items = [p for p in items if p.get("lifecycleState") == lifecycle_state]
+    if detector_rule_ids:
+        items = [p for p in items if p.get("detectorRuleId") in set(detector_rule_ids)]
+    if limit is not None:
+        items = items[:limit]
+
+    # Cloud Guard ListProblems returns a ProblemCollection with `items`
+    return oci_res({"items": items})
+
+
+@cloud_guard_bp.route("/problems/<problem_id>", methods=["GET"])
+def get_problem(problem_id):
+    prob = next((p for p in PROBLEMS if p.get("id") == problem_id), None)
+    if not prob:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(prob)

--- a/tests/e2e/features/mocks/services/compute_data.py
+++ b/tests/e2e/features/mocks/services/compute_data.py
@@ -7,7 +7,7 @@ https://oss.oracle.com/licenses/upl.
 INSTANCES = [
     {
         "id": "ocid1.instance.oc1..mock-uuid-1",
-        "compartmentId": "ocid1.compartment.oc1..mock",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
         "displayName": "Mock-Server-1",
         "lifecycleState": "RUNNING",
         "availabilityDomain": "aNMj:US-ASHBURN-AD-1",
@@ -16,7 +16,7 @@ INSTANCES = [
     },
     {
         "id": "ocid1.instance.oc1..mock-uuid-2",
-        "compartmentId": "ocid1.compartment.oc1..mock",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
         "displayName": "Mock-Server-2",
         "lifecycleState": "RUNNING",
         "availabilityDomain": "aNMj:US-ASHBURN-AD-1",
@@ -38,7 +38,7 @@ VNIC_ATTACHMENTS = [
     {
         "id": "ocid1.vnicattachment.oc1..mock-vnic-1",
         "instanceId": "ocid1.instance.oc1..mock-uuid-1",
-        "compartmentId": "ocid1.compartment.oc1..mock",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
         "lifecycleState": "ATTACHED",
         "vnicId": "ocid1.vnic.oc1..mock-vnic-core-1",
     }

--- a/tests/e2e/features/mocks/services/faaas_data.py
+++ b/tests/e2e/features/mocks/services/faaas_data.py
@@ -1,0 +1,62 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+# All mock data keys use camelCase to align with OCI SDK JSON expectations.
+
+FUSION_ENVIRONMENT_FAMILIES = [
+    {
+        "id": "ocid1.fusionenvironmentfamily.oc1..mock-family-1",
+        "displayName": "Mock Family 1",
+        "lifecycleState": "ACTIVE",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
+        "timeCreated": "2026-01-15T12:00:00Z",
+    },
+    {
+        "id": "ocid1.fusionenvironmentfamily.oc1..mock-family-2",
+        "displayName": "Mock Family 1",
+        "lifecycleState": "ACTIVE",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
+        "timeCreated": "2026-01-15T12:00:00Z",
+    },
+]
+
+FUSION_ENVIRONMENTS = [
+    {
+        "id": "ocid1.fusionenvironment.oc1..mock-env-1",
+        "displayName": "Mock Env 1",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
+        "fusionEnvironmentFamilyId": "ocid1.fusionenvironmentfamily.oc1..mock-family-1",
+        "fusionEnvironmentType": "TEST",
+        "version": "25C",
+        "publicUrl": "https://mock-env1.example.com",
+        "lifecycleState": "ACTIVE",
+        "timeCreated": "2026-01-15T13:00:00Z",
+    },
+    {
+        "id": "ocid1.fusionenvironment.oc1..mock-env-2",
+        "displayName": "Mock Env 2",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
+        "fusionEnvironmentFamilyId": "ocid1.fusionenvironmentfamily.oc1..mock-family-1",
+        "fusionEnvironmentType": "PRODUCTION",
+        "version": "25C",
+        "publicUrl": "https://mock-env2.example.com",
+        "lifecycleState": "ACTIVE",
+        "timeCreated": "2026-01-15T14:00:00Z",
+    },
+]
+
+FUSION_ENVIRONMENT_STATUSES = [
+    {
+        "fusionEnvironmentId": "ocid1.fusionenvironment.oc1..mock-env-1",
+        "status": "AVAILABLE",
+        "timeUpdated": "2026-01-15T15:00:00Z",
+    },
+    {
+        "fusionEnvironmentId": "ocid1.fusionenvironment.oc1..mock-env-2",
+        "status": "AVAILABLE",
+        "timeUpdated": "2026-01-15T15:00:00Z",
+    },
+]

--- a/tests/e2e/features/mocks/services/faaas_routes.py
+++ b/tests/e2e/features/mocks/services/faaas_routes.py
@@ -1,0 +1,82 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from _common import oci_res
+from faaas_data import (
+    FUSION_ENVIRONMENT_FAMILIES,
+    FUSION_ENVIRONMENT_STATUSES,
+    FUSION_ENVIRONMENTS,
+)
+from flask import Blueprint, jsonify, request
+
+# Fusion Applications public base path follows service's versioning; using 20211201
+faaas_bp = Blueprint("faaas", __name__, url_prefix="/20211201")
+
+
+@faaas_bp.route("/fusionEnvironmentFamilies", methods=["GET"])
+def list_fusion_environment_families():
+    # Filters: compartmentId, displayName, lifecycleState, page
+    compartment_id = request.args.get("compartmentId")
+    display_name = request.args.get("displayName")
+    lifecycle_state = request.args.get("lifecycleState")
+
+    items = FUSION_ENVIRONMENT_FAMILIES
+
+    if compartment_id:
+        items = [i for i in items if i.get("compartmentId") == compartment_id]
+    if display_name:
+        items = [i for i in items if i.get("displayName") == display_name]
+    if lifecycle_state:
+        items = [i for i in items if i.get("lifecycleState") == lifecycle_state]
+
+    # Emulate collection shape with `items` key
+    return oci_res({"items": items})
+
+
+@faaas_bp.route("/fusionEnvironments", methods=["GET"])
+def list_fusion_environments():
+    compartment_id = request.args.get("compartmentId")
+    family_id = request.args.get("fusionEnvironmentFamilyId")
+    display_name = request.args.get("displayName")
+    lifecycle_state = request.args.get("lifecycleState")
+
+    items = FUSION_ENVIRONMENTS
+
+    if compartment_id:
+        items = [i for i in items if i.get("compartmentId") == compartment_id]
+    if family_id:
+        items = [i for i in items if i.get("fusionEnvironmentFamilyId") == family_id]
+    if display_name:
+        items = [i for i in items if i.get("displayName") == display_name]
+    if lifecycle_state:
+        items = [i for i in items if i.get("lifecycleState") == lifecycle_state]
+
+    return oci_res({"items": items})
+
+
+@faaas_bp.route("/fusionEnvironments/<fusion_environment_id>", methods=["GET"])
+def get_fusion_environment(fusion_environment_id):
+    env = next(
+        (i for i in FUSION_ENVIRONMENTS if i.get("id") == fusion_environment_id), None
+    )
+    if not env:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(env)
+
+
+@faaas_bp.route("/fusionEnvironments/<fusion_environment_id>/status", methods=["GET"])
+def get_fusion_environment_status(fusion_environment_id):
+    status = next(
+        (
+            i
+            for i in FUSION_ENVIRONMENT_STATUSES
+            if i.get("fusionEnvironmentId") == fusion_environment_id
+        ),
+        None,
+    )
+    if not status:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(status)

--- a/tests/e2e/features/mocks/services/identity_data.py
+++ b/tests/e2e/features/mocks/services/identity_data.py
@@ -4,7 +4,69 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+# Availability Domains
 ADS = [
-    {"name": "aNMj:US-ASHBURN-AD-1", "id": "ocid1.ad.oc1..1"},
-    {"name": "aNMj:US-ASHBURN-AD-2", "id": "ocid1.ad.oc1..2"},
+    {
+        "name": "aNMj:US-ASHBURN-AD-1",
+        "id": "ocid1.ad.oc1..1",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
+    },
+    {
+        "name": "aNMj:US-ASHBURN-AD-2",
+        "id": "ocid1.ad.oc1..2",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
+    },
+]
+
+# Tenancy
+TENANCY = {
+    "id": "ocid1.tenancy.oc1..mock",
+    "name": "mock-tenancy",
+    "description": "Mock tenancy for tests",
+    "homeRegionKey": "MOCK",
+}
+
+# User (current user)
+USER = {
+    "id": "ocid1.user.oc1..mock",
+    "compartmentId": TENANCY["id"],
+    "name": "mock.user@oracle.com",
+    "description": "Mock user",
+    "email": "mock.user@oracle.com",
+    "emailVerified": True,
+}
+
+# Compartments (children of tenancy and nested example)
+COMPARTMENTS = [
+    {
+        "id": "ocid1.compartment.oc1..root",
+        "compartmentId": TENANCY["id"],
+        "name": "root",
+        "description": "Root compartment",
+        "lifecycleState": "ACTIVE",
+    },
+    {
+        "id": "ocid1.compartment.oc1..dev",
+        "compartmentId": TENANCY["id"],
+        "name": "Dev",
+        "description": "Development",
+        "lifecycleState": "ACTIVE",
+    },
+    {
+        "id": "ocid1.compartment.oc1..dev-sub",
+        "compartmentId": "ocid1.compartment.oc1..dev",
+        "name": "Dev-Sub",
+        "description": "Nested under Dev",
+        "lifecycleState": "ACTIVE",
+    },
+]
+
+# Region subscriptions for the tenancy
+REGION_SUBSCRIPTIONS = [
+    {
+        "regionKey": "MOCK",
+        "regionName": "us-mock-1",
+        "status": "READY",
+        "isHomeRegion": True,
+    },
 ]

--- a/tests/e2e/features/mocks/services/identity_routes.py
+++ b/tests/e2e/features/mocks/services/identity_routes.py
@@ -5,12 +5,58 @@ https://oss.oracle.com/licenses/upl.
 """
 
 from _common import oci_res
-from flask import Blueprint
-from identity_data import ADS
+from flask import Blueprint, jsonify, request
+from identity_data import ADS, COMPARTMENTS, REGION_SUBSCRIPTIONS, TENANCY, USER
 
 identity_bp = Blueprint("identity", __name__, url_prefix="/20160918")
 
 
-@identity_bp.route("/20160918/availabilityDomains", methods=["GET"])
+@identity_bp.route("/availabilityDomains", methods=["GET"])
 def list_ads():
+    # OCI expects compartmentId but we ignore filtering in mock
     return oci_res(ADS)
+
+
+@identity_bp.route("/compartments/<compartment_id>", methods=["GET"])
+def get_compartment(compartment_id):
+    compartments = COMPARTMENTS + [TENANCY]
+    compartment = next((i for i in compartments if i["id"] == compartment_id), None)
+    return (
+        oci_res(compartment)
+        if compartment
+        else (jsonify({"code": "NotAuthorizedOrNotFound"}), 404)
+    )
+
+
+@identity_bp.route("/compartments", methods=["GET"])
+def list_compartments():
+    parent_id = request.args.get("compartmentId")
+
+    items = COMPARTMENTS
+    if parent_id:
+        items = [c for c in COMPARTMENTS if c.get("compartmentId") == parent_id]
+
+    return oci_res(items)
+
+
+@identity_bp.route("/tenancies/<tenancy_id>", methods=["GET"])
+def get_tenancy(tenancy_id):
+    if TENANCY.get("id") == tenancy_id:
+        return oci_res(TENANCY)
+    return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+
+
+@identity_bp.route("/users/<user_id>", methods=["GET"])
+def get_user(user_id):
+    if USER.get("id") == user_id:
+        return oci_res(USER)
+    return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+
+
+@identity_bp.route("/tenancies/<tenancy_id>/regionSubscriptions", methods=["GET"])
+def list_region_subscriptions(tenancy_id):
+    # Filter by tenancyId if passed
+    tenancy_id = request.args.get("tenancyId")
+    if tenancy_id and TENANCY.get("id") != tenancy_id:
+        return oci_res([])
+    return oci_res(REGION_SUBSCRIPTIONS)

--- a/tests/e2e/features/mocks/services/logging_data.py
+++ b/tests/e2e/features/mocks/services/logging_data.py
@@ -1,0 +1,40 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+# All mock data keys use camelCase to align with OCI SDK JSON expectations.
+
+LOG_GROUPS = [
+    {
+        "id": "ocid1.loggroup.oc1..mock-lg-1",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
+        "displayName": "Mock Log Group 1",
+        "description": "Test log group",
+        "lifecycleState": "ACTIVE",
+        "timeCreated": "2026-01-15T10:00:00Z",
+        "timeLastModified": "2026-01-15T11:00:00Z",
+    }
+]
+
+LOGS = [
+    {
+        "id": "ocid1.log.oc1..mock-log-1",
+        "displayName": "Mock-Service-Log",
+        "logGroupId": "ocid1.loggroup.oc1..mock-lg-1",
+        "logType": "SERVICE",
+        "lifecycleState": "ACTIVE",
+        "configuration": {
+            "source": {
+                "sourceType": "OCISERVICE",
+                "service": "compute",
+                "resource": "ocid1.instance.oc1..mock-uuid-1",
+                "category": "all",
+            }
+        },
+        "isEnabled": True,
+        "retentionDuration": 30,
+        "timeCreated": "2026-01-13T10:00:00Z",
+    }
+]

--- a/tests/e2e/features/mocks/services/logging_routes.py
+++ b/tests/e2e/features/mocks/services/logging_routes.py
@@ -1,0 +1,57 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from _common import oci_res
+from flask import Blueprint, jsonify, request
+from logging_data import LOG_GROUPS, LOGS
+
+# OCI Logging Management API version base path
+logging_bp = Blueprint("logging", __name__, url_prefix="/20200531")
+
+
+@logging_bp.route("/logGroups", methods=["GET"])
+def list_log_groups():
+    compartment_id = request.args.get("compartmentId")
+    limit = request.args.get("limit", type=int)
+
+    items = LOG_GROUPS
+    if compartment_id:
+        items = [i for i in items if i.get("compartmentId") == compartment_id]
+    if limit is not None:
+        items = items[:limit]
+
+    return oci_res(items)
+
+
+@logging_bp.route("/logGroups/<log_group_id>", methods=["GET"])
+def get_log_group(log_group_id):
+    lg = next((i for i in LOG_GROUPS if i.get("id") == log_group_id), None)
+    if not lg:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(lg)
+
+
+@logging_bp.route("/logGroups/<log_group_id>/logs", methods=["GET"])
+def list_logs(log_group_id):
+    limit = request.args.get("limit", type=int)
+
+    items = LOGS
+    if log_group_id:
+        items = [i for i in items if i.get("logGroupId") == log_group_id]
+    if limit is not None:
+        items = items[:limit]
+
+    return oci_res(items)
+
+
+@logging_bp.route("/logGroups/<log_group_id>/logs/<log_id>", methods=["GET"])
+def get_log(log_group_id, log_id):
+    match = next((i for i in LOGS if i.get("id") == log_id), None)
+    if not match:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    if log_group_id and match.get("logGroupId") != log_group_id:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(match)

--- a/tests/e2e/features/mocks/services/migration_data.py
+++ b/tests/e2e/features/mocks/services/migration_data.py
@@ -1,0 +1,33 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+# All mock data keys use camelCase to align with OCI SDK JSON expectations.
+
+MIGRATIONS = [
+    {
+        "id": "ocid1.migration.oc1..mock-mig-1",
+        "displayName": "Mock Migration 1",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
+        "lifecycleState": "ACTIVE",
+        "lifecycleDetails": "Running",
+        "timeCreated": "2026-01-10T10:00:00Z",
+        "timeUpdated": "2026-01-11T11:00:00Z",
+        "replicationScheduleId": "ocid1.replicationschedule.oc1..mock-rs-1",
+        "isCompleted": False,
+        "freeformTags": {"env": "dev"},
+    },
+    {
+        "id": "ocid1.migration.oc1..mock-mig-2",
+        "displayName": "Mock Migration 2",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
+        "lifecycleState": "NEEDS_ATTENTION",
+        "lifecycleDetails": "Configuration required",
+        "timeCreated": "2026-01-12T12:00:00Z",
+        "timeUpdated": "2026-01-13T13:00:00Z",
+        "replicationScheduleId": None,
+        "isCompleted": False,
+    },
+]

--- a/tests/e2e/features/mocks/services/migration_routes.py
+++ b/tests/e2e/features/mocks/services/migration_routes.py
@@ -1,0 +1,39 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from _common import oci_res
+from flask import Blueprint, jsonify, request
+from migration_data import MIGRATIONS
+
+# OCI Cloud Migrations API version base path (approximate)
+migration_bp = Blueprint("migration", __name__, url_prefix="/20220919")
+
+
+@migration_bp.route("/migrations", methods=["GET"])
+def list_migrations():
+    compartment_id = request.args.get("compartmentId")
+    lifecycle_state = request.args.get("lifecycleState")
+    limit = request.args.get("limit", type=int)
+
+    items = MIGRATIONS
+
+    if compartment_id:
+        items = [i for i in items if i.get("compartmentId") == compartment_id]
+    if lifecycle_state:
+        items = [i for i in items if i.get("lifecycleState") == lifecycle_state]
+    if limit is not None:
+        items = items[:limit]
+
+    # list_migrations returns a collection with `items`
+    return oci_res({"items": items})
+
+
+@migration_bp.route("/migrations/<migration_id>", methods=["GET"])
+def get_migration(migration_id):
+    mig = next((i for i in MIGRATIONS if i.get("id") == migration_id), None)
+    if not mig:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(mig)

--- a/tests/e2e/features/mocks/services/networking_data.py
+++ b/tests/e2e/features/mocks/services/networking_data.py
@@ -8,6 +8,6 @@ SUBNETS = [
     {
         "id": "ocid1.subnet.oc1..mock-subnet",
         "displayName": "Default Subnet",
-        "compartmentId": "ocid1.compartment.oc1..mock",
+        "compartmentId": "ocid1.tenancy.oc1..mock",
     }
 ]

--- a/tests/e2e/features/mocks/sitecustomize.py
+++ b/tests/e2e/features/mocks/sitecustomize.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+import oci.identity
+
+# Use this file to perform patches for individual servers that ignore HTTP/HTTPS proxy settings
+# E.g. the OCI identity service has one global endpoint that ignores proxies.
+# You can patch the identity client's init function to shove the mocked endpoint in there.
+
+original_init = oci.identity.IdentityClient.__init__
+
+
+def patched_init(self, config, **kwargs):
+    # Change http to https so the Shim triggers the SSL logic
+    kwargs["service_endpoint"] = "https://iaas.us-mock-1.oraclecloud.com"
+    kwargs["verify"] = False
+    return original_init(self, config, **kwargs)
+
+
+oci.identity.IdentityClient.__init__ = patched_init
+
+# IMPORTANT: Use stderr for logging
+sys.stderr.write("!!! IDENTITY PATCH INJECTED VIA SITECUSTOMIZE !!!\n")
+
+config_env = os.environ.get("OCI_CONFIG_FILE", "NOT SET (Using default ~/.oci/config)")
+sys.stderr.write(f"!!! DEBUG: Identity Server using config: {config_env} !!!\n")

--- a/tests/e2e/features/oci-cloud-guard-mcp-server.feature
+++ b/tests/e2e/features/oci-cloud-guard-mcp-server.feature
@@ -1,0 +1,23 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+
+Feature: OCI Cloud Guard MCP Server
+  Scenario: List the Cloud Guard tools available in the agent
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "What cloud guard mcp tools do you have"
+    Then the response should contain a list of cloud guard tools available
+
+  Scenario: List Cloud Guard problems
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list my cloud guard problems for the past 30 days"
+    Then the response should contain a list of cloud guard problems
+
+  Scenario: Get Cloud Guard problem details
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list my cloud guard problems for the past 30 days, then get the details of the first problem in the list"
+    Then the response should contain the details of a cloud guard problem

--- a/tests/e2e/features/oci-compute-mcp-server.feature
+++ b/tests/e2e/features/oci-compute-mcp-server.feature
@@ -7,7 +7,7 @@ Feature: OCI Compute MCP Server
   Scenario: List the compute tools available in the agent
     Given the MCP server is running with OCI tools
     And the ollama model with the tools is properly working
-    When I send a request with the prompt "What compute tools do you have"
+    When I send a request with the prompt "What compute mcp tools do you have"
     Then the response should contain a list of compute tools available
 
   Scenario: List the compute instances

--- a/tests/e2e/features/oci-faaas-mcp-server.feature
+++ b/tests/e2e/features/oci-faaas-mcp-server.feature
@@ -1,0 +1,35 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+
+Feature: OCI Fusion Applications (FaaS) MCP Server
+  Scenario: List the FaaS tools available in the agent
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "What fusion applications (faaas) mcp tools do you have"
+    Then the response should contain a list of faaas tools available
+
+  Scenario: List Fusion Environment Families
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list fusion environment families"
+    Then the response should contain a list of fusion environment families
+
+  Scenario: List Fusion Environments
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list fusion environments"
+    Then the response should contain a list of fusion environments
+
+  Scenario: Get Fusion Environment details
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list fusion environments and then get the details of the first one"
+    Then the response should contain the details of a fusion environment
+
+  Scenario: Get Fusion Environment status
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "get the status of the first fusion environment"
+    Then the response should contain the status of a fusion environment

--- a/tests/e2e/features/oci-identity-mcp-server.feature
+++ b/tests/e2e/features/oci-identity-mcp-server.feature
@@ -1,0 +1,41 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+
+Feature: OCI Identity MCP Server
+  Scenario: List the identity tools available in the agent
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "What identity mcp tools do you have"
+    Then the response should contain a list of identity tools available
+
+  Scenario: List compartments
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list my compartments"
+    Then the response should contain a list of compartments
+
+  Scenario: Get tenancy details
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "get my tenancy details"
+    Then the response should contain the details of a tenancy
+
+  Scenario: List availability domains
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list availability domains"
+    Then the response should contain a list of availability domains
+
+  Scenario: Get current user
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "show me my user details"
+    Then the response should contain the details of a user
+
+  Scenario: List subscribed regions
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list my subscribed regions"
+    Then the response should contain a list of regions

--- a/tests/e2e/features/oci-logging-mcp-server.feature
+++ b/tests/e2e/features/oci-logging-mcp-server.feature
@@ -1,0 +1,35 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+
+Feature: OCI Logging MCP Server
+  Scenario: List the logging tools available in the agent
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "What logging mcp tools do you have"
+    Then the response should contain a list of logging tools available
+
+  Scenario: List log groups
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list my log groups"
+    Then the response should contain a list of log groups
+
+  Scenario: Get log group details
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list my log groups, then get the details of the first log group in the list"
+    Then the response should contain the details of a log group
+
+  Scenario: List logs in a log group
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list my log groups and list the logs for the first log group"
+    Then the response should contain a list of logs
+
+  Scenario: Get log details
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list my log groups and list the logs for the first log group, then fetch the details of the first log in that list"
+    Then the response should contain the details of a log

--- a/tests/e2e/features/oci-migration-mcp-server.feature
+++ b/tests/e2e/features/oci-migration-mcp-server.feature
@@ -1,0 +1,23 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+
+Feature: OCI Migration MCP Server
+  Scenario: List the migration tools available in the agent
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "What migration mcp tools do you have"
+    Then the response should contain a list of migration tools available
+
+  Scenario: List migrations in a compartment
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list my migrations"
+    Then the response should contain a list of migrations
+
+  Scenario: Get a migration by OCID
+    Given the MCP server is running with OCI tools
+    And the ollama model with the tools is properly working
+    When I send a request with the prompt "list my migrations, then get the details of the first migration in the list"
+    Then the response should contain the details of a migration

--- a/tests/e2e/features/steps/oci-cloud-guard-mcp-server-steps.py
+++ b/tests/e2e/features/steps/oci-cloud-guard-mcp-server-steps.py
@@ -1,0 +1,39 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from behave import then
+
+
+@then("the response should contain a list of cloud guard tools available")
+def step_impl_cloud_guard_tools_available(context):
+    response_json = context.response.json()
+    assert (
+        "content" in response_json["message"]
+    ), "Response does not contain a content key."
+    content = response_json["message"]["content"].lower()
+    # Tools from Cloud Guard server
+    assert any(
+        tool in content for tool in ["list_problems", "get_problem_details"]
+    ), "Cloud Guard tools could not be queried."
+
+
+@then("the response should contain a list of cloud guard problems")
+def step_impl_list_problems(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    # Look for a known OCID prefix for Cloud Guard Problem
+    assert (
+        "ocid1.cloudguardproblem" in result["message"]["content"].lower()
+    ), "List of Cloud Guard problems not found."
+
+
+@then("the response should contain the details of a cloud guard problem")
+def step_impl_get_problem_details(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    assert (
+        "ocid1.cloudguardproblem" in result["message"]["content"].lower()
+    ), "Cloud Guard problem details not found."

--- a/tests/e2e/features/steps/oci-faaas-mcp-server-steps.py
+++ b/tests/e2e/features/steps/oci-faaas-mcp-server-steps.py
@@ -1,0 +1,63 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from behave import then
+
+
+@then("the response should contain a list of faaas tools available")
+def step_impl_faaas_tools_available(context):
+    response_json = context.response.json()
+    assert (
+        "content" in response_json["message"]
+    ), "Response does not contain a content key."
+    content = response_json["message"]["content"].lower()
+    assert any(
+        tool in content
+        for tool in [
+            "list_fusion_environment_families",
+            "list_fusion_environments",
+            "get_fusion_environment",
+            "get_fusion_environment_status",
+        ]
+    ), "FaaS tools could not be queried."
+
+
+@then("the response should contain a list of fusion environment families")
+def step_impl_list_families(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    # Look for family OCID prefix to be present
+    assert (
+        "ocid1.fusionenvironmentfamily" in content
+    ), "Fusion environment families not found."
+
+
+@then("the response should contain a list of fusion environments")
+def step_impl_list_environments(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    assert "ocid1.fusionenvironment" in content, "Fusion environments not found."
+
+
+@then("the response should contain the details of a fusion environment")
+def step_impl_get_environment(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    assert "ocid1.fusionenvironment" in content, "Fusion environment details not found."
+
+
+@then("the response should contain the status of a fusion environment")
+def step_impl_get_environment_status(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    # Expect to mention status and/or environment OCID
+    assert any(
+        kw in content for kw in ["status", "available", "ocid1.fusionenvironment"]
+    ), "Fusion environment status not found."

--- a/tests/e2e/features/steps/oci-identity-mcp-server-steps.py
+++ b/tests/e2e/features/steps/oci-identity-mcp-server-steps.py
@@ -1,0 +1,71 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from behave import then
+
+
+@then("the response should contain a list of identity tools available")
+def step_impl_identity_tools_available(context):
+    response_json = context.response.json()
+    assert (
+        "content" in response_json["message"]
+    ), "Response does not contain a content key."
+    content = response_json["message"]["content"].lower()
+    # Tools from Identity server we expect the model to list
+    assert any(
+        tool in content
+        for tool in [
+            "list_compartments",
+            "get_tenancy",
+            "list_availability_domains",
+            "get_current_user",
+            "list_subscribed_regions",
+        ]
+    ), "Identity tools could not be queried."
+
+
+@then("the response should contain a list of compartments")
+def step_impl_list_compartments(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    assert (
+        "ocid1.compartment" in result["message"]["content"]
+    ), "Compartments not found."
+
+
+@then("the response should contain the details of a tenancy")
+def step_impl_get_tenancy(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    assert "ocid1.tenancy" in result["message"]["content"], "Tenancy details not found."
+
+
+@then("the response should contain a list of availability domains")
+def step_impl_list_ads(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    assert (
+        "us-ashburn-ad" in result["message"]["content"].lower()
+        or "availabilitydomain" in result["message"]["content"].lower()
+        or "ad-" in result["message"]["content"].lower()
+    ), "Availability domains not found."
+
+
+@then("the response should contain the details of a user")
+def step_impl_get_user(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    assert "ocid1.user" in result["message"]["content"], "User details not found."
+
+
+@then("the response should contain a list of regions")
+def step_impl_list_regions(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    assert any(
+        kw in content for kw in ["region", "us-mock-1", "home region", "phx", "iad"]
+    ), "Subscribed regions not found."

--- a/tests/e2e/features/steps/oci-logging-mcp-server-steps.py
+++ b/tests/e2e/features/steps/oci-logging-mcp-server-steps.py
@@ -1,0 +1,59 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from behave import then
+
+
+@then("the response should contain a list of logging tools available")
+def step_impl_logging_tools_available(context):
+    response_json = context.response.json()
+    assert (
+        "content" in response_json["message"]
+    ), "Response does not contain a content key."
+    content = response_json["message"]["content"].lower()
+    assert any(
+        tool in content
+        for tool in [
+            "list_log_groups",
+            "get_log_group",
+            "list_logs",
+            "get_log",
+        ]
+    ), "Logging tools could not be queried."
+
+
+@then("the response should contain a list of log groups")
+def step_impl_list_log_groups(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    assert (
+        "ocid1.loggroup" in result["message"]["content"].lower()
+    ), "List of log groups not found."
+
+
+@then("the response should contain the details of a log group")
+def step_impl_get_log_group(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    assert (
+        "ocid1.loggroup" in result["message"]["content"].lower()
+    ), "Log group details not found."
+
+
+@then("the response should contain a list of logs")
+def step_impl_list_logs(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    assert (
+        "ocid1.log" in result["message"]["content"].lower()
+    ), "List of logs not found."
+
+
+@then("the response should contain the details of a log")
+def step_impl_get_log(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    assert "ocid1.log" in result["message"]["content"].lower(), "Log details not found."

--- a/tests/e2e/features/steps/oci-migration-mcp-server-steps.py
+++ b/tests/e2e/features/steps/oci-migration-mcp-server-steps.py
@@ -1,0 +1,37 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from behave import then
+
+
+@then("the response should contain a list of migration tools available")
+def step_impl_migration_tools_available(context):
+    response_json = context.response.json()
+    assert (
+        "content" in response_json["message"]
+    ), "Response does not contain a content key."
+    content = response_json["message"]["content"].lower()
+    assert any(
+        tool in content for tool in ["list_migrations", "get_migration"]
+    ), "Migration tools could not be queried."
+
+
+@then("the response should contain a list of migrations")
+def step_impl_list_migrations(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    assert (
+        "ocid1.migration" in result["message"]["content"].lower()
+    ), "List of migrations not found."
+
+
+@then("the response should contain the details of a migration")
+def step_impl_get_migration(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    assert (
+        "ocid1.migration" in result["message"]["content"].lower()
+    ), "Migration details not found."


### PR DESCRIPTION
# Description

Includes E2E tests and mocking for:
- Cloud guard
- Identity
- FAaaS
- Logging
- Migration

Besides those tasks, this PR also addresses a few issues:
1. There was no way to override the config file location in servers. This is _supposed_ to be a feature of the oci python sdk, but for some reason their logic only allows the OCI_CONFIG_FILE env var to override the default file location if the default file does not exist, when REALLY it should be falling back to the default location only if that env var is not present. Talked with @gebhardtr, he agrees this is an issue and approved this change. This was required because I realized my previous PR created the mock oci config, but it wasnt actually being consumed like I thought it was because the default path was being used instead. I will need to update unit tests for this change.
2. Identity client has a global endpoint that ignores HTTP/HTTPS proxy. This makes it so the normal method of supplying the proxy to the identity client to point it to our mock server doesnt work. I had to create a `sitecustomize.py` file that patches the identity client to pass in the service endpoint that points to our mock. Read more about `sitecustomize.py` files here: https://docs.python.org/3/library/site.html#module-sitecustomize
3. Data objects are sent over http with camelCase, but our data was snake_case (the pythonic way). I had to make the mock data camelCase to avoid some errors.

## Type of change

Please delete options that are not relevant.

- [x] E2E test updates

# How Has This Been Tested?

Tested locally with `behave features/<feature file>`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
