### PR TITLE
Update user agent for Tracking

### DIFF
--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/server.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/server.py
@@ -22,7 +22,7 @@ mcp = FastMCP(name=__project__)
 
 # setup user agent
 user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-USER_AGENT = f"{user_agent_name}/{__version__}"
+USER_AGENT = f"Oracle-{user_agent_name}/{__version__}"
 
 # Initialize the rotating audit logger. It will store logs at /tmp/audit.log
 initAuditLogger(logger)

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
@@ -16,7 +16,7 @@ from oracle.oci_api_mcp_server.server import mcp
 
 __version__ = importlib.metadata.version(__project__)
 user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-USER_AGENT = f"{user_agent_name}/{__version__}"
+USER_AGENT = f"Oracle-{user_agent_name}/{__version__}"
 
 
 class TestOCITools:

--- a/src/oci-cloud-guard-mcp-server/oracle/oci_cloud_guard_mcp_server/server.py
+++ b/src/oci-cloud-guard-mcp-server/oracle/oci_cloud_guard_mcp_server/server.py
@@ -31,7 +31,7 @@ def get_cloud_guard_client():
     )
 
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])

--- a/src/oci-compute-instance-agent-mcp-server/oracle/oci_compute_instance_agent_mcp_server/server.py
+++ b/src/oci-compute-instance-agent-mcp-server/oracle/oci_compute_instance_agent_mcp_server/server.py
@@ -40,7 +40,7 @@ def get_compute_instance_agent_client():
     )
 
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])

--- a/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/server.py
+++ b/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/server.py
@@ -41,7 +41,7 @@ def get_compute_client():
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])

--- a/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/tests/test_compute_tools.py
+++ b/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/tests/test_compute_tools.py
@@ -712,7 +712,7 @@ class TestGetClient:
         args, _ = mock_client.call_args
         passed_config = args[0]
         assert passed_config is config
-        expected_user_agent = f"{server.__project__.split('oracle.', 1)[1].split('-server', 1)[0]}/{server.__version__}"  # noqa
+        expected_user_agent = f"Oracle-{server.__project__.split('oracle.', 1)[1].split('-server', 1)[0]}/{server.__version__}"  # noqa
         assert passed_config.get("additional_user_agent") == expected_user_agent
         # And we returned the client instance
         assert result == mock_client.return_value

--- a/src/oci-database-mcp-server/oracle/oci_database_mcp_server/server.py
+++ b/src/oci-database-mcp-server/oracle/oci_database_mcp_server/server.py
@@ -288,7 +288,8 @@ def get_database_client(region: str = None):
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
+
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = config["security_token_file"]
     with open(token_file, "r") as f:

--- a/src/oci-faaas-mcp-server/oracle/oci_faaas_mcp_server/server.py
+++ b/src/oci-faaas-mcp-server/oracle/oci_faaas_mcp_server/server.py
@@ -36,7 +36,7 @@ def get_faaas_client():
     )
 
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = config["security_token_file"]

--- a/src/oci-identity-mcp-server/oracle/oci_identity_mcp_server/server.py
+++ b/src/oci-identity-mcp-server/oracle/oci_identity_mcp_server/server.py
@@ -40,7 +40,8 @@ def get_identity_client():
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
+
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])
     with open(token_file, "r") as f:

--- a/src/oci-logging-mcp-server/oracle/oci_logging_mcp_server/server.py
+++ b/src/oci-logging-mcp-server/oracle/oci_logging_mcp_server/server.py
@@ -30,7 +30,7 @@ from oracle.oci_logging_mcp_server.scripts import (
 )
 from pydantic import Field
 
-from . import __project__
+from . import __project__, __version__
 
 logger = Logger(__name__, level="INFO")
 
@@ -42,6 +42,8 @@ def get_logging_client():
     config = oci.config.from_file(
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
     )
+    user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])

--- a/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/server.py
+++ b/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/server.py
@@ -30,8 +30,10 @@ def get_migration_client():
     config = oci.config.from_file(
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
     )
+
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
+
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])
     token = None

--- a/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/server.py
+++ b/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/server.py
@@ -49,8 +49,9 @@ def get_monitoring_client():
     config = oci.config.from_file(
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
     )
+
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])

--- a/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/server.py
+++ b/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/server.py
@@ -35,7 +35,8 @@ def get_nlb_client():
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
+
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])
     token = None

--- a/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/tests/test_network_load_balancer_tools.py
+++ b/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/tests/test_network_load_balancer_tools.py
@@ -610,7 +610,7 @@ class TestGetClient:
         args, _ = mock_client.call_args
         passed_config = args[0]
         assert passed_config is config
-        expected_user_agent = f"{server.__project__.split('oracle.', 1)[1].split('-server', 1)[0]}/{server.__version__}"  # noqa
+        expected_user_agent = f"Oracle-{server.__project__.split('oracle.', 1)[1].split('-server', 1)[0]}/{server.__version__}"  # noqa
         assert passed_config.get("additional_user_agent") == expected_user_agent
         # And we returned the client instance
         assert result == mock_client.return_value

--- a/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/server.py
+++ b/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/server.py
@@ -37,8 +37,10 @@ def get_networking_client():
     config = oci.config.from_file(
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
     )
+
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
+
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])
     token = None

--- a/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/tests/test_networking_tools.py
+++ b/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/tests/test_networking_tools.py
@@ -604,7 +604,7 @@ class TestGetClient:
         args, _ = mock_client.call_args
         passed_config = args[0]
         assert passed_config is config
-        expected_user_agent = f"{server.__project__.split('oracle.', 1)[1].split('-server', 1)[0]}/{server.__version__}"  # noqa
+        expected_user_agent = f"Oracle-{server.__project__.split('oracle.', 1)[1].split('-server', 1)[0]}/{server.__version__}"  # noqa
         assert passed_config.get("additional_user_agent") == expected_user_agent
         # And we returned the client instance
         assert result == mock_client.return_value

--- a/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/server.py
+++ b/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/server.py
@@ -34,7 +34,7 @@ def get_object_storage_client():
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])

--- a/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/server.py
+++ b/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/server.py
@@ -30,7 +30,8 @@ def get_ocir_client():
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
     )
 
-    config["additional_user_agent"] = f"{__project__}/{__version__}"
+    user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])

--- a/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/server.py
+++ b/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/server.py
@@ -31,7 +31,7 @@ def get_search_client():
     )
 
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])

--- a/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/server.py
+++ b/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/server.py
@@ -25,7 +25,7 @@ def get_usage_client():
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    config["additional_user_agent"] = f"Oracle-{user_agent_name}/{__version__}"
 
     private_key = oci.signer.load_private_key_from_file(config["key_file"])
     token_file = os.path.expanduser(config["security_token_file"])

--- a/tests/e2e/features/environment.py
+++ b/tests/e2e/features/environment.py
@@ -28,7 +28,7 @@ try:
 except FileNotFoundError:
     raise EnvironmentError(
         print(
-            f"{config["MCP_HOST_FILE"]} could not be found. Provide one to configure the MCP servers"
+            f"{config['MCP_HOST_FILE']} could not be found. Provide one to configure the MCP servers"
         )
     )
 
@@ -46,7 +46,7 @@ def set_mcp_servers(context):
         print("Configured servers: ", ", ".join(sorted(context.mcp_servers)))
     except FileNotFoundError:
         raise EnvironmentError(
-            f"{config["MCP_HOST_FILE"]} could not be found. Provide one to configure the MCP servers"
+            f"{config['MCP_HOST_FILE']} could not be found. Provide one to configure the MCP servers"
         )
 
 


### PR DESCRIPTION
# Description

This PR updates userAgent metric to include "Oracle-" as part of it. 

Fixes # (issue)

## Type of change
- [X] Metric update

# How Has This Been Tested?
By executing live prompts in Cline and the Inspector tool, I successfully verified through Lumberjack log that the userAgent metric has been updated as 'Oracle-oci-compute-mcp/1.2.2'.
<img width="1907" height="920" alt="Screenshot 2026-01-21 at 4 00 50 PM" src="https://github.com/user-attachments/assets/b6e94b2b-6217-4b3c-839c-84d4cca72022" />



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
