### PR TITLE
Add Load balancer MCP and unit tests

### DIFF
--- a/src/oci-load-balancer-mcp-server/.gitignore
+++ b/src/oci-load-balancer-mcp-server/.gitignore
@@ -1,0 +1,59 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+.venv
+env/
+venv/
+ENV/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Testing
+.tox/
+.coverage
+.coverage.*
+htmlcov/
+.pytest_cache/
+
+# Ruff
+.ruff_cache/
+
+# Build
+*.manifest
+*.spec
+.pybuilder/
+target/
+
+# Environments
+.env
+.env.local
+.env.*.local
+
+# PyPI
+.pypirc

--- a/src/oci-load-balancer-mcp-server/CHANGELOG.md
+++ b/src/oci-load-balancer-mcp-server/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Initial project setup

--- a/src/oci-load-balancer-mcp-server/LICENSE.txt
+++ b/src/oci-load-balancer-mcp-server/LICENSE.txt
@@ -1,0 +1,35 @@
+Copyright (c) 2026 Oracle and/or its affiliates.
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any
+person obtaining a copy of this software, associated documentation and/or data
+(collectively the "Software"), free of charge and under any and all copyright
+rights in the Software, and any and all patent rights owned or freely
+licensable by each licensor hereunder covering either (i) the unmodified
+Software as contributed to or provided by such licensor, or (ii) the Larger
+Works (as defined below), to deal in both
+
+(a) the Software, and
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+one is included with the Software (each a "Larger Work" to which the Software
+is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create
+derivative works of, display, perform, and distribute the Software and make,
+use, sell, offer for sale, import, export, have made, and have sold the
+Software and the Larger Work(s), and to sublicense the foregoing rights on
+either these or other terms.
+
+This license is subject to the following condition:
+The above copyright notice and either this complete permission notice or at
+a minimum a reference to the UPL must be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/oci-load-balancer-mcp-server/README.md
+++ b/src/oci-load-balancer-mcp-server/README.md
@@ -1,0 +1,3 @@
+# OCI Load Balancer MCP Server
+
+This server provides tools for interacting with Oracle Cloud Infrastructure (OCI) Load Balancer service.

--- a/src/oci-load-balancer-mcp-server/oracle/__init__.py
+++ b/src/oci-load-balancer-mcp-server/oracle/__init__.py
@@ -1,0 +1,5 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""

--- a/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/__init__.py
+++ b/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/__init__.py
@@ -1,0 +1,8 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+__project__ = "oracle.oci-load-balancer-mcp-server"
+__version__ = "0.0.0"

--- a/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/models.py
+++ b/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/models.py
@@ -1,0 +1,1253 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional, Union
+
+import oci
+from pydantic import BaseModel, Field
+
+# Utilities
+
+
+def _oci_to_dict(obj: Any) -> Optional[Dict[str, Any]]:
+    """Best-effort conversion of OCI SDK model objects to plain dicts."""
+    if obj is None:
+        return None
+    try:
+        from oci.util import to_dict as oci_to_dict
+
+        return oci_to_dict(obj)  # handles nested OCI models
+    except Exception:
+        pass
+    if isinstance(obj, dict):
+        return obj
+    if hasattr(obj, "__dict__"):
+        return {k: v for k, v in obj.__dict__.items() if not k.startswith("_")}
+    return None
+
+
+# Sub-objects of LoadBalancer (SDK: oci.load_balancer.models)
+
+
+class ReservedIP(BaseModel):
+    """Reserved IP details used by load balancer IP addresses."""
+
+    id: Optional[str] = Field(
+        None,
+        description=(
+            "OCID of the Reserved/Public IP created with VCN. When set, the load balancer "
+            "is configured to listen on this IP."
+        ),
+    )
+
+
+class IpAddress(BaseModel):
+    """A load balancer IP address entry."""
+
+    ip_address: Optional[str] = Field(
+        None, description="An IP address. Example: 192.168.0.3"
+    )
+    is_public: Optional[bool] = Field(
+        None,
+        description=(
+            "Whether the IP address is public (internet-routable) or private (VCN-local)."
+        ),
+    )
+    reserved_ip: Optional[ReservedIP] = Field(
+        None, description="Reserved IP metadata if this address is reserved."
+    )
+
+
+class ShapeDetails(BaseModel):
+    """Flexible shape bandwidth configuration for the load balancer."""
+
+    minimum_bandwidth_in_mbps: Optional[int] = Field(
+        None,
+        description=(
+            "Guaranteed pre-provisioned bandwidth (ingress + egress), in Mbps."
+        ),
+    )
+    maximum_bandwidth_in_mbps: Optional[int] = Field(
+        None,
+        description=(
+            "Maximum bandwidth (ingress + egress) that can be achieved, in Mbps."
+        ),
+    )
+
+
+class ConnectionConfiguration(BaseModel):
+    """Connection settings between client and backend servers."""
+
+    idle_timeout: Optional[int] = Field(
+        None,
+        description=(
+            "Maximum idle time in seconds allowed between successive send/receive operations."
+        ),
+    )
+    backend_tcp_proxy_protocol_version: Optional[int] = Field(
+        None, description="Backend TCP Proxy Protocol version (1 or 2)."
+    )
+    backend_tcp_proxy_protocol_options: Optional[
+        List[Literal["PP2_TYPE_AUTHORITY"]]
+    ] = Field(None, description="PPv2 options that can be enabled on TCP listeners.")
+
+
+class SSLConfiguration(BaseModel):
+    """SSL/TLS negotiation settings for listeners and backend sets."""
+
+    verify_depth: Optional[int] = Field(
+        None, description="Maximum depth for peer certificate chain verification."
+    )
+    verify_peer_certificate: Optional[bool] = Field(
+        None, description="Whether peer certificates should be verified."
+    )
+    has_session_resumption: Optional[bool] = Field(
+        None,
+        description=(
+            "Whether to resume TLS sessions to improve performance (lower security)."
+        ),
+    )
+    trusted_certificate_authority_ids: Optional[List[str]] = Field(
+        None,
+        description="OCI Certificates CA/Bundle OCIDs the load balancer should trust.",
+    )
+    certificate_ids: Optional[List[str]] = Field(
+        None,
+        description=(
+            "OCI Certificates certificate OCIDs (currently a single ID supported)."
+        ),
+    )
+    certificate_name: Optional[str] = Field(
+        None,
+        description="Friendly name of the certificate bundle bound to this config.",
+    )
+    server_order_preference: Optional[
+        Literal["ENABLED", "DISABLED", "UNKNOWN_ENUM_VALUE"]
+    ] = Field(  # noqa: E501
+        None, description="Prefer server ciphers over client ciphers when enabled."
+    )
+    cipher_suite_name: Optional[str] = Field(
+        None, description="The cipher suite name for HTTPS/SSL connections."
+    )
+    protocols: Optional[List[str]] = Field(
+        None,
+        description=(
+            "Supported SSL protocols for HTTPS/SSL connections (e.g., TLSv1.2, TLSv1.3)."
+        ),
+    )
+
+
+class Hostname(BaseModel):
+    """A hostname resource associated with a load balancer for one or more listeners."""
+
+    name: Optional[str] = Field(
+        None, description="Unique, friendly hostname resource name."
+    )
+    hostname: Optional[str] = Field(
+        None, description="Virtual hostname (e.g., app.example.com)."
+    )
+
+
+class SSLCipherSuite(BaseModel):
+    """A named set of SSL ciphers used for HTTPS/SSL connections."""
+
+    name: Optional[str] = Field(
+        None, description="Friendly name of the SSL cipher suite."
+    )
+    ciphers: Optional[List[str]] = Field(
+        None, description="List of SSL cipher names in the suite."
+    )
+
+
+class Certificate(BaseModel):
+    """Certificate bundle configuration (public and CA certificates)."""
+
+    certificate_name: Optional[str] = Field(
+        None, description="Friendly name of the certificate bundle."
+    )
+    public_certificate: Optional[str] = Field(
+        None, description="Public certificate in PEM format."
+    )
+    ca_certificate: Optional[str] = Field(
+        None, description="CA or intermediate certificate in PEM format."
+    )
+
+
+class Backend(BaseModel):
+    """Backend server configuration within a backend set."""
+
+    name: Optional[str] = Field(
+        None,
+        description=(
+            "Read-only composite key of backend (IP:port) within the backend set."
+        ),
+    )
+    ip_address: Optional[str] = Field(None, description="Backend server IP address.")
+    port: Optional[int] = Field(
+        None, description="Communication port for the backend server."
+    )
+    weight: Optional[int] = Field(
+        None,
+        description=(
+            "Load balancing weight; higher values receive more new connections."
+        ),
+    )
+    max_connections: Optional[int] = Field(
+        None,
+        description=(
+            "Maximum simultaneous connections allowed to this backend (unlimited if unset)."
+        ),
+    )
+    drain: Optional[bool] = Field(
+        None, description="Whether the backend is in drain mode (no new connections)."
+    )
+    backup: Optional[bool] = Field(
+        None,
+        description=(
+            "Treat server as backup; receives traffic only if primary backends are unhealthy."
+        ),
+    )
+    offline: Optional[bool] = Field(
+        None, description="Whether the backend is offline (no incoming traffic)."
+    )
+
+
+class HealthChecker(BaseModel):
+    """Health check policy configuration for backends."""
+
+    protocol: Optional[str] = Field(
+        None, description="Protocol to use for health checks (HTTP or TCP)."
+    )
+    url_path: Optional[str] = Field(
+        None, description="Path for HTTP health checks (e.g., /healthcheck)."
+    )
+    port: Optional[int] = Field(
+        None,
+        description=(
+            "Backend port to use for the health check; falls back to Backend.port if unset."
+        ),
+    )
+    return_code: Optional[int] = Field(
+        None, description="Expected status code from a healthy backend."
+    )
+    retries: Optional[int] = Field(
+        None,
+        description=(
+            "Number of retries before marking backend unhealthy or when recovering to healthy."
+        ),
+    )
+    timeout_in_millis: Optional[int] = Field(
+        None, description="Maximum wait time for a health check reply (ms)."
+    )
+    interval_in_millis: Optional[int] = Field(
+        None, description="Interval between health checks (ms)."
+    )
+    response_body_regex: Optional[str] = Field(
+        None, description="Regex to match against response body for health checks."
+    )
+    is_force_plain_text: Optional[bool] = Field(
+        None,
+        description=(
+            "Force plaintext health check even if backend set uses SSL; otherwise follow SSL config."
+        ),
+    )
+
+
+class SessionPersistenceConfigurationDetails(BaseModel):
+    """Application cookie based session persistence configuration."""
+
+    cookie_name: Optional[str] = Field(
+        None,
+        description="Cookie name to detect a session initiated by the backend server.",
+    )
+    disable_fallback: Optional[bool] = Field(
+        None,
+        description=(
+            "Prevent directing persistent-session clients to another backend if original is unavailable."
+        ),
+    )
+
+
+class LBCookieSessionPersistenceConfigurationDetails(BaseModel):
+    """LB cookie based session persistence configuration (stickiness)."""
+
+    cookie_name: Optional[str] = Field(
+        None, description="Name of cookie inserted by the load balancer."
+    )
+    disable_fallback: Optional[bool] = Field(
+        None,
+        description="Prevent fallback to a different backend if original is unavailable.",
+    )
+    domain: Optional[str] = Field(None, description="Cookie domain attribute value.")
+    path: Optional[str] = Field(None, description="Cookie path attribute value.")
+    max_age_in_seconds: Optional[int] = Field(
+        None, description="Cookie Max-Age attribute (seconds)."
+    )
+    is_secure: Optional[bool] = Field(
+        None, description="Whether to set the Secure attribute on the cookie."
+    )
+    is_http_only: Optional[bool] = Field(
+        None, description="Whether to set the HttpOnly attribute on the cookie."
+    )
+
+
+class BackendSet(BaseModel):
+    """Configuration of a load balancer backend set."""
+
+    name: Optional[str] = Field(None, description="Friendly, unique backend set name.")
+    policy: Optional[str] = Field(
+        None, description="Load balancer policy (e.g., LEAST_CONNECTIONS)."
+    )
+    backends: Optional[List[Backend]] = Field(
+        None, description="Backends in this backend set."
+    )
+    backend_max_connections: Optional[int] = Field(
+        None,
+        description=(
+            "Max simultaneous connections to any backend unless overridden at backend level."
+        ),
+    )
+    health_checker: Optional[HealthChecker] = Field(
+        None, description="Health check policy for this backend set."
+    )
+    ssl_configuration: Optional[SSLConfiguration] = Field(
+        None, description="SSL configuration for this backend set."
+    )
+    session_persistence_configuration: Optional[
+        SessionPersistenceConfigurationDetails
+    ] = Field(None, description="Application cookie stickiness configuration.")
+    lb_cookie_session_persistence_configuration: Optional[
+        LBCookieSessionPersistenceConfigurationDetails
+    ] = Field(None, description="LB cookie stickiness configuration.")
+
+
+class PathMatchType(BaseModel):
+    """The type of matching to apply to incoming URIs for path routes."""
+
+    match_type: Optional[
+        Literal[
+            "EXACT_MATCH",
+            "FORCE_LONGEST_PREFIX_MATCH",
+            "PREFIX_MATCH",
+            "SUFFIX_MATCH",
+            "UNKNOWN_ENUM_VALUE",
+        ]
+    ] = Field(None, description="How to compare the path against the incoming URI.")
+
+
+class PathRoute(BaseModel):
+    """A path route rule mapping request path to a backend set."""
+
+    path: Optional[str] = Field(
+        None,
+        description=(
+            "Path string to match against the incoming URI path (case-insensitive, no wildcards or regex)."
+        ),
+    )
+    path_match_type: Optional[PathMatchType] = Field(
+        None, description="The type of path matching to apply."
+    )
+    backend_set_name: Optional[str] = Field(
+        None,
+        description=(
+            "Target backend set name for requests that match the specified path."
+        ),
+    )
+
+
+class PathRouteSet(BaseModel):
+    """A named set of path route rules for a listener (deprecated in favor of routing policies)."""
+
+    name: Optional[str] = Field(
+        None, description="Unique name for this set of path route rules."
+    )
+    path_routes: Optional[List[PathRoute]] = Field(
+        None, description="Path route rules."
+    )
+
+
+# Routing policy (listener-level advanced request routing)
+
+
+class ForwardToBackendSet(BaseModel):
+    """Routing action to forward requests to a backend set."""
+
+    name: Literal["FORWARD_TO_BACKENDSET"] = Field(
+        "FORWARD_TO_BACKENDSET", description="Routing action discriminator."
+    )
+    backend_set_name: Optional[str] = Field(
+        None, description="Name of the backend set to forward traffic to."
+    )
+
+
+class Action(BaseModel):
+    """Generic routing action. Unknown action payload is preserved in details."""
+
+    name: Optional[str] = Field(
+        None, description="Routing action discriminator (e.g., FORWARD_TO_BACKENDSET)."
+    )
+    details: Optional[Dict[str, Any]] = Field(
+        None, description="Raw action fields when not mapped to a typed model."
+    )
+
+
+RoutingAction = Union[ForwardToBackendSet, Action]
+
+
+class RoutingRule(BaseModel):
+    """A routing rule evaluating condition expression and applying actions."""
+
+    name: Optional[str] = Field(
+        None, description="Unique name for the routing policy rule."
+    )
+    condition: Optional[str] = Field(
+        None,
+        description=(
+            "Condition expression evaluated against the incoming HTTP request."
+        ),
+    )
+    actions: Optional[List[RoutingAction]] = Field(
+        None, description="Actions applied when the condition evaluates to true."
+    )
+
+
+class RoutingPolicy(BaseModel):
+    """Named ordered list of routing rules applied to a listener."""
+
+    name: Optional[str] = Field(
+        None, description="Unique name for this list of routing rules."
+    )
+    condition_language_version: Optional[Literal["V1", "UNKNOWN_ENUM_VALUE"]] = Field(
+        None, description="Version of the routing condition language."
+    )
+    rules: Optional[List[RoutingRule]] = Field(
+        None, description="Ordered list of routing rules."
+    )
+
+
+# Listener and rule sets
+
+
+class Listener(BaseModel):
+    """Listener configuration."""
+
+    name: Optional[str] = Field(None, description="Friendly, unique listener name.")
+    default_backend_set_name: Optional[str] = Field(
+        None, description="Name of the associated backend set."
+    )
+    port: Optional[int] = Field(
+        None, description="Communication port for the listener."
+    )
+    protocol: Optional[str] = Field(
+        None,
+        description=(
+            "Protocol on which the listener accepts connections (HTTP, HTTP2, TCP, GRPC)."
+        ),
+    )
+    hostname_names: Optional[List[str]] = Field(
+        None, description="Associated hostname resource names."
+    )
+    path_route_set_name: Optional[str] = Field(
+        None,
+        description="Deprecated. Name of the PathRouteSet applied to this listener.",
+    )
+    ssl_configuration: Optional[SSLConfiguration] = Field(
+        None, description="SSL configuration of the listener."
+    )
+    connection_configuration: Optional[ConnectionConfiguration] = Field(
+        None, description="Connection configuration between client and backends."
+    )
+    rule_set_names: Optional[List[str]] = Field(
+        None, description="Names of RuleSets applied to this listener."
+    )
+    routing_policy_name: Optional[str] = Field(
+        None, description="Name of the RoutingPolicy applied to this listener."
+    )
+
+
+class SimpleRule(BaseModel):
+    """Generic listener Rule (for RuleSet). Preserves action and raw fields."""
+
+    action: Optional[str] = Field(
+        None, description="Rule action (e.g., ADD_HTTP_REQUEST_HEADER, REDIRECT, etc.)."
+    )
+    fields: Optional[Dict[str, Any]] = Field(
+        None, description="Other rule fields serialized from the SDK model."
+    )
+
+
+class RuleSet(BaseModel):
+    """A named set of listener rules (header manipulation, access control, etc.)."""
+
+    name: Optional[str] = Field(None, description="Unique name for this set of rules.")
+    items: Optional[List[SimpleRule]] = Field(
+        None, description="Rules composed in this rule set."
+    )
+
+
+# Response (generic oci.response.Response mapping)
+
+
+class Request(BaseModel):
+    method: Optional[str] = Field(None, description="HTTP method")
+    url: Optional[str] = Field(None, description="Request URL")
+    query_params: Optional[Dict[str, Any]] = Field(None, description="Query parameters")
+    header_params: Optional[Dict[str, Any]] = Field(None, description="Request headers")
+    body: Optional[Any] = Field(None, description="Request body")
+    response_type: Optional[str] = Field(None, description="Expected response type")
+    enforce_content_headers: Optional[bool] = Field(
+        None, description="Whether content headers enforced for PUT/POST when absent"
+    )
+
+
+class Response(BaseModel):
+    status: Optional[int] = Field(None, description="HTTP status code")
+    headers: Optional[Dict[str, Any]] = Field(None, description="Response headers")
+    data: Optional[Any] = Field(None, description="Response data (mapped)")
+    request: Optional[Request] = Field(None, description="Original request")
+    next_page: Optional[str] = Field(None, description="opc-next-page header value")
+    request_id: Optional[str] = Field(None, description="opc-request-id header value")
+    has_next_page: Optional[bool] = Field(
+        None, description="Whether pagination continues"
+    )
+
+
+def _map_headers(headers) -> Optional[Dict[str, Any]]:
+    if headers is None:
+        return None
+    try:
+        return dict(headers)
+    except Exception:
+        try:
+            return {k: v for k, v in headers.items()}
+        except Exception:
+            return _oci_to_dict(headers) or None
+
+
+def _map_response_data(data: Any) -> Any:
+    # handle sequence
+    if isinstance(data, (list, tuple)):
+        return [_map_response_data(x) for x in data]
+    # passthrough simple
+    if data is None or isinstance(data, (str, int, float, bool, dict)):
+        return data
+    # map known LB models
+    try:
+        if isinstance(data, oci.load_balancer.models.LoadBalancer):
+            return map_load_balancer(data)  # type: ignore[name-defined]
+        if isinstance(data, oci.load_balancer.models.BackendSet):
+            return map_backend_set(data)  # type: ignore[name-defined]
+        if isinstance(data, oci.load_balancer.models.Certificate):
+            return map_certificate(data)  # type: ignore[name-defined]
+        if isinstance(data, oci.load_balancer.models.SSLCipherSuite):
+            return map_ssl_cipher_suite(data)  # type: ignore[name-defined]
+
+        if isinstance(data, oci.load_balancer.models.Hostname):
+            return map_hostname(data)  # type: ignore[name-defined]
+        if isinstance(data, oci.load_balancer.models.RuleSet):
+            return map_rule_set(data)  # type: ignore[name-defined]
+        if isinstance(data, oci.load_balancer.models.RoutingPolicy):
+            return map_routing_policy(data)  # type: ignore[name-defined]
+        if isinstance(data, oci.load_balancer.models.LoadBalancerHealth):
+            return map_load_balancer_health(data)  # type: ignore[name-defined]
+        if isinstance(data, oci.load_balancer.models.BackendSetHealth):
+            return map_backend_set_health(data)  # type: ignore[name-defined]
+        if isinstance(data, oci.load_balancer.models.BackendHealth):
+            return map_backend_health(data)  # type: ignore[name-defined]
+        if isinstance(data, oci.load_balancer.models.WorkRequest):
+            return map_work_request(data)  # type: ignore[name-defined]
+    except Exception:
+        pass
+    # fallback to dict
+    coerced = _oci_to_dict(data)
+    return coerced if coerced is not None else data
+
+
+def map_request(req) -> Optional[Request]:
+    if not req:
+        return None
+    return Request(
+        method=getattr(req, "method", None),
+        url=getattr(req, "url", None),
+        query_params=getattr(req, "query_params", None),
+        header_params=getattr(req, "header_params", None),
+        body=getattr(req, "body", None),
+        response_type=getattr(req, "response_type", None),
+        enforce_content_headers=getattr(req, "enforce_content_headers", None),
+    )
+
+
+def map_response(resp: oci.response.Response) -> Optional[Response]:
+    if resp is None:
+        return None
+    headers = _map_headers(getattr(resp, "headers", None))
+    next_page = getattr(resp, "next_page", None) or (headers or {}).get("opc-next-page")
+    request_id = getattr(resp, "request_id", None) or (headers or {}).get(
+        "opc-request-id"
+    )
+    return Response(
+        status=getattr(resp, "status", None),
+        headers=headers,
+        data=_map_response_data(getattr(resp, "data", None)),
+        request=map_request(getattr(resp, "request", None)),
+        next_page=next_page,
+        request_id=request_id,
+        has_next_page=(next_page is not None),
+    )
+
+
+# Top-level LoadBalancer
+
+
+class LoadBalancer(BaseModel):
+    """
+    Pydantic representation of oci.load_balancer.models.LoadBalancer and sub-objects.
+    """
+
+    id: Optional[str] = Field(None, description="OCID of the load balancer.")
+    compartment_id: Optional[str] = Field(
+        None, description="OCID of the compartment containing the load balancer."
+    )
+    display_name: Optional[str] = Field(
+        None, description="User-friendly name; does not need to be unique."
+    )
+    lifecycle_state: Optional[
+        Literal[
+            "CREATING",
+            "FAILED",
+            "ACTIVE",
+            "DELETING",
+            "DELETED",
+            "UNKNOWN_ENUM_VALUE",
+        ]
+    ] = Field(None, description="Current lifecycle state of the load balancer.")
+    time_created: Optional[datetime] = Field(
+        None, description="RFC3339 timestamp when the load balancer was created."
+    )
+
+    ip_addresses: Optional[List[IpAddress]] = Field(
+        None, description="Array of IP addresses assigned to the load balancer."
+    )
+
+    shape_name: Optional[str] = Field(
+        None,
+        description=(
+            "Shape template determining total pre-provisioned bandwidth (ingress + egress)."
+        ),
+    )
+    shape_details: Optional[ShapeDetails] = Field(
+        None, description="Flexible shape bandwidth configuration."
+    )
+
+    is_private: Optional[bool] = Field(
+        None,
+        description=(
+            "Whether the load balancer is assigned a VCN-local (private) IP address."
+        ),
+    )
+    is_delete_protection_enabled: Optional[bool] = Field(
+        None, description="Whether delete protection is enabled."
+    )
+    is_request_id_enabled: Optional[bool] = Field(
+        None,
+        description=(
+            "Whether to inject a unique request id header for HTTP listeners and echo on responses."
+        ),
+    )
+    request_id_header: Optional[str] = Field(
+        None,
+        description=(
+            "Header name used for the unique request id when Request Id feature is enabled."
+        ),
+    )
+
+    subnet_ids: Optional[List[str]] = Field(None, description="Array of subnet OCIDs.")
+    network_security_group_ids: Optional[List[str]] = Field(
+        None, description="Array of NSG OCIDs associated with this load balancer."
+    )
+
+    listeners: Optional[Dict[str, Listener]] = Field(
+        None, description="Listeners keyed by name."
+    )
+    hostnames: Optional[Dict[str, Hostname]] = Field(
+        None, description="Hostnames keyed by name."
+    )
+    ssl_cipher_suites: Optional[Dict[str, SSLCipherSuite]] = Field(
+        None, description="SSL cipher suites keyed by name."
+    )
+    certificates: Optional[Dict[str, Certificate]] = Field(
+        None, description="Certificate bundles keyed by name."
+    )
+    backend_sets: Optional[Dict[str, BackendSet]] = Field(
+        None, description="Backend sets keyed by name."
+    )
+    path_route_sets: Optional[Dict[str, PathRouteSet]] = Field(
+        None, description="Path route sets keyed by name (deprecated)."
+    )
+
+    freeform_tags: Optional[Dict[str, str]] = Field(
+        None, description="Free-form tags for this resource."
+    )
+    defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
+        None, description="Defined tags for this resource (scoped to namespaces)."
+    )
+    security_attributes: Optional[Dict[str, Dict[str, Any]]] = Field(
+        None,
+        description=(
+            "Extended defined tags for ZPR for this resource (scoped to namespaces)."
+        ),
+    )
+    system_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
+        None,
+        description=(
+            "System tags (scoped to namespaces), visible to users but only created by the system."
+        ),
+    )
+
+    rule_sets: Optional[Dict[str, RuleSet]] = Field(
+        None, description="Rule sets keyed by name."
+    )
+    routing_policies: Optional[Dict[str, RoutingPolicy]] = Field(
+        None, description="Routing policies keyed by name."
+    )
+
+    ip_mode: Optional[Literal["IPV4", "IPV6", "UNKNOWN_ENUM_VALUE"]] = Field(
+        None, description="Whether the load balancer has an IPv4 or IPv6 IP address."
+    )
+
+
+# Mapping functions from OCI SDK -> Pydantic models
+
+
+def map_reserved_ip(obj) -> Optional[ReservedIP]:
+    if not obj:
+        return None
+    return ReservedIP(id=getattr(obj, "id", None))
+
+
+def map_ip_address(obj) -> Optional[IpAddress]:
+    if not obj:
+        return None
+    return IpAddress(
+        ip_address=getattr(obj, "ip_address", None),
+        is_public=getattr(obj, "is_public", None),
+        reserved_ip=map_reserved_ip(getattr(obj, "reserved_ip", None)),
+    )
+
+
+def map_shape_details(obj) -> Optional[ShapeDetails]:
+    if not obj:
+        return None
+    return ShapeDetails(
+        minimum_bandwidth_in_mbps=getattr(obj, "minimum_bandwidth_in_mbps", None),
+        maximum_bandwidth_in_mbps=getattr(obj, "maximum_bandwidth_in_mbps", None),
+    )
+
+
+def map_connection_configuration(obj) -> Optional[ConnectionConfiguration]:
+    if not obj:
+        return None
+    return ConnectionConfiguration(
+        idle_timeout=getattr(obj, "idle_timeout", None),
+        backend_tcp_proxy_protocol_version=getattr(
+            obj, "backend_tcp_proxy_protocol_version", None
+        ),
+        backend_tcp_proxy_protocol_options=getattr(
+            obj, "backend_tcp_proxy_protocol_options", None
+        ),
+    )
+
+
+def map_ssl_configuration(obj) -> Optional[SSLConfiguration]:
+    if not obj:
+        return None
+    return SSLConfiguration(
+        verify_depth=getattr(obj, "verify_depth", None),
+        verify_peer_certificate=getattr(obj, "verify_peer_certificate", None),
+        has_session_resumption=getattr(obj, "has_session_resumption", None),
+        trusted_certificate_authority_ids=getattr(
+            obj, "trusted_certificate_authority_ids", None
+        ),
+        certificate_ids=getattr(obj, "certificate_ids", None),
+        certificate_name=getattr(obj, "certificate_name", None),
+        server_order_preference=getattr(obj, "server_order_preference", None),
+        cipher_suite_name=getattr(obj, "cipher_suite_name", None),
+        protocols=getattr(obj, "protocols", None),
+    )
+
+
+def map_hostname(obj) -> Optional[Hostname]:
+    if not obj:
+        return None
+    return Hostname(
+        name=getattr(obj, "name", None), hostname=getattr(obj, "hostname", None)
+    )
+
+
+def map_ssl_cipher_suite(obj) -> Optional[SSLCipherSuite]:
+    if not obj:
+        return None
+    return SSLCipherSuite(
+        name=getattr(obj, "name", None), ciphers=getattr(obj, "ciphers", None)
+    )
+
+
+def map_certificate(obj) -> Optional[Certificate]:
+    if not obj:
+        return None
+    return Certificate(
+        certificate_name=getattr(obj, "certificate_name", None),
+        public_certificate=getattr(obj, "public_certificate", None),
+        ca_certificate=getattr(obj, "ca_certificate", None),
+    )
+
+
+def map_backend(obj) -> Optional[Backend]:
+    if not obj:
+        return None
+    return Backend(
+        name=getattr(obj, "name", None),
+        ip_address=getattr(obj, "ip_address", None),
+        port=getattr(obj, "port", None),
+        weight=getattr(obj, "weight", None),
+        max_connections=getattr(obj, "max_connections", None),
+        drain=getattr(obj, "drain", None),
+        backup=getattr(obj, "backup", None),
+        offline=getattr(obj, "offline", None),
+    )
+
+
+def map_health_checker(obj) -> Optional[HealthChecker]:
+    if not obj:
+        return None
+    return HealthChecker(
+        protocol=getattr(obj, "protocol", None),
+        url_path=getattr(obj, "url_path", None),
+        port=getattr(obj, "port", None),
+        return_code=getattr(obj, "return_code", None),
+        retries=getattr(obj, "retries", None),
+        timeout_in_millis=getattr(obj, "timeout_in_millis", None),
+        interval_in_millis=getattr(obj, "interval_in_millis", None),
+        response_body_regex=getattr(obj, "response_body_regex", None),
+        is_force_plain_text=getattr(obj, "is_force_plain_text", None),
+    )
+
+
+def map_session_persistence_configuration_details(
+    obj,
+) -> Optional[SessionPersistenceConfigurationDetails]:
+    if not obj:
+        return None
+    return SessionPersistenceConfigurationDetails(
+        cookie_name=getattr(obj, "cookie_name", None),
+        disable_fallback=getattr(obj, "disable_fallback", None),
+    )
+
+
+def map_lb_cookie_session_persistence_configuration_details(
+    obj,
+) -> Optional[LBCookieSessionPersistenceConfigurationDetails]:
+    if not obj:
+        return None
+    return LBCookieSessionPersistenceConfigurationDetails(
+        cookie_name=getattr(obj, "cookie_name", None),
+        disable_fallback=getattr(obj, "disable_fallback", None),
+        domain=getattr(obj, "domain", None),
+        path=getattr(obj, "path", None),
+        max_age_in_seconds=getattr(obj, "max_age_in_seconds", None),
+        is_secure=getattr(obj, "is_secure", None),
+        is_http_only=getattr(obj, "is_http_only", None),
+    )
+
+
+def map_backend_set(obj) -> Optional[BackendSet]:
+    if not obj:
+        return None
+    backends = (
+        [map_backend(b) for b in getattr(obj, "backends", [])]
+        if getattr(obj, "backends", None)
+        else None
+    )
+    return BackendSet(
+        name=getattr(obj, "name", None),
+        policy=getattr(obj, "policy", None),
+        backends=backends,
+        backend_max_connections=getattr(obj, "backend_max_connections", None),
+        health_checker=map_health_checker(getattr(obj, "health_checker", None)),
+        ssl_configuration=map_ssl_configuration(
+            getattr(obj, "ssl_configuration", None)
+        ),
+        session_persistence_configuration=map_session_persistence_configuration_details(
+            getattr(obj, "session_persistence_configuration", None)
+        ),
+        lb_cookie_session_persistence_configuration=map_lb_cookie_session_persistence_configuration_details(
+            getattr(obj, "lb_cookie_session_persistence_configuration", None)
+        ),
+    )
+
+
+def map_path_match_type(obj) -> Optional[PathMatchType]:
+    if not obj:
+        return None
+    return PathMatchType(match_type=getattr(obj, "match_type", None))
+
+
+def map_path_route(obj) -> Optional[PathRoute]:
+    if not obj:
+        return None
+    return PathRoute(
+        path=getattr(obj, "path", None),
+        path_match_type=map_path_match_type(getattr(obj, "path_match_type", None)),
+        backend_set_name=getattr(obj, "backend_set_name", None),
+    )
+
+
+def map_path_route_set(obj) -> Optional[PathRouteSet]:
+    if not obj:
+        return None
+    routes = (
+        [map_path_route(x) for x in getattr(obj, "path_routes", [])]
+        if getattr(obj, "path_routes", None)
+        else None
+    )
+    return PathRouteSet(name=getattr(obj, "name", None), path_routes=routes)
+
+
+def map_action(obj) -> RoutingAction:
+    if not obj:
+        return Action(name=None, details=None)
+    name = getattr(obj, "name", None) or getattr(obj, "action", None)
+    if name == "FORWARD_TO_BACKENDSET":
+        return ForwardToBackendSet(
+            backend_set_name=getattr(obj, "backend_set_name", None)
+        )
+    # Fallback: preserve raw fields
+    data = _oci_to_dict(obj) or {}
+    data.pop("name", None)
+    data.pop("action", None)
+    return Action(name=name, details=data or None)
+
+
+def map_routing_rule(obj) -> Optional[RoutingRule]:
+    if not obj:
+        return None
+    actions = (
+        [map_action(a) for a in getattr(obj, "actions", [])]
+        if getattr(obj, "actions", None)
+        else None
+    )
+    return RoutingRule(
+        name=getattr(obj, "name", None),
+        condition=getattr(obj, "condition", None),
+        actions=actions,
+    )
+
+
+def map_routing_policy(obj) -> Optional[RoutingPolicy]:
+    if not obj:
+        return None
+    rules = (
+        [map_routing_rule(r) for r in getattr(obj, "rules", [])]
+        if getattr(obj, "rules", None)
+        else None
+    )
+    return RoutingPolicy(
+        name=getattr(obj, "name", None),
+        condition_language_version=getattr(obj, "condition_language_version", None),
+        rules=rules,
+    )
+
+
+def map_listener(obj) -> Optional[Listener]:
+    if not obj:
+        return None
+    return Listener(
+        name=getattr(obj, "name", None),
+        default_backend_set_name=getattr(obj, "default_backend_set_name", None),
+        port=getattr(obj, "port", None),
+        protocol=getattr(obj, "protocol", None),
+        hostname_names=getattr(obj, "hostname_names", None),
+        path_route_set_name=getattr(obj, "path_route_set_name", None),
+        ssl_configuration=map_ssl_configuration(
+            getattr(obj, "ssl_configuration", None)
+        ),
+        connection_configuration=map_connection_configuration(
+            getattr(obj, "connection_configuration", None)
+        ),
+        rule_set_names=getattr(obj, "rule_set_names", None),
+        routing_policy_name=getattr(obj, "routing_policy_name", None),
+    )
+
+
+def map_simple_rule(obj) -> Optional[SimpleRule]:
+    if not obj:
+        return None
+    action = getattr(obj, "action", None)
+    raw = _oci_to_dict(obj) or {}
+    if "action" in raw:
+        raw.pop("action", None)
+    return SimpleRule(action=action, fields=raw or None)
+
+
+def map_rule_set(obj) -> Optional[RuleSet]:
+    if not obj:
+        return None
+    items = (
+        [map_simple_rule(x) for x in getattr(obj, "items", [])]
+        if getattr(obj, "items", None)
+        else None
+    )
+    return RuleSet(name=getattr(obj, "name", None), items=items)
+
+
+def map_load_balancer(obj: oci.load_balancer.models.LoadBalancer) -> LoadBalancer:
+    """Map OCI LoadBalancer SDK model (and nested types) to Pydantic model."""
+    ip_addresses = (
+        [map_ip_address(ip) for ip in getattr(obj, "ip_addresses", [])]
+        if getattr(obj, "ip_addresses", None)
+        else None
+    )
+    listeners = (
+        {k: map_listener(v) for k, v in getattr(obj, "listeners", {}).items()}
+        if getattr(obj, "listeners", None)
+        else None
+    )
+    hostnames = (
+        {k: map_hostname(v) for k, v in getattr(obj, "hostnames", {}).items()}
+        if getattr(obj, "hostnames", None)
+        else None
+    )
+    ssl_cipher_suites = (
+        {
+            k: map_ssl_cipher_suite(v)
+            for k, v in getattr(obj, "ssl_cipher_suites", {}).items()
+        }
+        if getattr(obj, "ssl_cipher_suites", None)
+        else None
+    )
+    certificates = (
+        {k: map_certificate(v) for k, v in getattr(obj, "certificates", {}).items()}
+        if getattr(obj, "certificates", None)
+        else None
+    )
+    backend_sets = (
+        {k: map_backend_set(v) for k, v in getattr(obj, "backend_sets", {}).items()}
+        if getattr(obj, "backend_sets", None)
+        else None
+    )
+    path_route_sets = (
+        {
+            k: map_path_route_set(v)
+            for k, v in getattr(obj, "path_route_sets", {}).items()
+        }
+        if getattr(obj, "path_route_sets", None)
+        else None
+    )
+    rule_sets = (
+        {k: map_rule_set(v) for k, v in getattr(obj, "rule_sets", {}).items()}
+        if getattr(obj, "rule_sets", None)
+        else None
+    )
+    routing_policies = (
+        {
+            k: map_routing_policy(v)
+            for k, v in getattr(obj, "routing_policies", {}).items()
+        }
+        if getattr(obj, "routing_policies", None)
+        else None
+    )
+
+    return LoadBalancer(
+        id=getattr(obj, "id", None),
+        compartment_id=getattr(obj, "compartment_id", None),
+        display_name=getattr(obj, "display_name", None),
+        lifecycle_state=getattr(obj, "lifecycle_state", None),
+        time_created=getattr(obj, "time_created", None),
+        ip_addresses=ip_addresses,
+        shape_name=getattr(obj, "shape_name", None),
+        shape_details=map_shape_details(getattr(obj, "shape_details", None)),
+        is_private=getattr(obj, "is_private", None),
+        is_delete_protection_enabled=getattr(obj, "is_delete_protection_enabled", None),
+        is_request_id_enabled=getattr(obj, "is_request_id_enabled", None),
+        request_id_header=getattr(obj, "request_id_header", None),
+        subnet_ids=getattr(obj, "subnet_ids", None),
+        network_security_group_ids=getattr(obj, "network_security_group_ids", None),
+        listeners=listeners,
+        hostnames=hostnames,
+        ssl_cipher_suites=ssl_cipher_suites,
+        certificates=certificates,
+        backend_sets=backend_sets,
+        path_route_sets=path_route_sets,
+        freeform_tags=getattr(obj, "freeform_tags", None),
+        defined_tags=getattr(obj, "defined_tags", None),
+        security_attributes=getattr(obj, "security_attributes", None),
+        system_tags=getattr(obj, "system_tags", None),
+        rule_sets=rule_sets,
+        routing_policies=routing_policies,
+        ip_mode=getattr(obj, "ip_mode", None),
+    )
+
+
+# Health and Work Request models + mapping
+
+
+class HealthCheckResult(BaseModel):
+    subnet_id: Optional[str] = None
+    source_ip_address: Optional[str] = None
+    timestamp: Optional[datetime] = None
+    health_check_status: Optional[
+        Literal[
+            "OK",
+            "INVALID_STATUS_CODE",
+            "TIMED_OUT",
+            "REGEX_MISMATCH",
+            "CONNECT_FAILED",
+            "IO_ERROR",
+            "OFFLINE",
+            "UNKNOWN",
+        ]
+    ] = None
+
+
+class BackendHealth(BaseModel):
+    status: Optional[Literal["OK", "WARNING", "CRITICAL", "UNKNOWN"]] = None
+    health_check_results: Optional[List[HealthCheckResult]] = None
+
+
+class BackendSetHealth(BaseModel):
+    status: Optional[Literal["OK", "WARNING", "CRITICAL", "UNKNOWN"]] = None
+    warning_state_backend_names: Optional[List[str]] = None
+    critical_state_backend_names: Optional[List[str]] = None
+    unknown_state_backend_names: Optional[List[str]] = None
+    total_backend_count: Optional[int] = None
+
+
+class LoadBalancerHealth(BaseModel):
+    status: Optional[Literal["OK", "WARNING", "CRITICAL", "UNKNOWN"]] = None
+    warning_state_backend_set_names: Optional[List[str]] = None
+    critical_state_backend_set_names: Optional[List[str]] = None
+    unknown_state_backend_set_names: Optional[List[str]] = None
+    total_backend_set_count: Optional[int] = None
+
+
+class LoadBalancerHealthSummary(BaseModel):
+    load_balancer_id: Optional[str] = None
+    status: Optional[Literal["OK", "WARNING", "CRITICAL", "UNKNOWN"]] = None
+
+
+class WorkRequestError(BaseModel):
+    error_code: Optional[Literal["BAD_INPUT", "INTERNAL_ERROR"]] = None
+    message: Optional[str] = None
+
+
+class WorkRequest(BaseModel):
+    id: Optional[str] = None
+    load_balancer_id: Optional[str] = None
+    type: Optional[str] = None
+    compartment_id: Optional[str] = None
+    lifecycle_state: Optional[
+        Literal["ACCEPTED", "IN_PROGRESS", "FAILED", "SUCCEEDED"]
+    ] = None
+    message: Optional[str] = None
+    time_accepted: Optional[datetime] = None
+    time_finished: Optional[datetime] = None
+    error_details: Optional[List[WorkRequestError]] = None
+
+
+def map_health_check_result(obj) -> Optional[HealthCheckResult]:
+    if not obj:
+        return None
+    return HealthCheckResult(
+        subnet_id=getattr(obj, "subnet_id", None),
+        source_ip_address=getattr(obj, "source_ip_address", None),
+        timestamp=getattr(obj, "timestamp", None),
+        health_check_status=getattr(obj, "health_check_status", None),
+    )
+
+
+def map_backend_health(obj) -> Optional[BackendHealth]:
+    if not obj:
+        return None
+    results = (
+        [map_health_check_result(r) for r in getattr(obj, "health_check_results", [])]
+        if getattr(obj, "health_check_results", None)
+        else None
+    )
+    return BackendHealth(
+        status=getattr(obj, "status", None), health_check_results=results
+    )
+
+
+def map_backend_set_health(obj) -> Optional[BackendSetHealth]:
+    if not obj:
+        return None
+    return BackendSetHealth(
+        status=getattr(obj, "status", None),
+        warning_state_backend_names=getattr(obj, "warning_state_backend_names", None),
+        critical_state_backend_names=getattr(obj, "critical_state_backend_names", None),
+        unknown_state_backend_names=getattr(obj, "unknown_state_backend_names", None),
+        total_backend_count=getattr(obj, "total_backend_count", None),
+    )
+
+
+def map_load_balancer_health(obj) -> Optional[LoadBalancerHealth]:
+    if not obj:
+        return None
+    return LoadBalancerHealth(
+        status=getattr(obj, "status", None),
+        warning_state_backend_set_names=getattr(
+            obj, "warning_state_backend_set_names", None
+        ),
+        critical_state_backend_set_names=getattr(
+            obj, "critical_state_backend_set_names", None
+        ),
+        unknown_state_backend_set_names=getattr(
+            obj, "unknown_state_backend_set_names", None
+        ),
+        total_backend_set_count=getattr(obj, "total_backend_set_count", None),
+    )
+
+
+def map_load_balancer_health_summary(obj) -> Optional[LoadBalancerHealthSummary]:
+    if not obj:
+        return None
+    return LoadBalancerHealthSummary(
+        load_balancer_id=getattr(obj, "load_balancer_id", None),
+        status=getattr(obj, "status", None),
+    )
+
+
+def map_work_request_error(obj) -> Optional[WorkRequestError]:
+    if not obj:
+        return None
+    return WorkRequestError(
+        error_code=getattr(obj, "error_code", None),
+        message=getattr(obj, "message", None),
+    )
+
+
+def map_work_request(obj) -> Optional[WorkRequest]:
+    if not obj:
+        return None
+    errors = (
+        [map_work_request_error(e) for e in getattr(obj, "error_details", [])]
+        if getattr(obj, "error_details", None)
+        else None
+    )
+    return WorkRequest(
+        id=getattr(obj, "id", None),
+        load_balancer_id=getattr(obj, "load_balancer_id", None),
+        type=getattr(obj, "type", None),
+        compartment_id=getattr(obj, "compartment_id", None),
+        lifecycle_state=getattr(obj, "lifecycle_state", None),
+        message=getattr(obj, "message", None),
+        time_accepted=getattr(obj, "time_accepted", None),
+        time_finished=getattr(obj, "time_finished", None),
+        error_details=errors,
+    )

--- a/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/server.py
+++ b/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/server.py
@@ -1,0 +1,2340 @@
+"""
+Copyright (c) 2025, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from __future__ import annotations
+
+import os
+from logging import Logger
+from typing import Literal, Optional
+
+import oci
+from fastmcp import FastMCP
+from oracle.oci_load_balancer_mcp_server.models import (
+    Backend,
+    BackendHealth,
+    BackendSet,
+    BackendSetHealth,
+    Certificate,
+    Hostname,
+    Listener,
+    LoadBalancer,
+    LoadBalancerHealth,
+    LoadBalancerHealthSummary,
+    Response,
+    RoutingPolicy,
+    RuleSet,
+    SSLCipherSuite,
+    WorkRequest,
+    map_backend,
+    map_backend_health,
+    map_backend_set,
+    map_backend_set_health,
+    map_certificate,
+    map_hostname,
+    map_listener,
+    map_load_balancer,
+    map_load_balancer_health,
+    map_load_balancer_health_summary,
+    map_response,
+    map_routing_policy,
+    map_rule_set,
+    map_ssl_cipher_suite,
+    map_work_request,
+)
+from pydantic import Field
+
+from . import __project__, __version__
+
+logger = Logger(__name__, level="INFO")
+
+mcp = FastMCP(
+    name=__project__,
+    instructions=(
+        "OCI Load Balancer MCP tools. Use these tools directly and concisely. "
+        "When a prompt mentions a load balancer by name, first call list_load_balancers with "
+        "compartment_id=<active compartment> and display_name=<specified name> to obtain its OCID. "
+        "Use that id for subsequent calls. Prefer minimal tool calls and return short confirmations using "
+        "words like created/updated/deleted/retrieved and the nouns listener, backend set, backend, "
+        "certificate, cipher suite, hostname, rule set, routing policy, health, work request."
+    ),
+)
+
+
+def get_load_balancer_client():
+    logger.info("entering get_load_balancer_client")
+    config = oci.config.from_file(
+        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+    )
+    user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
+    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
+    private_key = oci.signer.load_private_key_from_file(config["key_file"])
+    # Use the same token-based signer approach used in other servers for consistency
+    token_file = (
+        os.path.expanduser(config["security_token_file"])
+        if "security_token_file" in config
+        else None
+    )
+    token = None
+    if token_file:
+        with open(token_file, "r") as f:
+            token = f.read()
+    signer = oci.auth.signers.SecurityTokenSigner(token, private_key) if token else None
+    return oci.load_balancer.LoadBalancerClient(config, signer=signer)
+
+
+@mcp.tool(
+    name="list_load_balancers",
+    description=(
+        "Lists OCI load balancers in a compartment. Requires a compartment OCID. "
+        "If you have a display name, you may first use this tool to list load balancers and "
+        "search for the desired OCID based on display_name."
+        " You MUST pass compartment_id=... (do NOT use name or 'root')."
+        "Example: call list_load_balancers with compartment_id=ocid1.tenancy.oc1..abcd"
+    ),
+)
+def list_load_balancers(
+    compartment_id: str = Field(..., description="The OCID of the compartment"),
+    limit: Optional[int] = Field(
+        None,
+        description="The maximum amount of load balancers to return. If None, there is no limit.",
+        ge=1,
+    ),
+    lifecycle_state: Optional[
+        Literal[
+            "CREATING",
+            "FAILED",
+            "ACTIVE",
+            "DELETING",
+            "DELETED",
+        ]
+    ] = Field(
+        None,
+        description="The lifecycle state of the load balancer to filter on",
+    ),
+    display_name: Optional[str] = Field(
+        None, description="Exact display name to filter on"
+    ),
+    sort_by: Optional[Literal["TIMECREATED", "DISPLAYNAME"]] = Field(
+        None, description="Field to sort by"
+    ),
+    sort_order: Optional[Literal["ASC", "DESC"]] = Field(
+        None, description="Sort order to use"
+    ),
+) -> list[LoadBalancer]:
+    lbs: list[LoadBalancer] = []
+
+    try:
+        client = get_load_balancer_client()
+
+        next_page: Optional[str] = None
+        first_page = True
+        while first_page or (next_page and (limit is None or len(lbs) < limit)):
+            first_page = False
+            # Respect remaining client-side limit to avoid overfetching
+            page_limit = None if limit is None else max(1, limit - len(lbs))
+            # Build kwargs only for values that are not None to satisfy OCI SDK validation
+            kwargs = {"compartment_id": compartment_id}
+            if page_limit is not None:
+                kwargs["limit"] = page_limit
+            if next_page is not None:
+                kwargs["page"] = next_page
+            if display_name is not None:
+                kwargs["display_name"] = display_name
+            if lifecycle_state is not None:
+                kwargs["lifecycle_state"] = lifecycle_state
+            if sort_by is not None:
+                kwargs["sort_by"] = sort_by
+            if sort_order is not None:
+                kwargs["sort_order"] = sort_order
+
+            response = client.list_load_balancers(**kwargs)
+            items = getattr(response.data, "items", response.data) or []
+            remaining = None if limit is None else max(0, limit - len(lbs))
+            to_process = items if remaining is None else items[:remaining]
+            for d in to_process:
+                lbs.append(map_load_balancer(d))
+            next_page = getattr(response, "next_page", None)
+
+        logger.info(f"Found {len(lbs)} Load Balancers")
+        return lbs
+
+    except Exception as e:
+        logger.error(f"Error in list_load_balancers tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="get_load_balancer",
+    description=(
+        "Get details for a specific load balancer. Requires load_balancer_id (OCID). "
+        "If you only have a display name, first perform a list_load_balancers call and search "
+        "for the matching display_name to figure out the OCID."
+        " Example: call get_load_balancer with load_balancer_id=ocid1.loadbalancer.oc1..abcd"
+    ),
+)
+def get_load_balancer(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer")
+) -> LoadBalancer:
+    try:
+        client = get_load_balancer_client()
+
+        response: oci.response.Response = client.get_load_balancer(load_balancer_id)
+        data: oci.load_balancer.models.LoadBalancer = response.data
+        logger.info("Found Load Balancer")
+        return map_load_balancer(data)
+
+    except Exception as e:
+        logger.error(f"Error in get_load_balancer tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="create_load_balancer",
+    description=(
+        "Create a new load balancer. Requires compartment_id (OCID), display_name, shape_name, "
+        "and subnet_ids (list of OCIDs). Do NOT use compartment name. "
+        "Example: call create_load_balancer with compartment_id=ocid1.tenancy.oc1..abcd, "
+        "display_name=lb-name, shape_name=Flexible, subnet_ids=[ocid1.subnet.oc1..subnet-abcd]"
+        " When a compartment_id is not provided, use the currently active compartment."
+    ),
+)
+def create_load_balancer(
+    compartment_id: str = Field(
+        ..., description="The OCID of the compartment to create the load balancer in."
+    ),
+    display_name: str = Field(
+        ...,
+        description="A user-friendly display name for the load balancer.",
+        min_length=1,
+        max_length=1024,
+    ),
+    shape_name: str = Field(
+        ...,
+        description="The shape name for the load balancer (e.g., Flexible, 100Mbps).",
+    ),
+    subnet_ids: list[str] = Field(
+        ..., description="An array of subnet OCIDs for the load balancer."
+    ),
+    is_private: Optional[bool] = Field(
+        None, description="Whether the load balancer should be private"
+    ),
+    ip_mode: Optional[Literal["IPV4", "IPV6"]] = Field(
+        None, description="Whether the load balancer should have IPv4 or IPv6 address"
+    ),
+    is_delete_protection_enabled: Optional[bool] = Field(
+        None, description="Enable delete protection for this load balancer"
+    ),
+    is_request_id_enabled: Optional[bool] = Field(
+        None, description="Enable Request Id header feature for HTTP listeners"
+    ),
+    request_id_header: Optional[str] = Field(
+        None, description="Custom header name for Request Id feature when enabled"
+    ),
+    network_security_group_ids: Optional[list[str]] = Field(
+        None, description="Array of NSG OCIDs to associate with the load balancer"
+    ),
+    minimum_bandwidth_in_mbps: Optional[int] = Field(
+        None, description="Minimum bandwidth in Mbps (Flexible shape only)"
+    ),
+    maximum_bandwidth_in_mbps: Optional[int] = Field(
+        None, description="Maximum bandwidth in Mbps (Flexible shape only)"
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+
+        shape_details = None
+        if (
+            minimum_bandwidth_in_mbps is not None
+            and maximum_bandwidth_in_mbps is not None
+        ):
+            shape_details = oci.load_balancer.models.ShapeDetails(
+                minimum_bandwidth_in_mbps=minimum_bandwidth_in_mbps,
+                maximum_bandwidth_in_mbps=maximum_bandwidth_in_mbps,
+            )
+
+        details = oci.load_balancer.models.CreateLoadBalancerDetails(
+            compartment_id=compartment_id,
+            display_name=display_name,
+            shape_name=shape_name,
+            subnet_ids=subnet_ids,
+            is_private=is_private,
+            ip_mode=ip_mode,
+            is_delete_protection_enabled=is_delete_protection_enabled,
+            is_request_id_enabled=is_request_id_enabled,
+            request_id_header=request_id_header,
+            network_security_group_ids=network_security_group_ids,
+            shape_details=shape_details,
+        )
+
+        response: oci.response.Response = client.create_load_balancer(details)
+        logger.info("Create Load Balancer request accepted")
+        return map_response(response)
+
+    except Exception as e:
+        logger.error(f"Error in create_load_balancer tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="update_load_balancer", description="Update a load balancer configuration"
+)
+def update_load_balancer(
+    load_balancer_id: str = Field(
+        ..., description="The OCID of the load balancer to update"
+    ),
+    display_name: Optional[str] = Field(
+        None, description="New display name for the load balancer"
+    ),
+    is_delete_protection_enabled: Optional[bool] = Field(
+        None, description="Whether delete protection should be enabled"
+    ),
+    is_request_id_enabled: Optional[bool] = Field(
+        None, description="Enable Request Id header feature for HTTP listeners"
+    ),
+    request_id_header: Optional[str] = Field(
+        None, description="Custom header name for Request Id feature when enabled"
+    ),
+    freeform_tags: Optional[dict[str, str]] = Field(
+        None, description="Free-form tags to set on the resource"
+    ),
+    defined_tags: Optional[dict[str, dict[str, object]]] = Field(
+        None, description="Defined tags to set on the resource"
+    ),
+    defined_tags_extended: Optional[dict[str, dict[str, dict[str, object]]]] = Field(
+        None, description="Extended defined tags to set on the resource"
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+
+        update_details = oci.load_balancer.models.UpdateLoadBalancerDetails(
+            display_name=display_name,
+            is_delete_protection_enabled=is_delete_protection_enabled,
+            is_request_id_enabled=is_request_id_enabled,
+            request_id_header=request_id_header,
+            freeform_tags=freeform_tags,
+            defined_tags=defined_tags,
+            defined_tags_extended=defined_tags_extended,
+        )
+
+        response: oci.response.Response = client.update_load_balancer(
+            update_details, load_balancer_id
+        )
+        logger.info("Update Load Balancer request accepted")
+        return map_response(response)
+
+    except Exception as e:
+        logger.error(f"Error in update_load_balancer tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="update_load_balancer_shape",
+    description="Update the shape (bandwidth) of a load balancer",
+)
+def update_load_balancer_shape(
+    load_balancer_id: str = Field(
+        ..., description="The OCID of the load balancer to update"
+    ),
+    shape_name: Optional[str] = Field(
+        None,
+        description="The shape name for the load balancer (e.g., Flexible, 100Mbps)",
+    ),
+    minimum_bandwidth_in_mbps: Optional[int] = Field(
+        None,
+        description="Minimum bandwidth in Mbps (Flexible shape only)",
+    ),
+    maximum_bandwidth_in_mbps: Optional[int] = Field(
+        None,
+        description="Maximum bandwidth in Mbps (Flexible shape only)",
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+
+        shape_details = None
+        if (
+            minimum_bandwidth_in_mbps is not None
+            and maximum_bandwidth_in_mbps is not None
+        ):
+            shape_details = oci.load_balancer.models.ShapeDetails(
+                minimum_bandwidth_in_mbps=minimum_bandwidth_in_mbps,
+                maximum_bandwidth_in_mbps=maximum_bandwidth_in_mbps,
+            )
+
+        update_details = oci.load_balancer.models.UpdateLoadBalancerShapeDetails(
+            shape_name=shape_name,
+            shape_details=shape_details,
+        )
+
+        response: oci.response.Response = client.update_load_balancer_shape(
+            load_balancer_id, update_details
+        )
+        logger.info("Update Load Balancer shape request accepted")
+        return map_response(response)
+
+    except Exception as e:
+        logger.error(f"Error in update_load_balancer_shape tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="delete_load_balancer",
+    description=(
+        "Delete the specified load balancer. Requires load_balancer_id (OCID). "
+        "If you have only a display name, use list_load_balancers to obtain the OCID first."
+        " Example: call delete_load_balancer with load_balancer_id=ocid1.loadbalancer.oc1..abcd"
+    ),
+)
+def delete_load_balancer(
+    load_balancer_id: str = Field(
+        ..., description="The OCID of the load balancer to delete"
+    )
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+
+        response: oci.response.Response = client.delete_load_balancer(load_balancer_id)
+        logger.info("Delete Load Balancer request accepted")
+        return map_response(response)
+
+    except Exception as e:
+        logger.error(f"Error in delete_load_balancer tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="update_load_balancer_network_security_groups",
+    description="Update the network security groups associated with a load balancer",
+)
+def update_load_balancer_network_security_groups(
+    load_balancer_id: str = Field(
+        ..., description="The OCID of the load balancer to update"
+    ),
+    network_security_group_ids: Optional[list[str]] = Field(
+        None, description="Array of NSG OCIDs to associate with the load balancer"
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+
+        update_details = oci.load_balancer.models.UpdateNetworkSecurityGroupsDetails(
+            network_security_group_ids=network_security_group_ids,
+        )
+
+        response: oci.response.Response = client.update_network_security_groups(
+            update_details, load_balancer_id
+        )
+        logger.info("Update Load Balancer network security groups request accepted")
+        return map_response(response)
+
+    except Exception as e:
+        logger.error(
+            f"Error in update_load_balancer_network_security_groups tool: {str(e)}"
+        )
+        raise e
+
+
+@mcp.tool(
+    name="list_load_balancer_listeners",
+    description=(
+        "List all listeners for the given load balancer. Use full OCID for load_balancer_id "
+        "(do NOT use display_name or nickname). Example: call list_load_balancer_listeners with "
+        "load_balancer_id=ocid1.loadbalancer.oc1..abcd"
+        " IMPORTANT: Must be called by: list_load_balancer_listeners."
+    ),
+)
+def list_load_balancer_listeners(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    limit: Optional[int] = Field(
+        None,
+        description="The maximum number of listeners to return. If None, all listeners are returned.",
+        ge=1,
+    ),
+) -> list[Listener]:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.get_load_balancer(load_balancer_id)
+        lb: oci.load_balancer.models.LoadBalancer = response.data
+        listeners_map = getattr(lb, "listeners", {}) or {}
+        listeners: list[Listener] = []
+        for _, l in listeners_map.items():
+            listeners.append(map_listener(l))
+            if limit is not None and len(listeners) >= limit:
+                break
+        logger.info(f"Found {len(listeners)} Listeners")
+        return listeners
+    except Exception as e:
+        logger.error(f"Error in list_load_balancer_listeners tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="create_load_balancer_listener",
+    description="Adds a listener to a load balancer",
+)
+def create_load_balancer_listener(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(
+        ...,
+        description="A friendly name for the listener",
+        min_length=1,
+        max_length=255,
+    ),
+    default_backend_set_name: str = Field(
+        ...,
+        description="The name of the associated backend set",
+        min_length=1,
+        max_length=32,
+    ),
+    port: int = Field(
+        ..., description="The communication port for the listener", ge=1, le=65535
+    ),
+    protocol: Literal["HTTP", "HTTP2", "TCP", "GRPC"] = Field(
+        ...,
+        description="The protocol on which the listener accepts connection requests",
+    ),
+    hostname_names: Optional[list[str]] = Field(
+        None, description="An array of hostname resource names"
+    ),
+    path_route_set_name: Optional[str] = Field(
+        None,
+        description="Deprecated. Name of the PathRouteSet applied to this listener",
+    ),
+    routing_policy_name: Optional[str] = Field(
+        None, description="Name of the RoutingPolicy applied to this listener"
+    ),
+    rule_set_names: Optional[list[str]] = Field(
+        None, description="Names of RuleSets applied to this listener"
+    ),
+    # SSL configuration (common subset)
+    ssl_protocols: Optional[list[str]] = Field(
+        None, description="Supported SSL protocols (e.g., TLSv1.2, TLSv1.3)"
+    ),
+    ssl_cipher_suite_name: Optional[str] = Field(
+        None, description="Cipher suite name to use for SSL/HTTPS"
+    ),
+    ssl_server_order_preference: Optional[Literal["ENABLED", "DISABLED"]] = Field(
+        None, description="Preference for server ciphers over client ciphers"
+    ),
+    ssl_certificate_name: Optional[str] = Field(
+        None, description="Certificate bundle name configured on the load balancer"
+    ),
+    ssl_has_session_resumption: Optional[bool] = Field(
+        None, description="Whether TLS session resumption should be enabled"
+    ),
+    ssl_verify_peer_certificate: Optional[bool] = Field(
+        None, description="Whether to verify peer certificates"
+    ),
+    ssl_verify_depth: Optional[int] = Field(
+        None, description="Max depth for peer certificate chain verification"
+    ),
+    # Connection configuration
+    idle_timeout: Optional[int] = Field(
+        None,
+        description="Maximum idle time in seconds between client/backend operations",
+    ),
+    backend_tcp_proxy_protocol_version: Optional[int] = Field(
+        None, description="Backend TCP Proxy Protocol version (1 or 2)"
+    ),
+    backend_tcp_proxy_protocol_options: Optional[
+        list[Literal["PP2_TYPE_AUTHORITY"]]
+    ] = Field(None, description="PPv2 options that can be enabled on TCP listeners"),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+
+        ssl_cfg = None
+        if any(
+            x is not None
+            for x in [
+                ssl_protocols,
+                ssl_cipher_suite_name,
+                ssl_server_order_preference,
+                ssl_certificate_name,
+                ssl_has_session_resumption,
+                ssl_verify_peer_certificate,
+                ssl_verify_depth,
+            ]
+        ):
+            ssl_cfg = oci.load_balancer.models.SSLConfigurationDetails(
+                protocols=ssl_protocols,
+                cipher_suite_name=ssl_cipher_suite_name,
+                server_order_preference=ssl_server_order_preference,
+                certificate_name=ssl_certificate_name,
+                has_session_resumption=ssl_has_session_resumption,
+                verify_peer_certificate=ssl_verify_peer_certificate,
+                verify_depth=ssl_verify_depth,
+            )
+
+        conn_cfg = None
+        if any(
+            x is not None
+            for x in [
+                idle_timeout,
+                backend_tcp_proxy_protocol_version,
+                backend_tcp_proxy_protocol_options,
+            ]
+        ):
+            conn_cfg = oci.load_balancer.models.ConnectionConfiguration(
+                idle_timeout=idle_timeout,
+                backend_tcp_proxy_protocol_version=backend_tcp_proxy_protocol_version,
+                backend_tcp_proxy_protocol_options=backend_tcp_proxy_protocol_options,
+            )
+
+        details = oci.load_balancer.models.CreateListenerDetails(
+            name=name,
+            default_backend_set_name=default_backend_set_name,
+            port=port,
+            protocol=protocol,
+            hostname_names=hostname_names,
+            path_route_set_name=path_route_set_name,
+            ssl_configuration=ssl_cfg,
+            connection_configuration=conn_cfg,
+            routing_policy_name=routing_policy_name,
+            rule_set_names=rule_set_names,
+        )
+
+        response: oci.response.Response = client.create_listener(
+            details, load_balancer_id
+        )
+        logger.info("Create Listener request accepted")
+        return map_response(response)
+
+    except Exception as e:
+        logger.error(f"Error in create_load_balancer_listener tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="get_load_balancer_listener",
+    description="Gets a listener by name from the given load balancer",
+)
+def get_load_balancer_listener(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    listener_name: str = Field(..., description="The name of the listener to fetch"),
+) -> Listener:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.get_load_balancer(load_balancer_id)
+        lb: oci.load_balancer.models.LoadBalancer = response.data
+        listeners_map = getattr(lb, "listeners", {}) or {}
+        raw = listeners_map.get(listener_name)
+        if raw is None:
+            raise ValueError(
+                f"Listener '{listener_name}' not found on load balancer {load_balancer_id}"
+            )
+        return map_listener(raw)
+    except Exception as e:
+        logger.error(f"Error in get_load_balancer_listener tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="update_load_balancer_listener",
+    description="Updates a listener for a given load balancer",
+)
+def update_load_balancer_listener(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    listener_name: str = Field(..., description="The name of the listener to update"),
+    default_backend_set_name: Optional[str] = Field(
+        None,
+        description="The name of the associated backend set",
+        min_length=1,
+        max_length=32,
+    ),
+    port: Optional[int] = Field(
+        None, description="The communication port for the listener", ge=1, le=65535
+    ),
+    protocol: Optional[Literal["HTTP", "HTTP2", "TCP", "GRPC"]] = Field(
+        None,
+        description="The protocol on which the listener accepts connection requests",
+    ),
+    hostname_names: Optional[list[str]] = Field(
+        None, description="An array of hostname resource names"
+    ),
+    path_route_set_name: Optional[str] = Field(
+        None,
+        description="Deprecated. Name of the PathRouteSet applied to this listener",
+    ),
+    routing_policy_name: Optional[str] = Field(
+        None, description="Name of the RoutingPolicy applied to this listener"
+    ),
+    rule_set_names: Optional[list[str]] = Field(
+        None, description="Names of RuleSets applied to this listener"
+    ),
+    # SSL configuration (common subset)
+    ssl_protocols: Optional[list[str]] = Field(
+        None, description="Supported SSL protocols (e.g., TLSv1.2, TLSv1.3)"
+    ),
+    ssl_cipher_suite_name: Optional[str] = Field(
+        None, description="Cipher suite name to use for SSL/HTTPS"
+    ),
+    ssl_server_order_preference: Optional[Literal["ENABLED", "DISABLED"]] = Field(
+        None, description="Preference for server ciphers over client ciphers"
+    ),
+    ssl_certificate_name: Optional[str] = Field(
+        None, description="Certificate bundle name configured on the load balancer"
+    ),
+    ssl_has_session_resumption: Optional[bool] = Field(
+        None, description="Whether TLS session resumption should be enabled"
+    ),
+    ssl_verify_peer_certificate: Optional[bool] = Field(
+        None, description="Whether to verify peer certificates"
+    ),
+    ssl_verify_depth: Optional[int] = Field(
+        None, description="Max depth for peer certificate chain verification"
+    ),
+    # Connection configuration
+    idle_timeout: Optional[int] = Field(
+        None,
+        description="Maximum idle time in seconds between client/backend operations",
+    ),
+    backend_tcp_proxy_protocol_version: Optional[int] = Field(
+        None, description="Backend TCP Proxy Protocol version (1 or 2)"
+    ),
+    backend_tcp_proxy_protocol_options: Optional[
+        list[Literal["PP2_TYPE_AUTHORITY"]]
+    ] = Field(None, description="PPv2 options that can be enabled on TCP listeners"),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+
+        ssl_cfg = None
+        if any(
+            x is not None
+            for x in [
+                ssl_protocols,
+                ssl_cipher_suite_name,
+                ssl_server_order_preference,
+                ssl_certificate_name,
+                ssl_has_session_resumption,
+                ssl_verify_peer_certificate,
+                ssl_verify_depth,
+            ]
+        ):
+            ssl_cfg = oci.load_balancer.models.SSLConfigurationDetails(
+                protocols=ssl_protocols,
+                cipher_suite_name=ssl_cipher_suite_name,
+                server_order_preference=ssl_server_order_preference,
+                certificate_name=ssl_certificate_name,
+                has_session_resumption=ssl_has_session_resumption,
+                verify_peer_certificate=ssl_verify_peer_certificate,
+                verify_depth=ssl_verify_depth,
+            )
+
+        conn_cfg = None
+        if any(
+            x is not None
+            for x in [
+                idle_timeout,
+                backend_tcp_proxy_protocol_version,
+                backend_tcp_proxy_protocol_options,
+            ]
+        ):
+            conn_cfg = oci.load_balancer.models.ConnectionConfiguration(
+                idle_timeout=idle_timeout,
+                backend_tcp_proxy_protocol_version=backend_tcp_proxy_protocol_version,
+                backend_tcp_proxy_protocol_options=backend_tcp_proxy_protocol_options,
+            )
+
+        details = oci.load_balancer.models.UpdateListenerDetails(
+            default_backend_set_name=default_backend_set_name,
+            port=port,
+            protocol=protocol,
+            hostname_names=hostname_names,
+            path_route_set_name=path_route_set_name,
+            ssl_configuration=ssl_cfg,
+            connection_configuration=conn_cfg,
+            routing_policy_name=routing_policy_name,
+            rule_set_names=rule_set_names,
+        )
+
+        response: oci.response.Response = client.update_listener(
+            details, load_balancer_id, listener_name
+        )
+        logger.info("Update Listener request accepted")
+        return map_response(response)
+
+    except Exception as e:
+        logger.error(f"Error in update_load_balancer_listener tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="delete_load_balancer_listener",
+    description="Deletes a listener from a load balancer",
+)
+def delete_load_balancer_listener(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    listener_name: str = Field(..., description="The name of the listener to delete"),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.delete_listener(
+            load_balancer_id, listener_name
+        )
+        logger.info("Delete Listener request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in delete_load_balancer_listener tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="list_load_balancer_backend_sets",
+    description="Lists the backend sets from the given load balancer",
+)
+def list_load_balancer_backend_sets(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    limit: Optional[int] = Field(
+        None,
+        description="The maximum number of backend sets to return. If None, all are returned.",
+        ge=1,
+    ),
+) -> list[BackendSet]:
+    try:
+        client = get_load_balancer_client()
+        backend_sets: list[BackendSet] = []
+        response: oci.response.Response = client.list_backend_sets(load_balancer_id)
+        items = getattr(response.data, "items", response.data) or []
+        for d in items:
+            backend_sets.append(map_backend_set(d))
+            if limit is not None and len(backend_sets) >= limit:
+                break
+        logger.info(f"Found {len(backend_sets)} Backend Sets")
+        return backend_sets
+    except Exception as e:
+        logger.error(f"Error in list_load_balancer_backend_sets tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="get_load_balancer_backend_set",
+    description="Gets the backend set with the given name from the given load balancer",
+)
+def get_load_balancer_backend_set(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    backend_set_name: str = Field(
+        ..., description="The name of the backend set to fetch"
+    ),
+) -> BackendSet:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.get_backend_set(
+            load_balancer_id, backend_set_name
+        )
+        data: oci.load_balancer.models.BackendSet = response.data
+        logger.info("Found Backend Set")
+        return map_backend_set(data)
+    except Exception as e:
+        logger.error(f"Error in get_load_balancer_backend_set tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="create_load_balancer_backend_set",
+    description="Adds a backend set to a load balancer",
+)
+def create_load_balancer_backend_set(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=32,
+        description="A friendly, unique backend set name",
+    ),
+    policy: str = Field(..., description="Load balancer policy for this backend set"),
+    # Health checker (required argument must come before any optional args)
+    health_checker_protocol: str = Field(
+        ..., description="Protocol used for health checks (HTTP or TCP)"
+    ),
+    # Optional collections and tuning
+    # Health checker (optional fields)
+    health_checker_url_path: Optional[str] = Field(
+        None, description="Path for HTTP health checks"
+    ),
+    health_checker_port: Optional[int] = Field(
+        None, description="Port to use for the health check", ge=0, le=65535
+    ),
+    health_checker_return_code: Optional[int] = Field(
+        None, description="Expected return code from healthy backend"
+    ),
+    health_checker_retries: Optional[int] = Field(
+        None, description="Number of retries before marking backend unhealthy"
+    ),
+    health_checker_timeout_in_millis: Optional[int] = Field(
+        None,
+        description="Timeout in milliseconds for health check replies",
+        ge=1,
+        le=600000,
+    ),
+    health_checker_interval_in_millis: Optional[int] = Field(
+        None,
+        description="Interval between health checks in milliseconds",
+        ge=1000,
+        le=1800000,
+    ),
+    health_checker_response_body_regex: Optional[str] = Field(
+        None, description="Regex to match against HTTP response body"
+    ),
+    health_checker_is_force_plain_text: Optional[bool] = Field(
+        None,
+        description=(
+            "Force plaintext health checks regardless of backend set SSL configuration"
+        ),
+    ),
+    backends: Optional[list[Backend]] = Field(
+        None, description="Backends to include in the backend set"
+    ),
+    backend_max_connections: Optional[int] = Field(
+        None,
+        description=(
+            "Max simultaneous connections to any backend unless overridden at backend level"
+        ),
+        ge=256,
+        le=65535,
+    ),
+    # SSL configuration
+    ssl_protocols: Optional[list[str]] = Field(
+        None, description="Supported SSL protocols (e.g., TLSv1.2, TLSv1.3)"
+    ),
+    ssl_cipher_suite_name: Optional[str] = Field(
+        None, description="Cipher suite name for SSL configuration"
+    ),
+    ssl_server_order_preference: Optional[Literal["ENABLED", "DISABLED"]] = Field(
+        None, description="Preference for server ciphers over client ciphers"
+    ),
+    ssl_certificate_name: Optional[str] = Field(
+        None, description="Certificate bundle name configured on the load balancer"
+    ),
+    ssl_certificate_ids: Optional[list[str]] = Field(
+        None, description="OCI Certificates service certificate OCIDs"
+    ),
+    ssl_trusted_certificate_authority_ids: Optional[list[str]] = Field(
+        None, description="OCI Certificates CA/bundle OCIDs to trust"
+    ),
+    ssl_has_session_resumption: Optional[bool] = Field(
+        None, description="Whether TLS session resumption should be enabled"
+    ),
+    ssl_verify_peer_certificate: Optional[bool] = Field(
+        None, description="Whether to verify peer certificates"
+    ),
+    ssl_verify_depth: Optional[int] = Field(
+        None, description="Max depth for peer certificate chain verification"
+    ),
+    # Session persistence (application cookie)
+    session_persistence_cookie_name: Optional[str] = Field(
+        None, description="Cookie name for application-cookie stickiness"
+    ),
+    session_persistence_disable_fallback: Optional[bool] = Field(
+        None,
+        description="Disable fallback to a different backend when original unavailable",
+    ),
+    # LB cookie persistence
+    lb_cookie_cookie_name: Optional[str] = Field(
+        None, description="Name of cookie inserted by the load balancer"
+    ),
+    lb_cookie_disable_fallback: Optional[bool] = Field(
+        None, description="Disable fallback when original backend unavailable"
+    ),
+    lb_cookie_domain: Optional[str] = Field(None, description="Cookie domain"),
+    lb_cookie_path: Optional[str] = Field(None, description="Cookie path"),
+    lb_cookie_max_age_in_seconds: Optional[int] = Field(
+        None, description="Cookie Max-Age in seconds"
+    ),
+    lb_cookie_is_secure: Optional[bool] = Field(
+        None, description="Whether to set the Secure attribute on the cookie"
+    ),
+    lb_cookie_is_http_only: Optional[bool] = Field(
+        None, description="Whether to set the HttpOnly attribute on the cookie"
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+
+        # Health checker details (protocol is required; always build)
+        health_checker = oci.load_balancer.models.HealthCheckerDetails(
+            protocol=health_checker_protocol,
+            url_path=health_checker_url_path,
+            port=health_checker_port,
+            return_code=health_checker_return_code,
+            retries=health_checker_retries,
+            timeout_in_millis=health_checker_timeout_in_millis,
+            interval_in_millis=health_checker_interval_in_millis,
+            response_body_regex=health_checker_response_body_regex,
+            is_force_plain_text=health_checker_is_force_plain_text,
+        )
+
+        # SSL configuration
+        ssl_cfg = None
+        if any(
+            x is not None
+            for x in [
+                ssl_protocols,
+                ssl_cipher_suite_name,
+                ssl_server_order_preference,
+                ssl_certificate_name,
+                ssl_certificate_ids,
+                ssl_trusted_certificate_authority_ids,
+                ssl_has_session_resumption,
+                ssl_verify_peer_certificate,
+                ssl_verify_depth,
+            ]
+        ):
+            ssl_cfg = oci.load_balancer.models.SSLConfigurationDetails(
+                protocols=ssl_protocols,
+                cipher_suite_name=ssl_cipher_suite_name,
+                server_order_preference=ssl_server_order_preference,
+                certificate_name=ssl_certificate_name,
+                certificate_ids=ssl_certificate_ids,
+                trusted_certificate_authority_ids=ssl_trusted_certificate_authority_ids,
+                has_session_resumption=ssl_has_session_resumption,
+                verify_peer_certificate=ssl_verify_peer_certificate,
+                verify_depth=ssl_verify_depth,
+            )
+
+        # Session persistence
+        session_persistence = None
+        if any(
+            x is not None
+            for x in [
+                session_persistence_cookie_name,
+                session_persistence_disable_fallback,
+            ]
+        ):
+            session_persistence = (
+                oci.load_balancer.models.SessionPersistenceConfigurationDetails(
+                    cookie_name=session_persistence_cookie_name,
+                    disable_fallback=session_persistence_disable_fallback,
+                )
+            )
+
+        # LB cookie persistence
+        lb_cookie_persistence = None
+        if any(
+            x is not None
+            for x in [
+                lb_cookie_cookie_name,
+                lb_cookie_disable_fallback,
+                lb_cookie_domain,
+                lb_cookie_path,
+                lb_cookie_max_age_in_seconds,
+                lb_cookie_is_secure,
+                lb_cookie_is_http_only,
+            ]
+        ):
+            lb_cookie_persistence = (
+                oci.load_balancer.models.LBCookieSessionPersistenceConfigurationDetails(
+                    cookie_name=lb_cookie_cookie_name,
+                    disable_fallback=lb_cookie_disable_fallback,
+                    domain=lb_cookie_domain,
+                    path=lb_cookie_path,
+                    max_age_in_seconds=lb_cookie_max_age_in_seconds,
+                    is_secure=lb_cookie_is_secure,
+                    is_http_only=lb_cookie_is_http_only,
+                )
+            )
+
+        # Backend details conversion
+        backend_details = None
+        if backends is not None:
+            backend_details = [
+                oci.load_balancer.models.BackendDetails(
+                    ip_address=b.ip_address,
+                    port=b.port,
+                    weight=b.weight,
+                    max_connections=b.max_connections,
+                    backup=b.backup,
+                    drain=b.drain,
+                    offline=b.offline,
+                )
+                for b in backends
+            ]
+
+        details = oci.load_balancer.models.CreateBackendSetDetails(
+            name=name,
+            policy=policy,
+            backends=backend_details,
+            backend_max_connections=backend_max_connections,
+            health_checker=health_checker,
+            ssl_configuration=ssl_cfg,
+            session_persistence_configuration=session_persistence,
+            lb_cookie_session_persistence_configuration=lb_cookie_persistence,
+        )
+
+        response: oci.response.Response = client.create_backend_set(
+            details, load_balancer_id
+        )
+        logger.info("Create Backend Set request accepted")
+        return map_response(response)
+
+    except Exception as e:
+        logger.error(f"Error in create_load_balancer_backend_set tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="update_load_balancer_backend_set",
+    description="Updates a backend set on a load balancer",
+)
+def update_load_balancer_backend_set(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=32,
+        description="The name of the backend set to update",
+    ),
+    policy: Optional[str] = Field(
+        None, description="Load balancer policy for this backend set"
+    ),
+    backends: Optional[list[Backend]] = Field(
+        None, description="Backends to include in the backend set"
+    ),
+    backend_max_connections: Optional[int] = Field(
+        None,
+        description=(
+            "Max simultaneous connections to any backend unless overridden at backend level"
+        ),
+        ge=256,
+        le=65535,
+    ),
+    # Health checker (same fields as create)
+    health_checker_protocol: Optional[str] = Field(
+        None, description="Protocol used for health checks (HTTP or TCP)"
+    ),
+    health_checker_url_path: Optional[str] = Field(
+        None, description="Path for HTTP health checks"
+    ),
+    health_checker_port: Optional[int] = Field(
+        None, description="Port to use for the health check", ge=0, le=65535
+    ),
+    health_checker_return_code: Optional[int] = Field(
+        None, description="Expected return code from healthy backend"
+    ),
+    health_checker_retries: Optional[int] = Field(
+        None, description="Number of retries before marking backend unhealthy"
+    ),
+    health_checker_timeout_in_millis: Optional[int] = Field(
+        None,
+        description="Timeout in milliseconds for health check replies",
+        ge=1,
+        le=600000,
+    ),
+    health_checker_interval_in_millis: Optional[int] = Field(
+        None,
+        description="Interval between health checks in milliseconds",
+        ge=1000,
+        le=1800000,
+    ),
+    health_checker_response_body_regex: Optional[str] = Field(
+        None, description="Regex to match against HTTP response body"
+    ),
+    health_checker_is_force_plain_text: Optional[bool] = Field(
+        None,
+        description=(
+            "Force plaintext health checks regardless of backend set SSL configuration"
+        ),
+    ),
+    # SSL configuration
+    ssl_protocols: Optional[list[str]] = Field(
+        None, description="Supported SSL protocols (e.g., TLSv1.2, TLSv1.3)"
+    ),
+    ssl_cipher_suite_name: Optional[str] = Field(
+        None, description="Cipher suite name for SSL configuration"
+    ),
+    ssl_server_order_preference: Optional[Literal["ENABLED", "DISABLED"]] = Field(
+        None, description="Preference for server ciphers over client ciphers"
+    ),
+    ssl_certificate_name: Optional[str] = Field(
+        None, description="Certificate bundle name configured on the load balancer"
+    ),
+    ssl_certificate_ids: Optional[list[str]] = Field(
+        None, description="OCI Certificates service certificate OCIDs"
+    ),
+    ssl_trusted_certificate_authority_ids: Optional[list[str]] = Field(
+        None, description="OCI Certificates CA/bundle OCIDs to trust"
+    ),
+    ssl_has_session_resumption: Optional[bool] = Field(
+        None, description="Whether TLS session resumption should be enabled"
+    ),
+    ssl_verify_peer_certificate: Optional[bool] = Field(
+        None, description="Whether to verify peer certificates"
+    ),
+    ssl_verify_depth: Optional[int] = Field(
+        None, description="Max depth for peer certificate chain verification"
+    ),
+    # Session persistence (application cookie)
+    session_persistence_cookie_name: Optional[str] = Field(
+        None, description="Cookie name for application-cookie stickiness"
+    ),
+    session_persistence_disable_fallback: Optional[bool] = Field(
+        None,
+        description="Disable fallback to a different backend when original unavailable",
+    ),
+    # LB cookie persistence
+    lb_cookie_cookie_name: Optional[str] = Field(
+        None, description="Name of cookie inserted by the load balancer"
+    ),
+    lb_cookie_disable_fallback: Optional[bool] = Field(
+        None, description="Disable fallback when original backend unavailable"
+    ),
+    lb_cookie_domain: Optional[str] = Field(None, description="Cookie domain"),
+    lb_cookie_path: Optional[str] = Field(None, description="Cookie path"),
+    lb_cookie_max_age_in_seconds: Optional[int] = Field(
+        None, description="Cookie Max-Age in seconds"
+    ),
+    lb_cookie_is_secure: Optional[bool] = Field(
+        None, description="Whether to set the Secure attribute on the cookie"
+    ),
+    lb_cookie_is_http_only: Optional[bool] = Field(
+        None, description="Whether to set the HttpOnly attribute on the cookie"
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+
+        # Always fetch current backend set so we can safely preserve unspecified fields
+        current_bs = client.get_backend_set(load_balancer_id, name).data
+
+        # Determine policy value (preserve existing if not provided)
+        effective_policy = (
+            policy if policy is not None else getattr(current_bs, "policy", None)
+        )
+
+        # Backend details conversion (preserve existing if not provided)
+        if backends is not None:
+            backend_details = [
+                oci.load_balancer.models.BackendDetails(
+                    ip_address=b.ip_address,
+                    port=b.port,
+                    weight=b.weight,
+                    max_connections=b.max_connections,
+                    backup=b.backup,
+                    drain=b.drain,
+                    offline=b.offline,
+                )
+                for b in backends
+            ]
+        else:
+            existing_backends = (
+                (getattr(current_bs, "backends", []) or []) if current_bs else []
+            )
+            backend_details = [
+                oci.load_balancer.models.BackendDetails(
+                    ip_address=b.ip_address,
+                    port=b.port,
+                    weight=b.weight,
+                    max_connections=b.max_connections,
+                    backup=b.backup,
+                    drain=b.drain,
+                    offline=b.offline,
+                )
+                for b in existing_backends
+            ]
+
+        # Health checker fields (preserve existing where not provided)
+        if current_bs:
+            existing_hc = getattr(current_bs, "health_checker", None)
+        else:
+            existing_hc = None
+        health_checker = oci.load_balancer.models.HealthCheckerDetails(
+            protocol=health_checker_protocol
+            or (existing_hc.protocol if existing_hc else None),
+            url_path=(
+                health_checker_url_path
+                if health_checker_url_path is not None
+                else (existing_hc.url_path if existing_hc else None)
+            ),
+            port=(
+                health_checker_port
+                if health_checker_port is not None
+                else (existing_hc.port if existing_hc else None)
+            ),
+            return_code=(
+                health_checker_return_code
+                if health_checker_return_code is not None
+                else (existing_hc.return_code if existing_hc else None)
+            ),
+            retries=(
+                health_checker_retries
+                if health_checker_retries is not None
+                else (existing_hc.retries if existing_hc else None)
+            ),
+            timeout_in_millis=(
+                health_checker_timeout_in_millis
+                if health_checker_timeout_in_millis is not None
+                else (existing_hc.timeout_in_millis if existing_hc else None)
+            ),
+            interval_in_millis=(
+                health_checker_interval_in_millis
+                if health_checker_interval_in_millis is not None
+                else (existing_hc.interval_in_millis if existing_hc else None)
+            ),
+            response_body_regex=(
+                health_checker_response_body_regex
+                if health_checker_response_body_regex is not None
+                else (existing_hc.response_body_regex if existing_hc else None)
+            ),
+            is_force_plain_text=(
+                health_checker_is_force_plain_text
+                if health_checker_is_force_plain_text is not None
+                else (existing_hc.is_force_plain_text if existing_hc else None)
+            ),
+        )
+
+        # SSL configuration
+        ssl_cfg = None
+        if any(
+            x is not None
+            for x in [
+                ssl_protocols,
+                ssl_cipher_suite_name,
+                ssl_server_order_preference,
+                ssl_certificate_name,
+                ssl_certificate_ids,
+                ssl_trusted_certificate_authority_ids,
+                ssl_has_session_resumption,
+                ssl_verify_peer_certificate,
+                ssl_verify_depth,
+            ]
+        ):
+            ssl_cfg = oci.load_balancer.models.SSLConfigurationDetails(
+                protocols=ssl_protocols,
+                cipher_suite_name=ssl_cipher_suite_name,
+                server_order_preference=ssl_server_order_preference,
+                certificate_name=ssl_certificate_name,
+                certificate_ids=ssl_certificate_ids,
+                trusted_certificate_authority_ids=ssl_trusted_certificate_authority_ids,
+                has_session_resumption=ssl_has_session_resumption,
+                verify_peer_certificate=ssl_verify_peer_certificate,
+                verify_depth=ssl_verify_depth,
+            )
+
+        # Session persistence
+        session_persistence = None
+        if any(
+            x is not None
+            for x in [
+                session_persistence_cookie_name,
+                session_persistence_disable_fallback,
+            ]
+        ):
+            session_persistence = (
+                oci.load_balancer.models.SessionPersistenceConfigurationDetails(
+                    cookie_name=session_persistence_cookie_name,
+                    disable_fallback=session_persistence_disable_fallback,
+                )
+            )
+
+        # LB cookie persistence
+        lb_cookie_persistence = None
+        if any(
+            x is not None
+            for x in [
+                lb_cookie_cookie_name,
+                lb_cookie_disable_fallback,
+                lb_cookie_domain,
+                lb_cookie_path,
+                lb_cookie_max_age_in_seconds,
+                lb_cookie_is_secure,
+                lb_cookie_is_http_only,
+            ]
+        ):
+            lb_cookie_persistence = (
+                oci.load_balancer.models.LBCookieSessionPersistenceConfigurationDetails(
+                    cookie_name=lb_cookie_cookie_name,
+                    disable_fallback=lb_cookie_disable_fallback,
+                    domain=lb_cookie_domain,
+                    path=lb_cookie_path,
+                    max_age_in_seconds=lb_cookie_max_age_in_seconds,
+                    is_secure=lb_cookie_is_secure,
+                    is_http_only=lb_cookie_is_http_only,
+                )
+            )
+
+        details = oci.load_balancer.models.UpdateBackendSetDetails(
+            policy=effective_policy,
+            backends=backend_details,
+            backend_max_connections=backend_max_connections,
+            health_checker=health_checker,
+            ssl_configuration=ssl_cfg,
+            session_persistence_configuration=session_persistence,
+            lb_cookie_session_persistence_configuration=lb_cookie_persistence,
+        )
+
+        response: oci.response.Response = client.update_backend_set(
+            details, load_balancer_id, name
+        )
+        logger.info("Update Backend Set request accepted")
+        return map_response(response)
+
+    except Exception as e:
+        logger.error(f"Error in update_load_balancer_backend_set tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="delete_load_balancer_backend_set",
+    description="Deletes a backend set from a load balancer",
+)
+def delete_load_balancer_backend_set(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=32,
+        description="The name of the backend set to delete",
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.delete_backend_set(
+            load_balancer_id, name
+        )
+        logger.info("Delete Backend Set request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in delete_load_balancer_backend_set tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="list_backends",
+    description="Lists the backends from the given backend set and load balancer",
+)
+def list_backends(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    backend_set_name: str = Field(..., description="The name of the backend set"),
+    limit: Optional[int] = Field(
+        None,
+        description="The maximum number of backends to return. If None, all are returned.",
+        ge=1,
+    ),
+) -> list[Backend]:
+    try:
+        client = get_load_balancer_client()
+        backends: list[Backend] = []
+        response: oci.response.Response = client.list_backends(
+            load_balancer_id, backend_set_name
+        )
+        items = getattr(response.data, "items", response.data) or []
+        for d in items:
+            backends.append(map_backend(d))
+            if limit is not None and len(backends) >= limit:
+                break
+        logger.info(f"Found {len(backends)} Backends")
+        return backends
+    except Exception as e:
+        logger.error(f"Error in list_backends tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="create_backend",
+    description="Adds a backend to a backend set",
+)
+def create_backend(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    backend_set_name: str = Field(..., description="The name of the backend set"),
+    ip_address: str = Field(..., description="IP address of the backend server"),
+    port: int = Field(..., description="Port of the backend server", ge=1, le=65535),
+    weight: Optional[int] = Field(
+        None, description="Load balancing weight for the backend", ge=1, le=100
+    ),
+    max_connections: Optional[int] = Field(
+        None, description="Maximum simultaneous connections for the backend"
+    ),
+    backup: Optional[bool] = Field(
+        None, description="Whether this backend is a backup"
+    ),
+    drain: Optional[bool] = Field(
+        None, description="Whether the backend is in drain mode"
+    ),
+    offline: Optional[bool] = Field(None, description="Whether the backend is offline"),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        details = oci.load_balancer.models.CreateBackendDetails(
+            ip_address=ip_address,
+            port=port,
+            weight=weight,
+            max_connections=max_connections,
+            backup=backup,
+            drain=drain,
+            offline=offline,
+        )
+        response: oci.response.Response = client.create_backend(
+            details, load_balancer_id, backend_set_name
+        )
+        logger.info("Create Backend request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in create_backend tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="get_backend",
+    description="Gets a backend by name from the given backend set and load balancer",
+)
+def get_backend(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    backend_set_name: str = Field(..., description="The name of the backend set"),
+    backend_name: str = Field(..., description="The name of the backend (IP:port)"),
+) -> Backend:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.get_backend(
+            load_balancer_id, backend_set_name, backend_name
+        )
+        data: oci.load_balancer.models.Backend = response.data
+        logger.info("Found Backend")
+        return map_backend(data)
+    except Exception as e:
+        logger.error(f"Error in get_backend tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="update_backend",
+    description="Updates a backend in a backend set",
+)
+def update_backend(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    backend_set_name: str = Field(..., description="The name of the backend set"),
+    backend_name: str = Field(..., description="The name of the backend (IP:port)"),
+    weight: Optional[int] = Field(
+        None, description="Load balancing weight for the backend", ge=1, le=100
+    ),
+    max_connections: Optional[int] = Field(
+        None, description="Maximum simultaneous connections for the backend"
+    ),
+    backup: Optional[bool] = Field(
+        None, description="Whether this backend is a backup"
+    ),
+    drain: Optional[bool] = Field(
+        None, description="Whether the backend is in drain mode"
+    ),
+    offline: Optional[bool] = Field(None, description="Whether the backend is offline"),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        details = oci.load_balancer.models.UpdateBackendDetails(
+            weight=weight,
+            max_connections=max_connections,
+            backup=backup,
+            drain=drain,
+            offline=offline,
+        )
+        response: oci.response.Response = client.update_backend(
+            details, load_balancer_id, backend_set_name, backend_name
+        )
+        logger.info("Update Backend request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in update_backend tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="delete_backend",
+    description="Deletes a backend from a backend set",
+)
+def delete_backend(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    backend_set_name: str = Field(..., description="The name of the backend set"),
+    backend_name: str = Field(..., description="The name of the backend (IP:port)"),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.delete_backend(
+            load_balancer_id, backend_set_name, backend_name
+        )
+        logger.info("Delete Backend request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in delete_backend tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="list_load_balancer_certificates",
+    description="Lists the certificates from the given load balancer",
+)
+def list_load_balancer_certificates(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    limit: Optional[int] = Field(
+        None,
+        description="The maximum number of certificates to return. If None, all are returned.",
+        ge=1,
+    ),
+) -> list[Certificate]:
+    try:
+        client = get_load_balancer_client()
+        certificates: list[Certificate] = []
+        response: oci.response.Response = client.list_certificates(load_balancer_id)
+        items = getattr(response.data, "items", response.data) or []
+        for d in items:
+            certificates.append(map_certificate(d))
+            if limit is not None and len(certificates) >= limit:
+                break
+        logger.info(f"Found {len(certificates)} Certificates")
+        return certificates
+    except Exception as e:
+        logger.error(f"Error in list_load_balancer_certificates tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="create_load_balancer_certificate",
+    description="Creates a new certificate for HTTPS termination on a load balancer",
+)
+def create_load_balancer_certificate(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    certificate_name: str = Field(
+        ..., description="A friendly name for the certificate"
+    ),
+    public_certificate: str = Field(..., description="Public certificate PEM contents"),
+    private_key: str = Field(..., description="Private key PEM contents"),
+    ca_certificate: Optional[str] = Field(
+        None,
+        description="CA certificate PEM contents (optional if using certificate bundle)",
+    ),
+    passphrase: Optional[str] = Field(
+        None, description="Passphrase for the private key if encrypted"
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        details = oci.load_balancer.models.CreateCertificateDetails(
+            certificate_name=certificate_name,
+            ca_certificate=ca_certificate,
+            public_certificate=public_certificate,
+            private_key=private_key,
+            passphrase=passphrase,
+        )
+        response: oci.response.Response = client.create_certificate(
+            details, load_balancer_id
+        )
+        logger.info("Create Certificate request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in create_load_balancer_certificate tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="delete_load_balancer_certificate",
+    description="Deletes a certificate from a load balancer",
+)
+def delete_load_balancer_certificate(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    certificate_name: str = Field(
+        ..., description="The name of the certificate to delete"
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.delete_certificate(
+            load_balancer_id, certificate_name
+        )
+        logger.info("Delete Certificate request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in delete_load_balancer_certificate tool: {str(e)}")
+        raise e
+
+
+# SSL Cipher Suite tools
+
+
+@mcp.tool(
+    name="list_ssl_cipher_suites",
+    description="Lists the SSL cipher suites from the given load balancer",
+)
+def list_ssl_cipher_suites(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    limit: Optional[int] = Field(
+        None,
+        description="Maximum number of cipher suites to return. If None, all are returned.",
+        ge=1,
+    ),
+) -> list[SSLCipherSuite]:
+    try:
+        client = get_load_balancer_client()
+        cipher_suites: list[SSLCipherSuite] = []
+        response: oci.response.Response = client.list_ssl_cipher_suites(
+            load_balancer_id
+        )
+        items = getattr(response.data, "items", response.data) or []
+        for d in items:
+            cipher_suites.append(map_ssl_cipher_suite(d))
+            if limit is not None and len(cipher_suites) >= limit:
+                break
+        logger.info(f"Found {len(cipher_suites)} SSL Cipher Suites")
+        return cipher_suites
+    except Exception as e:
+        logger.error(f"Error in list_ssl_cipher_suites tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="create_ssl_cipher_suite",
+    description="Creates a new SSL cipher suite for a load balancer",
+)
+def create_ssl_cipher_suite(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Friendly name for the SSL cipher suite"),
+    ciphers: list[str] = Field(..., description="List of cipher names for the suite"),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        details = oci.load_balancer.models.CreateSSLCipherSuiteDetails(
+            name=name,
+            ciphers=ciphers,
+        )
+        response: oci.response.Response = client.create_ssl_cipher_suite(
+            details, load_balancer_id
+        )
+        logger.info("Create SSL Cipher Suite request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in create_ssl_cipher_suite tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="get_ssl_cipher_suite",
+    description="Gets an SSL cipher suite by name from a load balancer",
+)
+def get_ssl_cipher_suite(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Name of the SSL cipher suite to retrieve"),
+) -> SSLCipherSuite:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.get_ssl_cipher_suite(
+            load_balancer_id, name
+        )
+        data: oci.load_balancer.models.SSLCipherSuite = response.data
+        logger.info("Found SSL Cipher Suite")
+        return map_ssl_cipher_suite(data)
+    except Exception as e:
+        logger.error(f"Error in get_ssl_cipher_suite tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="update_ssl_cipher_suite",
+    description="Updates an existing SSL cipher suite for a load balancer",
+)
+def update_ssl_cipher_suite(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Name of the SSL cipher suite to update"),
+    ciphers: Optional[list[str]] = Field(
+        None, description="Updated list of cipher names for the suite"
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        details = oci.load_balancer.models.UpdateSSLCipherSuiteDetails(
+            ciphers=ciphers,
+        )
+        response: oci.response.Response = client.update_ssl_cipher_suite(
+            details, load_balancer_id, name
+        )
+        logger.info("Update SSL Cipher Suite request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in update_ssl_cipher_suite tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="delete_ssl_cipher_suite",
+    description="Deletes an SSL cipher suite from a load balancer",
+)
+def delete_ssl_cipher_suite(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Name of the SSL cipher suite to delete"),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.delete_ssl_cipher_suite(
+            load_balancer_id, name
+        )
+        logger.info("Delete SSL Cipher Suite request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in delete_ssl_cipher_suite tool: {str(e)}")
+        raise e
+
+
+# -------------------------------------------------------------------------
+# Advanced routing and rule tools
+# -------------------------------------------------------------------------
+
+# Hostname tools
+
+
+@mcp.tool(
+    name="list_hostnames",
+    description="Lists the hostnames from the given load balancer",
+)
+def list_hostnames(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    limit: Optional[int] = Field(
+        None,
+        description="Maximum number of hostnames to return. If None, all are returned.",
+        ge=1,
+    ),
+) -> list[Hostname]:
+    try:
+        client = get_load_balancer_client()
+        hostnames: list[Hostname] = []
+        response: oci.response.Response = client.list_hostnames(load_balancer_id)
+        items = getattr(response.data, "items", response.data) or []
+        for d in items:
+            hostnames.append(map_hostname(d))
+            if limit is not None and len(hostnames) >= limit:
+                break
+        logger.info(f"Found {len(hostnames)} Hostnames")
+        return hostnames
+    except Exception as e:
+        logger.error(f"Error in list_hostnames tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="create_hostname",
+    description="Creates a new hostname resource for a load balancer",
+)
+def create_hostname(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Unique name for the hostname resource"),
+    hostname: str = Field(..., description="Virtual hostname (e.g., app.example.com)"),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        details = oci.load_balancer.models.CreateHostnameDetails(
+            name=name,
+            hostname=hostname,
+        )
+        response: oci.response.Response = client.create_hostname(
+            details, load_balancer_id
+        )
+        logger.info("Create Hostname request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in create_hostname tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="get_hostname",
+    description="Gets a hostname resource by name from a load balancer",
+)
+def get_hostname(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Name of the hostname resource"),
+) -> Hostname:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.get_hostname(load_balancer_id, name)
+        data = response.data
+        logger.info("Found Hostname")
+        return map_hostname(data)
+    except Exception as e:
+        logger.error(f"Error in get_hostname tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="update_hostname",
+    description="Updates an existing hostname resource",
+)
+def update_hostname(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Name of the hostname resource to update"),
+    hostname: Optional[str] = Field(
+        None, description="New virtual hostname (e.g., app.example.com)"
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        details = oci.load_balancer.models.UpdateHostnameDetails(
+            hostname=hostname,
+        )
+        response: oci.response.Response = client.update_hostname(
+            details, load_balancer_id, name
+        )
+        logger.info("Update Hostname request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in update_hostname tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="delete_hostname",
+    description="Deletes a hostname resource from a load balancer",
+)
+def delete_hostname(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Name of the hostname resource to delete"),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.delete_hostname(load_balancer_id, name)
+        logger.info("Delete Hostname request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in delete_hostname tool: {str(e)}")
+        raise e
+
+
+# Rule Set tools
+
+
+@mcp.tool(
+    name="list_rule_sets",
+    description="Lists the rule sets from the given load balancer",
+)
+def list_rule_sets(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    limit: Optional[int] = Field(
+        None,
+        description="Maximum number of rule sets to return. If None, all are returned.",
+        ge=1,
+    ),
+) -> list[RuleSet]:
+    try:
+        client = get_load_balancer_client()
+        rule_sets: list[RuleSet] = []
+        response: oci.response.Response = client.list_rule_sets(load_balancer_id)
+        items = getattr(response.data, "items", response.data) or []
+        for d in items:
+            rule_sets.append(map_rule_set(d))
+            if limit is not None and len(rule_sets) >= limit:
+                break
+
+        logger.info(f"Found {len(rule_sets)} Rule Sets")
+        return rule_sets
+    except Exception as e:
+        logger.error(f"Error in list_rule_sets tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="create_rule_set",
+    description="Creates a new rule set for a load balancer",
+)
+def create_rule_set(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Unique name for the rule set"),
+    items: Optional[list[dict]] = Field(
+        None,
+        description="List of rule definitions (raw dicts) to include in the rule set",
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        details = oci.load_balancer.models.CreateRuleSetDetails(
+            name=name,
+            items=items,
+        )
+        response: oci.response.Response = client.create_rule_set(
+            load_balancer_id, details
+        )
+        logger.info("Create Rule Set request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in create_rule_set tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="get_rule_set",
+    description="Gets a rule set by name from a load balancer",
+)
+def get_rule_set(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Name of the rule set"),
+) -> RuleSet:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.get_rule_set(load_balancer_id, name)
+        data = response.data
+        logger.info("Found Rule Set")
+        return map_rule_set(data)
+    except Exception as e:
+        logger.error(f"Error in get_rule_set tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="update_rule_set",
+    description="Updates an existing rule set",
+)
+def update_rule_set(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Name of the rule set to update"),
+    items: Optional[list[dict]] = Field(
+        None,
+        description="Updated list of rule definitions (raw dicts)",
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        details = oci.load_balancer.models.UpdateRuleSetDetails(
+            items=items,
+        )
+        response: oci.response.Response = client.update_rule_set(
+            load_balancer_id, name, details
+        )
+        logger.info("Update Rule Set request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in update_rule_set tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="delete_rule_set",
+    description="Deletes a rule set from a load balancer",
+)
+def delete_rule_set(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Name of the rule set to delete"),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.delete_rule_set(load_balancer_id, name)
+        logger.info("Delete Rule Set request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in delete_rule_set tool: {str(e)}")
+        raise e
+
+
+# Routing Policy tools
+
+
+@mcp.tool(
+    name="list_routing_policies",
+    description="Lists the routing policies from the given load balancer",
+)
+def list_routing_policies(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    limit: Optional[int] = Field(
+        None,
+        description="Maximum number of routing policies to return. If None, all are returned.",
+        ge=1,
+    ),
+) -> list[RoutingPolicy]:
+    try:
+        client = get_load_balancer_client()
+        policies: list[RoutingPolicy] = []
+        next_page: Optional[str] = None
+        first_page = True
+
+        while first_page or (next_page and (limit is None or len(policies) < limit)):
+            first_page = False
+            page_limit = None if limit is None else max(1, limit - len(policies))
+            response = client.list_routing_policies(
+                load_balancer_id, limit=page_limit, page=next_page
+            )
+            items = getattr(response.data, "items", response.data) or []
+            remaining = None if limit is None else max(0, limit - len(policies))
+            to_process = items if remaining is None else items[:remaining]
+            for d in to_process:
+                policies.append(map_routing_policy(d))
+            next_page = getattr(response, "next_page", None)
+
+        logger.info(f"Found {len(policies)} Routing Policies")
+        return policies
+    except Exception as e:
+        logger.error(f"Error in list_routing_policies tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="create_routing_policy",
+    description="Creates a new routing policy for a load balancer",
+)
+def create_routing_policy(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Unique name for the routing policy"),
+    condition_language_version: Optional[Literal["V1", "UNKNOWN_ENUM_VALUE"]] = Field(
+        None, description="Version of the routing condition language"
+    ),
+    rules: Optional[list[dict]] = Field(
+        None, description="List of routing rule definitions (raw dicts)"
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        details = oci.load_balancer.models.CreateRoutingPolicyDetails(
+            name=name,
+            condition_language_version=condition_language_version,
+            rules=rules,
+        )
+        response: oci.response.Response = client.create_routing_policy(
+            details, load_balancer_id
+        )
+        logger.info("Create Routing Policy request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in create_routing_policy tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="get_routing_policy",
+    description="Gets a routing policy by name from a load balancer",
+)
+def get_routing_policy(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Name of the routing policy"),
+) -> RoutingPolicy:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.get_routing_policy(
+            load_balancer_id, name
+        )
+        data = response.data
+        logger.info("Found Routing Policy")
+        return map_routing_policy(data)
+    except Exception as e:
+        logger.error(f"Error in get_routing_policy tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="update_routing_policy",
+    description="Updates an existing routing policy",
+)
+def update_routing_policy(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Name of the routing policy to update"),
+    condition_language_version: Optional[Literal["V1", "UNKNOWN_ENUM_VALUE"]] = Field(
+        None, description="Version of the routing condition language"
+    ),
+    rules: Optional[list[dict]] = Field(
+        None, description="Updated list of routing rule definitions (raw dicts)"
+    ),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        details = oci.load_balancer.models.UpdateRoutingPolicyDetails(
+            condition_language_version=condition_language_version,
+            rules=rules,
+        )
+        response: oci.response.Response = client.update_routing_policy(
+            details, load_balancer_id, name
+        )
+        logger.info("Update Routing Policy request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in update_routing_policy tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="delete_routing_policy",
+    description="Deletes a routing policy from a load balancer",
+)
+def delete_routing_policy(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    name: str = Field(..., description="Name of the routing policy to delete"),
+) -> Response:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.delete_routing_policy(
+            load_balancer_id, name
+        )
+        logger.info("Delete Routing Policy request accepted")
+        return map_response(response)
+    except Exception as e:
+        logger.error(f"Error in delete_routing_policy tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="get_load_balancer_health",
+    description="Get health status of a load balancer",
+)
+def get_load_balancer_health(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer")
+) -> LoadBalancerHealth:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.get_load_balancer_health(
+            load_balancer_id
+        )
+        data = response.data
+        logger.info("Retrieved Load Balancer health")
+        return map_load_balancer_health(data)
+    except Exception as e:
+        logger.error(f"Error in get_load_balancer_health tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="get_backend_set_health",
+    description="Get health status of a backend set within a load balancer",
+)
+def get_backend_set_health(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    backend_set_name: str = Field(..., description="The name of the backend set"),
+) -> BackendSetHealth:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.get_backend_set_health(
+            load_balancer_id, backend_set_name
+        )
+        data = response.data
+        logger.info("Retrieved Backend Set health")
+        return map_backend_set_health(data)
+    except Exception as e:
+        logger.error(f"Error in get_backend_set_health tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="get_backend_health",
+    description="Get health status of a specific backend within a backend set",
+)
+def get_backend_health(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    backend_set_name: str = Field(..., description="The name of the backend set"),
+    backend_name: str = Field(..., description="The name of the backend (IP:port)"),
+) -> BackendHealth:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.get_backend_health(
+            load_balancer_id, backend_set_name, backend_name
+        )
+        data = response.data
+        logger.info("Retrieved Backend health")
+        return map_backend_health(data)
+    except Exception as e:
+        logger.error(f"Error in get_backend_health tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="list_load_balancer_healths",
+    description="List health summaries for all load balancers in a compartment",
+)
+def list_load_balancer_healths(
+    compartment_id: str = Field(..., description="The OCID of the compartment"),
+    limit: Optional[int] = Field(
+        None,
+        description="Maximum number of health summaries to return. If None, no limit.",
+        ge=1,
+    ),
+) -> list[LoadBalancerHealthSummary]:
+    health_summaries: list[LoadBalancerHealthSummary] = []
+    try:
+        client = get_load_balancer_client()
+        next_page: Optional[str] = None
+        first_page = True
+        while first_page or (
+            next_page and (limit is None or len(health_summaries) < limit)
+        ):
+            first_page = False
+            page_limit = (
+                None if limit is None else max(1, limit - len(health_summaries))
+            )
+            response: oci.response.Response = client.list_load_balancer_healths(
+                compartment_id, limit=page_limit, page=next_page
+            )
+            items = getattr(response.data, "items", response.data) or []
+            remaining = None if limit is None else max(0, limit - len(health_summaries))
+            to_process = items if remaining is None else items[:remaining]
+            for d in to_process:
+                health_summaries.append(map_load_balancer_health_summary(d))
+            next_page = getattr(response, "next_page", None)
+        logger.info(f"Found {len(health_summaries)} Load Balancer health summaries")
+        return health_summaries
+    except Exception as e:
+        logger.error(f"Error in list_load_balancer_healths tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="list_load_balancer_work_requests",
+    description="List work requests for a given load balancer",
+)
+def list_load_balancer_work_requests(
+    load_balancer_id: str = Field(..., description="The OCID of the load balancer"),
+    limit: Optional[int] = Field(
+        None,
+        description="Maximum number of work requests to return. If None, no limit.",
+        ge=1,
+    ),
+) -> list[WorkRequest]:
+    work_requests: list[WorkRequest] = []
+    try:
+        client = get_load_balancer_client()
+        next_page: Optional[str] = None
+        first_page = True
+        while first_page or (
+            next_page and (limit is None or len(work_requests) < limit)
+        ):
+            first_page = False
+            page_limit = None if limit is None else max(1, limit - len(work_requests))
+            response: oci.response.Response = client.list_work_requests(
+                load_balancer_id, limit=page_limit, page=next_page
+            )
+            items = getattr(response.data, "items", response.data) or []
+            remaining = None if limit is None else max(0, limit - len(work_requests))
+            to_process = items if remaining is None else items[:remaining]
+            for d in to_process:
+                work_requests.append(map_work_request(d))
+            next_page = getattr(response, "next_page", None)
+        logger.info(f"Found {len(work_requests)} Load Balancer work requests")
+        return work_requests
+    except Exception as e:
+        logger.error(f"Error in list_load_balancer_work_requests tool: {str(e)}")
+        raise e
+
+
+@mcp.tool(
+    name="get_load_balancer_work_request",
+    description="Get details of a specific load balancer work request",
+)
+def get_load_balancer_work_request(
+    work_request_id: str = Field(..., description="The OCID of the work request")
+) -> WorkRequest:
+    try:
+        client = get_load_balancer_client()
+        response: oci.response.Response = client.get_work_request(work_request_id)
+        data = response.data
+        logger.info("Retrieved Load Balancer work request")
+        return map_work_request(data)
+    except Exception as e:
+        logger.error(f"Error in get_load_balancer_work_request tool: {str(e)}")
+        raise e
+
+
+def main():
+
+    host = os.getenv("ORACLE_MCP_HOST")
+    port = os.getenv("ORACLE_MCP_PORT")
+
+    if host and port:
+        mcp.run(transport="http", host=host, port=int(port))
+    else:
+        mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/tests/test_load_balancer_models.py
+++ b/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/tests/test_load_balancer_models.py
@@ -1,0 +1,428 @@
+"""
+Unit tests for the model mapping functions in ``models.py`` of the OCI Load Balancer MCP server.
+
+The tests construct lightweight mock objects that mimic the attributes of OCI SDK models
+and verify that the ``map_*`` functions correctly translate them into the corresponding
+Pydantic models. All tests are asynchronous and marked with ``@pytest.mark.asyncio``.
+"""
+
+import types
+
+import pytest
+from oracle.oci_load_balancer_mcp_server import models
+
+
+def make_obj(**attrs):
+    """Utility to create a simple object with given attributes."""
+    return types.SimpleNamespace(**attrs)
+
+
+@pytest.mark.asyncio
+async def test_map_ip_address():
+    ip_obj = make_obj(
+        ip_address="10.0.0.1", is_public=True, reserved_ip=make_obj(id="reserved_ocid")
+    )
+    result = models.map_ip_address(ip_obj)
+    assert result.ip_address == "10.0.0.1"
+    assert result.is_public is True
+    assert result.reserved_ip.id == "reserved_ocid"
+
+
+@pytest.mark.asyncio
+async def test_map_shape_details():
+    shape_obj = make_obj(minimum_bandwidth_in_mbps=100, maximum_bandwidth_in_mbps=200)
+    result = models.map_shape_details(shape_obj)
+    assert result.minimum_bandwidth_in_mbps == 100
+    assert result.maximum_bandwidth_in_mbps == 200
+
+
+@pytest.mark.asyncio
+async def test_map_connection_configuration():
+    conn_obj = make_obj(
+        idle_timeout=30,
+        backend_tcp_proxy_protocol_version=1,
+        backend_tcp_proxy_protocol_options=["PP2_TYPE_AUTHORITY"],
+    )
+    result = models.map_connection_configuration(conn_obj)
+    assert result.idle_timeout == 30
+    assert result.backend_tcp_proxy_protocol_version == 1
+    assert result.backend_tcp_proxy_protocol_options == ["PP2_TYPE_AUTHORITY"]
+
+
+@pytest.mark.asyncio
+async def test_map_ssl_configuration():
+    ssl_obj = make_obj(
+        verify_depth=3,
+        verify_peer_certificate=True,
+        has_session_resumption=False,
+        trusted_certificate_authority_ids=["ca1"],
+        certificate_ids=["cert1"],
+        certificate_name="mycert",
+        server_order_preference="ENABLED",
+        cipher_suite_name="TLS_AES_128_GCM_SHA256",
+        protocols=["TLSv1.2", "TLSv1.3"],
+    )
+    result = models.map_ssl_configuration(ssl_obj)
+    assert result.verify_depth == 3
+    assert result.verify_peer_certificate is True
+    assert result.has_session_resumption is False
+    assert result.trusted_certificate_authority_ids == ["ca1"]
+    assert result.certificate_ids == ["cert1"]
+    assert result.certificate_name == "mycert"
+    assert result.server_order_preference == "ENABLED"
+    assert result.cipher_suite_name == "TLS_AES_128_GCM_SHA256"
+    assert result.protocols == ["TLSv1.2", "TLSv1.3"]
+
+
+@pytest.mark.asyncio
+async def test_map_backend():
+    backend_obj = make_obj(
+        name="backend1",
+        ip_address="10.0.0.2",
+        port=8080,
+        weight=5,
+        max_connections=100,
+        drain=False,
+        backup=True,
+        offline=False,
+    )
+    result = models.map_backend(backend_obj)
+    assert result.name == "backend1"
+    assert result.ip_address == "10.0.0.2"
+    assert result.port == 8080
+    assert result.weight == 5
+    assert result.max_connections == 100
+    assert result.drain is False
+    assert result.backup is True
+    assert result.offline is False
+
+
+@pytest.mark.asyncio
+async def test_map_health_checker():
+    hc_obj = make_obj(
+        protocol="HTTP",
+        url_path="/health",
+        port=8080,
+        return_code=200,
+        retries=3,
+        timeout_in_millis=5000,
+        interval_in_millis=10000,
+        response_body_regex="OK",
+        is_force_plain_text=False,
+    )
+    result = models.map_health_checker(hc_obj)
+    assert result.protocol == "HTTP"
+    assert result.url_path == "/health"
+    assert result.port == 8080
+    assert result.return_code == 200
+    assert result.retries == 3
+    assert result.timeout_in_millis == 5000
+    assert result.interval_in_millis == 10000
+    assert result.response_body_regex == "OK"
+    assert result.is_force_plain_text is False
+
+
+@pytest.mark.asyncio
+async def test_map_certificate():
+    cert_obj = make_obj(
+        certificate_name="cert1",
+        public_certificate="---PUBLIC---",
+        ca_certificate="---CA---",
+    )
+    result = models.map_certificate(cert_obj)
+    assert result.certificate_name == "cert1"
+    assert result.public_certificate == "---PUBLIC---"
+    assert result.ca_certificate == "---CA---"
+
+
+@pytest.mark.asyncio
+async def test_map_listener():
+    listener_obj = make_obj(
+        name="listener1",
+        default_backend_set_name="bs1",
+        port=80,
+        protocol="HTTP",
+        hostname_names=["host1"],
+        path_route_set_name=None,
+        ssl_configuration=make_obj(protocols=["TLSv1.2"]),
+        connection_configuration=make_obj(idle_timeout=30),
+        rule_set_names=["rs1"],
+        routing_policy_name="rp1",
+    )
+    result = models.map_listener(listener_obj)
+    assert result.name == "listener1"
+    assert result.default_backend_set_name == "bs1"
+    assert result.port == 80
+    assert result.protocol == "HTTP"
+    assert result.hostname_names == ["host1"]
+    assert result.path_route_set_name is None
+    assert result.ssl_configuration.protocols == ["TLSv1.2"]
+    assert result.connection_configuration.idle_timeout == 30
+    assert result.rule_set_names == ["rs1"]
+    assert result.routing_policy_name == "rp1"
+
+
+@pytest.mark.asyncio
+async def test_map_rule_set(monkeypatch):
+    # Ensure _oci_to_dict returns a plain dict for simple objects to avoid TypeError
+    monkeypatch.setattr(
+        models,
+        "_oci_to_dict",
+        lambda obj: obj if isinstance(obj, dict) else getattr(obj, "__dict__", None),
+    )
+    rule_set_obj = make_obj(
+        name="rs1",
+        items=[make_obj(action="ADD_HTTP_REQUEST_HEADER", header="X-Test")],
+    )
+    result = models.map_rule_set(rule_set_obj)
+    assert result.name == "rs1"
+    assert len(result.items) == 1
+    assert result.items[0].action == "ADD_HTTP_REQUEST_HEADER"
+    # fields preserves raw, minus the 'action' key if present
+    assert result.items[0].fields == {"header": "X-Test"}
+
+
+@pytest.mark.asyncio
+async def test_map_routing_policy():
+    rule_obj = make_obj(
+        name="rule1",
+        condition="true",
+        actions=[make_obj(name="FORWARD_TO_BACKENDSET", backend_set_name="bs1")],
+    )
+    policy_obj = make_obj(
+        name="policy1", condition_language_version="V1", rules=[rule_obj]
+    )
+    result = models.map_routing_policy(policy_obj)
+    assert result.name == "policy1"
+    assert result.condition_language_version == "V1"
+    assert len(result.rules) == 1
+    assert result.rules[0].name == "rule1"
+    assert result.rules[0].condition == "true"
+    assert isinstance(result.rules[0].actions[0], models.ForwardToBackendSet)
+    assert result.rules[0].actions[0].backend_set_name == "bs1"
+
+
+@pytest.mark.asyncio
+async def test_map_response_and_pagination_headers():
+    # Simulate an OCI response with nested data
+    inner_lb = make_obj(id="lb_ocid")
+    resp_obj = make_obj(
+        status=200,
+        headers={"opc-request-id": "req123", "opc-next-page": None},
+        data=inner_lb,
+        request=make_obj(method="GET", url="http://example.com"),
+        next_page=None,
+        request_id=None,
+    )
+    result = models.map_response(resp_obj)
+    assert result.status == 200
+    assert result.headers["opc-request-id"] == "req123"
+    # data may be a mapped Pydantic model or a plain dict depending on type detection
+    assert (isinstance(result.data, dict) and result.data.get("id") == "lb_ocid") or (
+        getattr(result.data, "id", None) == "lb_ocid"
+    )
+    assert result.request.method == "GET"
+    assert result.request.url == "http://example.com"
+    assert result.has_next_page is False
+
+
+@pytest.mark.asyncio
+async def test_map_load_balancer_full_structure():
+    lb_obj = make_obj(
+        id="lb1",
+        compartment_id="comp1",
+        display_name="my-lb",
+        lifecycle_state="ACTIVE",
+        time_created=None,
+        ip_addresses=[make_obj(ip_address="1.2.3.4", is_public=True, reserved_ip=None)],
+        shape_name="Flexible",
+        shape_details=make_obj(
+            minimum_bandwidth_in_mbps=10, maximum_bandwidth_in_mbps=100
+        ),
+        is_private=False,
+        is_delete_protection_enabled=False,
+        is_request_id_enabled=True,
+        request_id_header="X-Req-Id",
+        subnet_ids=["sub1"],
+        network_security_group_ids=["nsg1"],
+        listeners={"lsn": make_obj(name="lsn", port=80, protocol="HTTP")},
+        hostnames={"h": make_obj(name="h", hostname="app.example.com")},
+        ssl_cipher_suites={"s": make_obj(name="s", ciphers=["C1"])},
+        certificates={"c": make_obj(certificate_name="c", public_certificate="P")},
+        backend_sets={"bs": make_obj(name="bs", policy="ROUND_ROBIN", backends=[])},
+        path_route_sets={"prs": make_obj(name="prs", path_routes=[])},
+        rule_sets={"rs": make_obj(name="rs", items=[])},
+        routing_policies={"rp": make_obj(name="rp", rules=[])},
+        freeform_tags={"env": "dev"},
+        defined_tags={"ns": {"k": "v"}},
+        security_attributes=None,
+        system_tags=None,
+        ip_mode="IPV4",
+    )
+    result = models.map_load_balancer(lb_obj)
+    assert result.id == "lb1"
+    assert result.display_name == "my-lb"
+    assert result.ip_addresses[0].ip_address == "1.2.3.4"
+    assert result.shape_details.minimum_bandwidth_in_mbps == 10
+    assert result.listeners["lsn"].port == 80
+    assert result.backend_sets["bs"].policy == "ROUND_ROBIN"
+    assert result.ip_mode == "IPV4"
+
+
+@pytest.mark.asyncio
+async def test_map_health_and_work_request_models():
+    # Backend/BackendSet/LoadBalancer health mapping
+    hcr = make_obj(
+        subnet_id="sub1",
+        source_ip_address="10.0.0.2",
+        timestamp=None,
+        health_check_status="OK",
+    )
+    bh = make_obj(status="OK", health_check_results=[hcr])
+    bsh = make_obj(
+        status="WARNING",
+        warning_state_backend_names=["b1"],
+        critical_state_backend_names=["b2"],
+        unknown_state_backend_names=["b3"],
+        total_backend_count=3,
+    )
+    lbh = make_obj(
+        status="CRITICAL",
+        warning_state_backend_set_names=["bs1"],
+        critical_state_backend_set_names=["bs2"],
+        unknown_state_backend_set_names=["bs3"],
+        total_backend_set_count=3,
+    )
+    lbs = make_obj(load_balancer_id="lb1", status="UNKNOWN")
+
+    mapped_bh = models.map_backend_health(bh)
+    mapped_bsh = models.map_backend_set_health(bsh)
+    mapped_lbh = models.map_load_balancer_health(lbh)
+    mapped_lbs = models.map_load_balancer_health_summary(lbs)
+
+    assert mapped_bh.status == "OK"
+    assert mapped_bh.health_check_results[0].health_check_status == "OK"
+    assert mapped_bsh.total_backend_count == 3
+    assert mapped_lbh.status == "CRITICAL"
+    assert mapped_lbs.load_balancer_id == "lb1"
+
+    # Work request mapping
+    wre = make_obj(error_code="BAD_INPUT", message="oops")
+    wr = make_obj(
+        id="wr1",
+        load_balancer_id="lb1",
+        type="CREATE",
+        compartment_id="comp1",
+        lifecycle_state="ACCEPTED",
+        message="ok",
+        time_accepted=None,
+        time_finished=None,
+        error_details=[wre],
+    )
+    mapped_wr = models.map_work_request(wr)
+    assert mapped_wr.id == "wr1"
+    assert mapped_wr.error_details[0].error_code == "BAD_INPUT"
+
+
+@pytest.mark.asyncio
+async def test_oci_to_dict_variants(monkeypatch):
+    # None yields None
+    assert models._oci_to_dict(None) is None
+    # dict passthrough
+    d = {"a": 1}
+    assert models._oci_to_dict(d) == d
+
+    # When oci.util.to_dict is available, it may return the object unchanged for
+    # unknown types; in that case, ensure we can still access attributes.
+    obj = make_obj(x=1, _private=2)
+    out = models._oci_to_dict(obj)
+    assert (isinstance(out, dict) and out.get("x") == 1) or getattr(out, "x", None) == 1
+
+    # Force fallback branch (oci.util.to_dict raises) to verify underscore filtering
+    import oci as _oci_module
+
+    def _raise(_):
+        raise RuntimeError("force fallback")
+
+    monkeypatch.setattr(_oci_module.util, "to_dict", _raise)
+    out2 = models._oci_to_dict(obj)
+    assert out2 == {"x": 1}
+
+
+@pytest.mark.asyncio
+async def test_map_headers_variants(monkeypatch):
+    class HeadersObj:
+        def items(self):
+            return [("k", "v")]
+
+    assert models._map_headers({"a": 1}) == {"a": 1}
+    assert models._map_headers(HeadersObj()) == {"k": "v"}
+
+    # Fallback to _oci_to_dict when .items not available; it may return either a dict
+    # or the original object depending on the environment. Accept either shape.
+    raw = make_obj(a=1)
+    out = models._map_headers(raw)
+    assert (isinstance(out, dict) and out.get("a") == 1) or getattr(out, "a", None) == 1
+
+    # Force explicit dict via fallback path
+    monkeypatch.setattr(models, "_oci_to_dict", lambda obj: {"a": 1})
+    assert models._map_headers(raw) == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_map_response_next_page_and_request_id_from_attrs():
+    resp = make_obj(
+        status=200,
+        headers=None,
+        data=None,
+        request=None,
+        next_page="np",
+        request_id="rid",
+    )
+    out = models.map_response(resp)
+    assert out.next_page == "np"
+    assert out.request_id == "rid"
+    assert out.has_next_page is True
+
+
+@pytest.mark.asyncio
+async def test_map_response_data_list_and_primitives():
+    # list of primitives should be returned as-is
+    lst = [1, "a", True]
+    # use private helper via map_response
+    resp = make_obj(status=200, headers=None, data=lst, request=None)
+    out = models.map_response(resp)
+    assert out.data == lst
+
+
+@pytest.mark.asyncio
+async def test_map_action_unknown_preserves_details(monkeypatch):
+    # Ensure details dict is produced regardless of oci.util behavior
+    monkeypatch.setattr(
+        models,
+        "_oci_to_dict",
+        lambda obj: {"header": "X-Test", "value": "1", "name": "ADD_HEADER"},
+    )
+    act = make_obj(name="ADD_HEADER", header="X-Test", value="1")
+    mapped = models.map_action(act)
+    assert mapped.name == "ADD_HEADER"
+    assert isinstance(mapped.details, dict)
+    assert mapped.details["header"] == "X-Test"
+
+
+@pytest.mark.asyncio
+async def test_map_path_route_set_and_routes():
+    prs = make_obj(
+        name="prs1",
+        path_routes=[
+            make_obj(
+                path="/api",
+                path_match_type=make_obj(match_type="PREFIX_MATCH"),
+                backend_set_name="bs",
+            )
+        ],
+    )
+    mapped = models.map_path_route_set(prs)
+    assert mapped.name == "prs1"
+    assert mapped.path_routes[0].path == "/api"
+    assert mapped.path_routes[0].path_match_type.match_type == "PREFIX_MATCH"

--- a/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/tests/test_load_balancer_tools.py
+++ b/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/tests/test_load_balancer_tools.py
@@ -1,0 +1,1381 @@
+"""
+Unit tests for the OCI Load Balancer MCP server tools (server.py).
+
+The tests mock the underlying OCI client returned by ``get_load_balancer_client`` and
+verify that each tool forwards the correct parameters and returns the mapped
+Pydantic models.  All tests are asynchronous and marked with ``@pytest.mark.asyncio``.
+"""
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import the server module where the tools are defined
+from oracle.oci_load_balancer_mcp_server import server
+
+
+class MockResponse:
+    """Simple mock of an OCI response object."""
+
+    def __init__(
+        self, data=None, headers=None, status=200, request_id=None, next_page=None
+    ):
+        self.data = data
+        self.headers = headers or {}
+        self.status = status
+        self.request_id = request_id
+        self.next_page = next_page
+
+
+@pytest.fixture(autouse=True)
+def mock_client(monkeypatch):
+    """Patch ``get_load_balancer_client`` to return a MagicMock client and stub OCI model classes."""
+    # Stub OCI SDK model constructors to accept any kwargs (avoid strict validations during tests)
+    import oci
+
+    class _Dummy:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    m = oci.load_balancer.models
+    for name in [
+        "ShapeDetails",
+        "CreateLoadBalancerDetails",
+        "UpdateLoadBalancerDetails",
+        "UpdateLoadBalancerShapeDetails",
+        "SSLConfigurationDetails",
+        "ConnectionConfiguration",
+        "CreateListenerDetails",
+        "UpdateListenerDetails",
+        "HealthCheckerDetails",
+        "SessionPersistenceConfigurationDetails",
+        "LBCookieSessionPersistenceConfigurationDetails",
+        "BackendDetails",
+        "CreateBackendSetDetails",
+        "UpdateBackendSetDetails",
+        "CreateBackendDetails",
+        "UpdateBackendDetails",
+        "CreateCertificateDetails",
+        "CreateSSLCipherSuiteDetails",
+        "UpdateSSLCipherSuiteDetails",
+        "CreateHostnameDetails",
+        "UpdateHostnameDetails",
+        "CreateRuleSetDetails",
+        "UpdateRuleSetDetails",
+        "CreateRoutingPolicyDetails",
+        "UpdateRoutingPolicyDetails",
+    ]:
+        monkeypatch.setattr(m, name, _Dummy, raising=True)
+
+    with patch.object(server, "get_load_balancer_client") as get_client:
+        mock = MagicMock()
+        get_client.return_value = mock
+        yield mock
+
+
+# ----------------------------------------------------------------------
+# Load Balancer tools
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_load_balancers(mock_client):
+    mock_lb = types.SimpleNamespace(id="lb_ocid")
+    mock_client.list_load_balancers.return_value = MockResponse(data=[mock_lb])
+
+    result = server.list_load_balancers.fn(
+        compartment_id="compartment_ocid",
+        limit=None,
+        lifecycle_state=None,
+        display_name=None,
+        sort_by=None,
+        sort_order=None,
+    )
+
+    mock_client.list_load_balancers.assert_called_once()
+    assert isinstance(result, list)
+    assert result[0].id == "lb_ocid"
+
+
+@pytest.mark.asyncio
+async def test_list_load_balancers_pagination(mock_client):
+    # First page with next_page, second page without
+    page1 = MockResponse(data=[types.SimpleNamespace(id="lb1")], next_page="token")
+    page2 = MockResponse(data=[types.SimpleNamespace(id="lb2")], next_page=None)
+    mock_client.list_load_balancers.side_effect = [page1, page2]
+
+    result = server.list_load_balancers.fn(
+        compartment_id="compartment_ocid",
+        limit=None,
+    )
+    assert [lb.id for lb in result] == ["lb1", "lb2"]
+
+
+@pytest.mark.asyncio
+async def test_list_load_balancers_limit_stops_early(mock_client):
+    # next_page provided but limit should stop pagination after first page slice
+    page1 = MockResponse(
+        data=[types.SimpleNamespace(id="lb1"), types.SimpleNamespace(id="lb2")],
+        next_page="token",
+    )
+    mock_client.list_load_balancers.return_value = page1
+    out = server.list_load_balancers.fn(compartment_id="c", limit=1)
+    assert [lb.id for lb in out] == ["lb1"]
+    mock_client.list_load_balancers.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_load_balancer_listener_not_found(mock_client):
+    mock_client.get_load_balancer.return_value = MockResponse(
+        data=types.SimpleNamespace(listeners={})
+    )
+    with pytest.raises(ValueError):
+        server.get_load_balancer_listener.fn(
+            load_balancer_id="lb_ocid", listener_name="missing"
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_listener_with_ssl_and_conn_config(mock_client):
+    mock_client.create_listener.return_value = MockResponse(data={})
+    result = server.create_load_balancer_listener.fn(
+        load_balancer_id="lb_ocid",
+        name="lsn",
+        default_backend_set_name="bs1",
+        port=443,
+        protocol="HTTP",
+        ssl_protocols=["TLSv1.2"],
+        ssl_cipher_suite_name="suite",
+        ssl_server_order_preference="ENABLED",
+        ssl_certificate_name="cert",
+        ssl_has_session_resumption=True,
+        ssl_verify_peer_certificate=False,
+        ssl_verify_depth=3,
+        idle_timeout=60,
+        backend_tcp_proxy_protocol_version=1,
+        backend_tcp_proxy_protocol_options=["PP2_TYPE_AUTHORITY"],
+    )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_update_load_balancer_shape_and_nsgs(mock_client):
+    mock_client.update_load_balancer_shape.return_value = MockResponse(data={})
+    mock_client.update_network_security_groups.return_value = MockResponse(data={})
+
+    r1 = server.update_load_balancer_shape.fn(
+        load_balancer_id="lb_ocid",
+        shape_name="Flexible",
+        minimum_bandwidth_in_mbps=10,
+        maximum_bandwidth_in_mbps=100,
+    )
+    r2 = server.update_load_balancer_network_security_groups.fn(
+        load_balancer_id="lb_ocid", network_security_group_ids=["nsg1"]
+    )
+    assert r1 is not None and r2 is not None
+
+
+@pytest.mark.asyncio
+async def test_update_load_balancer_shape_name_only(mock_client):
+    mock_client.update_load_balancer_shape.return_value = MockResponse(data={})
+    out = server.update_load_balancer_shape.fn(
+        load_balancer_id="lb", shape_name="100Mbps"
+    )
+    assert out is not None
+
+
+@pytest.mark.asyncio
+async def test_update_load_balancer_shape_bandwidth_only(mock_client):
+    mock_client.update_load_balancer_shape.return_value = MockResponse(data={})
+    out = server.update_load_balancer_shape.fn(
+        load_balancer_id="lb",
+        minimum_bandwidth_in_mbps=10,
+        maximum_bandwidth_in_mbps=20,
+    )
+    assert out is not None
+
+
+@pytest.mark.asyncio
+async def test_update_load_balancer_network_security_groups_none(mock_client):
+    mock_client.update_network_security_groups.return_value = MockResponse(data={})
+    out = server.update_load_balancer_network_security_groups.fn(
+        load_balancer_id="lb", network_security_group_ids=None
+    )
+    assert out is not None
+
+
+@pytest.mark.asyncio
+async def test_limits_on_listing_helpers(mock_client):
+    # listeners limit
+    mock_listener = types.SimpleNamespace(name="listener1")
+    mock_client.get_load_balancer.return_value = MockResponse(
+        data=types.SimpleNamespace(
+            listeners={"listener1": mock_listener, "l2": mock_listener}
+        )
+    )
+    ls = server.list_load_balancer_listeners.fn(load_balancer_id="lb", limit=1)
+    assert len(ls) == 1
+
+    # backend sets limit
+    mock_bs = types.SimpleNamespace(name="bs1")
+    mock_client.list_backend_sets.return_value = MockResponse(data=[mock_bs, mock_bs])
+    bss = server.list_load_balancer_backend_sets.fn(load_balancer_id="lb", limit=1)
+    assert len(bss) == 1
+
+    # backends limit
+    mock_backend = types.SimpleNamespace(name="b1")
+    mock_client.list_backends.return_value = MockResponse(
+        data=[mock_backend, mock_backend]
+    )
+    bs = server.list_backends.fn(load_balancer_id="lb", backend_set_name="bs", limit=1)
+    assert len(bs) == 1
+
+    # certificates limit
+    mock_cert = types.SimpleNamespace(certificate_name="c1")
+    mock_client.list_certificates.return_value = MockResponse(
+        data=[mock_cert, mock_cert]
+    )
+    certs = server.list_load_balancer_certificates.fn(load_balancer_id="lb", limit=1)
+    assert len(certs) == 1
+
+    # cipher suites limit
+    mock_suite = types.SimpleNamespace(name="s")
+    mock_client.list_ssl_cipher_suites.return_value = MockResponse(
+        data=[mock_suite, mock_suite]
+    )
+    suites = server.list_ssl_cipher_suites.fn(load_balancer_id="lb", limit=1)
+    assert len(suites) == 1
+
+    # hostnames limit
+    mock_host = types.SimpleNamespace(name="h")
+    mock_client.list_hostnames.return_value = MockResponse(data=[mock_host, mock_host])
+    hosts = server.list_hostnames.fn(load_balancer_id="lb", limit=1)
+    assert len(hosts) == 1
+
+    # rule sets limit
+    mock_rs = types.SimpleNamespace(name="rs")
+    mock_client.list_rule_sets.return_value = MockResponse(data=[mock_rs, mock_rs])
+    rss = server.list_rule_sets.fn(load_balancer_id="lb", limit=1)
+    assert len(rss) == 1
+
+
+@pytest.mark.asyncio
+async def test_pagination_helpers(mock_client):
+    # routing policies pagination
+    rp1 = MockResponse(data=[types.SimpleNamespace(name="p1")], next_page="n1")
+    rp2 = MockResponse(data=[types.SimpleNamespace(name="p2")], next_page=None)
+    mock_client.list_routing_policies.side_effect = [rp1, rp2]
+    rps = server.list_routing_policies.fn(load_balancer_id="lb", limit=None)
+    assert [p.name for p in rps] == ["p1", "p2"]
+
+    # health summaries pagination
+    hs1 = MockResponse(
+        data=[types.SimpleNamespace(load_balancer_id="a")], next_page="n1"
+    )
+    hs2 = MockResponse(
+        data=[types.SimpleNamespace(load_balancer_id="b")], next_page=None
+    )
+    mock_client.list_load_balancer_healths.side_effect = [hs1, hs2]
+    healths = server.list_load_balancer_healths.fn(compartment_id="c", limit=None)
+    assert [h.load_balancer_id for h in healths] == ["a", "b"]
+
+    # work requests pagination
+    wr1 = MockResponse(data=[types.SimpleNamespace(id="w1")], next_page="n1")
+    wr2 = MockResponse(data=[types.SimpleNamespace(id="w2")], next_page=None)
+    mock_client.list_work_requests.side_effect = [wr1, wr2]
+    wrs = server.list_load_balancer_work_requests.fn(load_balancer_id="lb", limit=None)
+    assert [w.id for w in wrs] == ["w1", "w2"]
+
+
+@pytest.mark.asyncio
+async def test_limit_helpers_stop_after_first_page(mock_client):
+    # routing policies
+    mock_client.list_routing_policies.return_value = MockResponse(
+        data=[types.SimpleNamespace(name="p1"), types.SimpleNamespace(name="p2")],
+        next_page="n1",
+    )
+    rps = server.list_routing_policies.fn(load_balancer_id="lb", limit=1)
+    assert [p.name for p in rps] == ["p1"]
+    mock_client.list_routing_policies.assert_called_once()
+
+    # health summaries
+    mock_client.list_load_balancer_healths.return_value = MockResponse(
+        data=[
+            types.SimpleNamespace(load_balancer_id="a"),
+            types.SimpleNamespace(load_balancer_id="b"),
+        ],
+        next_page="n1",
+    )
+    hs = server.list_load_balancer_healths.fn(compartment_id="c", limit=1)
+    assert [h.load_balancer_id for h in hs] == ["a"]
+    mock_client.list_load_balancer_healths.assert_called_once()
+
+    # work requests
+    mock_client.list_work_requests.return_value = MockResponse(
+        data=[types.SimpleNamespace(id="w1"), types.SimpleNamespace(id="w2")],
+        next_page="n1",
+    )
+    wrs = server.list_load_balancer_work_requests.fn(load_balancer_id="lb", limit=1)
+    assert [w.id for w in wrs] == ["w1"]
+    mock_client.list_work_requests.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_load_balancer(mock_client):
+    mock_lb = types.SimpleNamespace(id="lb_ocid")
+    mock_client.get_load_balancer.return_value = MockResponse(data=mock_lb)
+
+    result = server.get_load_balancer.fn(load_balancer_id="lb_ocid")
+    mock_client.get_load_balancer.assert_called_once_with("lb_ocid")
+    assert result.id == "lb_ocid"
+
+
+@pytest.mark.asyncio
+async def test_error_paths_raise_and_log(mock_client):
+    # Simulate client raising to drive except blocks
+    mock_client.get_backend.side_effect = RuntimeError("boom")
+    with pytest.raises(RuntimeError):
+        server.get_backend.fn(
+            load_balancer_id="lb", backend_set_name="bs", backend_name="ip:1"
+        )
+
+    mock_client.create_ssl_cipher_suite.side_effect = ValueError("bad")
+    with pytest.raises(ValueError):
+        server.create_ssl_cipher_suite.fn(
+            load_balancer_id="lb", name="s", ciphers=["c"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_load_balancer(mock_client):
+    mock_resp = MagicMock()
+    mock_client.create_load_balancer.return_value = MockResponse(data=mock_resp)
+
+    result = server.create_load_balancer.fn(
+        compartment_id="compartment_ocid",
+        display_name="test-lb",
+        shape_name="100Mbps",
+        subnet_ids=["subnet_ocid"],
+        is_private=False,
+        ip_mode=None,
+        is_delete_protection_enabled=False,
+        is_request_id_enabled=False,
+        request_id_header=None,
+        network_security_group_ids=None,
+        minimum_bandwidth_in_mbps=None,
+        maximum_bandwidth_in_mbps=None,
+    )
+    mock_client.create_load_balancer.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_update_load_balancer(mock_client):
+    mock_resp = MagicMock()
+    mock_client.update_load_balancer.return_value = MockResponse(data=mock_resp)
+
+    result = server.update_load_balancer.fn(
+        load_balancer_id="lb_ocid",
+        display_name="new-name",
+        is_delete_protection_enabled=True,
+        is_request_id_enabled=True,
+        request_id_header="X-Request-Id",
+        freeform_tags={"env": "test"},
+        defined_tags=None,
+        defined_tags_extended=None,
+    )
+    mock_client.update_load_balancer.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_update_load_balancer_minimal(mock_client):
+    mock_client.update_load_balancer.return_value = MockResponse(data={})
+    res = server.update_load_balancer.fn(load_balancer_id="lb")
+    assert res is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_load_balancer(mock_client):
+    mock_resp = MagicMock()
+    mock_client.delete_load_balancer.return_value = MockResponse(data=mock_resp)
+
+    result = server.delete_load_balancer.fn(load_balancer_id="lb_ocid")
+    mock_client.delete_load_balancer.assert_called_once_with("lb_ocid")
+    assert result is not None
+
+
+# ----------------------------------------------------------------------
+# Listener tools
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_load_balancer_listeners(mock_client):
+    mock_listener = types.SimpleNamespace(name="listener1")
+    mock_client.get_load_balancer.return_value = MockResponse(
+        data=types.SimpleNamespace(listeners={"listener1": mock_listener})
+    )
+
+    result = server.list_load_balancer_listeners.fn(
+        load_balancer_id="lb_ocid", limit=None
+    )
+    mock_client.get_load_balancer.assert_called_once()
+    assert isinstance(result, list)
+    assert result[0].name == "listener1"
+
+
+@pytest.mark.asyncio
+async def test_create_load_balancer_listener(mock_client):
+    mock_resp = MagicMock()
+    mock_client.create_listener.return_value = MockResponse(data=mock_resp)
+
+    result = server.create_load_balancer_listener.fn(
+        load_balancer_id="lb_ocid",
+        name="listener1",
+        default_backend_set_name="backendset1",
+        port=80,
+        protocol="HTTP",
+    )
+    mock_client.create_listener.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_get_load_balancer_listener(mock_client):
+    mock_listener = types.SimpleNamespace(name="listener1")
+    mock_client.get_load_balancer.return_value = MockResponse(
+        data=types.SimpleNamespace(listeners={"listener1": mock_listener})
+    )
+
+    result = server.get_load_balancer_listener.fn(
+        load_balancer_id="lb_ocid", listener_name="listener1"
+    )
+    mock_client.get_load_balancer.assert_called_once()
+    assert result.name == "listener1"
+
+
+@pytest.mark.asyncio
+async def test_update_load_balancer_listener(mock_client):
+    mock_resp = MagicMock()
+    mock_client.update_listener.return_value = MockResponse(data=mock_resp)
+
+    result = server.update_load_balancer_listener.fn(
+        load_balancer_id="lb_ocid",
+        listener_name="listener1",
+        default_backend_set_name="backendset2",
+        port=443,
+        protocol="HTTPS",
+    )
+    mock_client.update_listener.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_update_load_balancer_listener_no_optional(mock_client):
+    mock_client.update_listener.return_value = MockResponse(data={})
+    res = server.update_load_balancer_listener.fn(
+        load_balancer_id="lb_ocid", listener_name="l1"
+    )
+    assert res is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_load_balancer_listener(mock_client):
+    mock_resp = MagicMock()
+    mock_client.delete_listener.return_value = MockResponse(data=mock_resp)
+
+    result = server.delete_load_balancer_listener.fn(
+        load_balancer_id="lb_ocid", listener_name="listener1"
+    )
+    mock_client.delete_listener.assert_called_once_with("lb_ocid", "listener1")
+    assert result is not None
+
+
+# ----------------------------------------------------------------------
+# Backend set tools
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_load_balancer_backend_sets(mock_client):
+    mock_bs = types.SimpleNamespace(name="backendset1")
+    mock_client.list_backend_sets.return_value = MockResponse(data=[mock_bs])
+
+    result = server.list_load_balancer_backend_sets.fn(
+        load_balancer_id="lb_ocid", limit=None
+    )
+    mock_client.list_backend_sets.assert_called_once_with("lb_ocid")
+    assert isinstance(result, list)
+    assert result[0].name == "backendset1"
+
+
+@pytest.mark.asyncio
+async def test_create_load_balancer_backend_set(mock_client):
+    mock_resp = MagicMock()
+    mock_client.create_backend_set.return_value = MockResponse(data=mock_resp)
+
+    result = server.create_load_balancer_backend_set.fn(
+        load_balancer_id="lb_ocid",
+        name="backendset1",
+        policy="ROUND_ROBIN",
+        health_checker_protocol="HTTP",
+        backends=[],
+    )
+    mock_client.create_backend_set.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_create_backend_set_without_backends(mock_client):
+    mock_client.create_backend_set.return_value = MockResponse(data={})
+    out = server.create_load_balancer_backend_set.fn(
+        load_balancer_id="lb",
+        name="bs",
+        policy="ROUND_ROBIN",
+        health_checker_protocol="HTTP",
+        backends=None,
+    )
+    assert out is not None
+
+
+@pytest.mark.asyncio
+async def test_update_load_balancer_backend_set(mock_client):
+    mock_resp = MagicMock()
+    mock_client.update_backend_set.return_value = MockResponse(data=mock_resp)
+
+    result = server.update_load_balancer_backend_set.fn(
+        load_balancer_id="lb_ocid",
+        name="backendset1",
+        policy="LEAST_CONNECTIONS",
+        backends=[],
+    )
+    mock_client.update_backend_set.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_load_balancer_backend_set(mock_client):
+    mock_resp = MagicMock()
+    mock_client.delete_backend_set.return_value = MockResponse(data=mock_resp)
+
+    result = server.delete_load_balancer_backend_set.fn(
+        load_balancer_id="lb_ocid", name="backendset1"
+    )
+    mock_client.delete_backend_set.assert_called_once_with("lb_ocid", "backendset1")
+    assert result is not None
+
+
+# ----------------------------------------------------------------------
+# Backend tools
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_backends(mock_client):
+    mock_backend = types.SimpleNamespace(name="backend1")
+    mock_client.list_backends.return_value = MockResponse(data=[mock_backend])
+
+    result = server.list_backends.fn(
+        load_balancer_id="lb_ocid", backend_set_name="bs1", limit=None
+    )
+    mock_client.list_backends.assert_called_once_with("lb_ocid", "bs1")
+    assert isinstance(result, list)
+    assert result[0].name == "backend1"
+
+
+@pytest.mark.asyncio
+async def test_create_backend(mock_client):
+    mock_resp = MagicMock()
+    mock_client.create_backend.return_value = MockResponse(data=mock_resp)
+
+    result = server.create_backend.fn(
+        load_balancer_id="lb_ocid",
+        backend_set_name="bs1",
+        ip_address="10.0.0.1",
+        port=8080,
+    )
+    mock_client.create_backend.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_get_backend(mock_client):
+    mock_backend = types.SimpleNamespace(name="backend1")
+    mock_client.get_backend.return_value = MockResponse(data=mock_backend)
+
+    result = server.get_backend.fn(
+        load_balancer_id="lb_ocid",
+        backend_set_name="bs1",
+        backend_name="10.0.0.1:8080",
+    )
+    mock_client.get_backend.assert_called_once()
+    assert result.name == "backend1"
+
+
+@pytest.mark.asyncio
+async def test_update_backend(mock_client):
+    mock_resp = MagicMock()
+    mock_client.update_backend.return_value = MockResponse(data=mock_resp)
+
+    result = server.update_backend.fn(
+        load_balancer_id="lb_ocid",
+        backend_set_name="bs1",
+        backend_name="10.0.0.1:8080",
+        weight=10,
+    )
+    mock_client.update_backend.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_backend(mock_client):
+    mock_resp = MagicMock()
+    mock_client.delete_backend.return_value = MockResponse(data=mock_resp)
+
+    result = server.delete_backend.fn(
+        load_balancer_id="lb_ocid",
+        backend_set_name="bs1",
+        backend_name="10.0.0.1:8080",
+    )
+    mock_client.delete_backend.assert_called_once()
+    assert result is not None
+
+
+# ----------------------------------------------------------------------
+# Certificate tools
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_load_balancer_certificates(mock_client):
+    mock_cert = types.SimpleNamespace(certificate_name="cert1")
+    mock_client.list_certificates.return_value = MockResponse(data=[mock_cert])
+
+    result = server.list_load_balancer_certificates.fn(
+        load_balancer_id="lb_ocid", limit=None
+    )
+    mock_client.list_certificates.assert_called_once_with("lb_ocid")
+    assert isinstance(result, list)
+    assert result[0].certificate_name == "cert1"
+
+
+@pytest.mark.asyncio
+async def test_create_load_balancer_certificate(mock_client):
+    mock_resp = MagicMock()
+    mock_client.create_certificate.return_value = MockResponse(data=mock_resp)
+
+    result = server.create_load_balancer_certificate.fn(
+        load_balancer_id="lb_ocid",
+        certificate_name="cert1",
+        public_certificate="---PUBLIC---",
+        private_key="---PRIVATE---",
+    )
+    mock_client.create_certificate.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_load_balancer_certificate(mock_client):
+    mock_resp = MagicMock()
+    mock_client.delete_certificate.return_value = MockResponse(data=mock_resp)
+
+    result = server.delete_load_balancer_certificate.fn(
+        load_balancer_id="lb_ocid", certificate_name="cert1"
+    )
+    mock_client.delete_certificate.assert_called_once_with("lb_ocid", "cert1")
+    assert result is not None
+
+
+# ----------------------------------------------------------------------
+# SSL Cipher Suite tools
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_ssl_cipher_suites(mock_client):
+    mock_suite = types.SimpleNamespace(name="suite1")
+    mock_client.list_ssl_cipher_suites.return_value = MockResponse(data=[mock_suite])
+    out = server.list_ssl_cipher_suites.fn(load_balancer_id="lb", limit=None)
+    mock_client.list_ssl_cipher_suites.assert_called_once_with("lb")
+    assert [s.name for s in out] == ["suite1"]
+
+
+@pytest.mark.asyncio
+async def test_create_ssl_cipher_suite(mock_client):
+    mock_client.create_ssl_cipher_suite.return_value = MockResponse(data={})
+    res = server.create_ssl_cipher_suite.fn(
+        load_balancer_id="lb", name="suite1", ciphers=["TLS_AES_128_GCM_SHA256"]
+    )
+    assert res is not None
+
+
+@pytest.mark.asyncio
+async def test_update_ssl_cipher_suite(mock_client):
+    mock_resp = MagicMock()
+    mock_client.update_ssl_cipher_suite.return_value = MockResponse(data=mock_resp)
+
+    result = server.update_ssl_cipher_suite.fn(
+        load_balancer_id="lb_ocid", name="suite1", ciphers=["TLS_AES_256_GCM_SHA384"]
+    )
+    mock_client.update_ssl_cipher_suite.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_ssl_cipher_suite(mock_client):
+    mock_resp = MagicMock()
+    mock_client.delete_ssl_cipher_suite.return_value = MockResponse(data=mock_resp)
+
+    result = server.delete_ssl_cipher_suite.fn(
+        load_balancer_id="lb_ocid", name="suite1"
+    )
+    mock_client.delete_ssl_cipher_suite.assert_called_once_with("lb_ocid", "suite1")
+    assert result is not None
+
+
+# ----------------------------------------------------------------------
+# Hostname tools
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_hostnames(mock_client):
+    mock_host = types.SimpleNamespace(name="host1")
+    mock_client.list_hostnames.return_value = MockResponse(data=[mock_host])
+
+    result = server.list_hostnames.fn(load_balancer_id="lb_ocid", limit=None)
+    mock_client.list_hostnames.assert_called_once_with("lb_ocid")
+    assert isinstance(result, list)
+    assert result[0].name == "host1"
+
+
+@pytest.mark.asyncio
+async def test_create_hostname(mock_client):
+    mock_resp = MagicMock()
+    mock_client.create_hostname.return_value = MockResponse(data=mock_resp)
+
+    result = server.create_hostname.fn(
+        load_balancer_id="lb_ocid", name="host1", hostname="app.example.com"
+    )
+    mock_client.create_hostname.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_get_hostname(mock_client):
+    mock_host = types.SimpleNamespace(name="host1")
+    mock_client.get_hostname.return_value = MockResponse(data=mock_host)
+
+    result = server.get_hostname.fn(load_balancer_id="lb_ocid", name="host1")
+    mock_client.get_hostname.assert_called_once_with("lb_ocid", "host1")
+    assert result.name == "host1"
+
+
+@pytest.mark.asyncio
+async def test_update_hostname(mock_client):
+    mock_resp = MagicMock()
+    mock_client.update_hostname.return_value = MockResponse(data=mock_resp)
+
+    result = server.update_hostname.fn(
+        load_balancer_id="lb_ocid", name="host1", hostname="new.example.com"
+    )
+    mock_client.update_hostname.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_hostname(mock_client):
+    mock_resp = MagicMock()
+    mock_client.delete_hostname.return_value = MockResponse(data=mock_resp)
+
+    result = server.delete_hostname.fn(load_balancer_id="lb_ocid", name="host1")
+    mock_client.delete_hostname.assert_called_once_with("lb_ocid", "host1")
+    assert result is not None
+
+
+# ----------------------------------------------------------------------
+# Rule Set tools
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_rule_sets(mock_client):
+    mock_rs = types.SimpleNamespace(name="ruleset1")
+    mock_client.list_rule_sets.return_value = MockResponse(data=[mock_rs])
+
+    result = server.list_rule_sets.fn(load_balancer_id="lb_ocid", limit=None)
+    mock_client.list_rule_sets.assert_called_once_with("lb_ocid")
+    assert isinstance(result, list)
+    assert result[0].name == "ruleset1"
+
+
+@pytest.mark.asyncio
+async def test_create_rule_set(mock_client):
+    mock_resp = MagicMock()
+    mock_client.create_rule_set.return_value = MockResponse(data=mock_resp)
+
+    result = server.create_rule_set.fn(
+        load_balancer_id="lb_ocid", name="ruleset1", items=[]
+    )
+    mock_client.create_rule_set.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_get_rule_set(mock_client):
+    mock_rs = types.SimpleNamespace(name="ruleset1")
+    mock_client.get_rule_set.return_value = MockResponse(data=mock_rs)
+
+    result = server.get_rule_set.fn(load_balancer_id="lb_ocid", name="ruleset1")
+    mock_client.get_rule_set.assert_called_once_with("lb_ocid", "ruleset1")
+    assert result.name == "ruleset1"
+
+
+@pytest.mark.asyncio
+async def test_update_rule_set(mock_client):
+    mock_resp = MagicMock()
+    mock_client.update_rule_set.return_value = MockResponse(data=mock_resp)
+
+    result = server.update_rule_set.fn(
+        load_balancer_id="lb_ocid", name="ruleset1", items=[]
+    )
+    mock_client.update_rule_set.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_rule_set(mock_client):
+    mock_resp = MagicMock()
+    mock_client.delete_rule_set.return_value = MockResponse(data=mock_resp)
+
+    result = server.delete_rule_set.fn(load_balancer_id="lb_ocid", name="ruleset1")
+    mock_client.delete_rule_set.assert_called_once_with("lb_ocid", "ruleset1")
+    assert result is not None
+
+
+# ----------------------------------------------------------------------
+# Routing Policy tools
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_routing_policies(mock_client):
+    mock_rp = types.SimpleNamespace(name="policy1")
+    mock_client.list_routing_policies.return_value = MockResponse(data=[mock_rp])
+
+    result = server.list_routing_policies.fn(load_balancer_id="lb_ocid", limit=None)
+    mock_client.list_routing_policies.assert_called_once_with(
+        "lb_ocid", limit=None, page=None
+    )
+    assert isinstance(result, list)
+    assert result[0].name == "policy1"
+
+
+@pytest.mark.asyncio
+async def test_create_routing_policy(mock_client):
+    mock_client.create_routing_policy.return_value = MockResponse(data={})
+    out = server.create_routing_policy.fn(
+        load_balancer_id="lb", name="rp1", condition_language_version="V1", rules=[]
+    )
+    assert out is not None
+
+
+@pytest.mark.asyncio
+async def test_update_backend_all_flags(mock_client):
+    mock_client.update_backend.return_value = MockResponse(data={})
+    out = server.update_backend.fn(
+        load_balancer_id="lb",
+        backend_set_name="bs",
+        backend_name="1.1.1.1:80",
+        weight=5,
+        max_connections=200,
+        backup=True,
+        drain=True,
+        offline=False,
+    )
+    assert out is not None
+
+
+@pytest.mark.asyncio
+async def test_get_routing_policy(mock_client):
+    mock_rp = types.SimpleNamespace(name="policy1")
+    mock_client.get_routing_policy.return_value = MockResponse(data=mock_rp)
+
+    result = server.get_routing_policy.fn(load_balancer_id="lb_ocid", name="policy1")
+    mock_client.get_routing_policy.assert_called_once_with("lb_ocid", "policy1")
+    assert result.name == "policy1"
+
+
+@pytest.mark.asyncio
+async def test_update_routing_policy(mock_client):
+    mock_resp = MagicMock()
+    mock_client.update_routing_policy.return_value = MockResponse(data=mock_resp)
+
+    result = server.update_routing_policy.fn(
+        load_balancer_id="lb_ocid",
+        name="policy1",
+        condition_language_version=None,
+        rules=[],
+    )
+    mock_client.update_routing_policy.assert_called_once()
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_routing_policy(mock_client):
+    mock_resp = MagicMock()
+    mock_client.delete_routing_policy.return_value = MockResponse(data=mock_resp)
+
+    result = server.delete_routing_policy.fn(load_balancer_id="lb_ocid", name="policy1")
+    mock_client.delete_routing_policy.assert_called_once_with("lb_ocid", "policy1")
+    assert result is not None
+
+
+# ----------------------------------------------------------------------
+# Health and Work Request tools
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_load_balancer_health(mock_client):
+    mock_health = types.SimpleNamespace(status="OK")
+    mock_client.get_load_balancer_health.return_value = MockResponse(data=mock_health)
+
+    result = server.get_load_balancer_health.fn(load_balancer_id="lb_ocid")
+    mock_client.get_load_balancer_health.assert_called_once_with("lb_ocid")
+    assert result.status == "OK"
+
+
+@pytest.mark.asyncio
+async def test_get_backend_set_health(mock_client):
+    mock_h = types.SimpleNamespace(status="WARNING")
+    mock_client.get_backend_set_health.return_value = MockResponse(data=mock_h)
+
+    result = server.get_backend_set_health.fn(
+        load_balancer_id="lb_ocid", backend_set_name="bs1"
+    )
+    mock_client.get_backend_set_health.assert_called_once_with("lb_ocid", "bs1")
+    assert result.status == "WARNING"
+
+
+@pytest.mark.asyncio
+async def test_get_backend_health(mock_client):
+    mock_h = types.SimpleNamespace(status="CRITICAL")
+    mock_client.get_backend_health.return_value = MockResponse(data=mock_h)
+
+    result = server.get_backend_health.fn(
+        load_balancer_id="lb_ocid", backend_set_name="bs1", backend_name="10.0.0.1:8080"
+    )
+    mock_client.get_backend_health.assert_called_once_with(
+        "lb_ocid", "bs1", "10.0.0.1:8080"
+    )
+    assert result.status == "CRITICAL"
+
+
+@pytest.mark.asyncio
+async def test_list_load_balancer_healths(mock_client):
+    mock_sum = types.SimpleNamespace(load_balancer_id="lb_ocid")
+    mock_client.list_load_balancer_healths.return_value = MockResponse(data=[mock_sum])
+
+    result = server.list_load_balancer_healths.fn(
+        compartment_id="compartment_ocid", limit=None
+    )
+    mock_client.list_load_balancer_healths.assert_called_once()
+    assert isinstance(result, list)
+    assert result[0].load_balancer_id == "lb_ocid"
+
+
+@pytest.mark.asyncio
+async def test_list_load_balancer_work_requests(mock_client):
+    mock_wr = types.SimpleNamespace(id="wr_ocid")
+    mock_client.list_work_requests.return_value = MockResponse(data=[mock_wr])
+
+    result = server.list_load_balancer_work_requests.fn(
+        load_balancer_id="lb_ocid", limit=None
+    )
+    mock_client.list_work_requests.assert_called_once()
+    assert isinstance(result, list)
+    assert result[0].id == "wr_ocid"
+
+
+@pytest.mark.asyncio
+async def test_get_load_balancer_work_request(mock_client):
+    mock_wr = types.SimpleNamespace(id="wr_ocid")
+    mock_client.get_work_request.return_value = MockResponse(data=mock_wr)
+
+    result = server.get_load_balancer_work_request.fn(work_request_id="wr_ocid")
+    mock_client.get_work_request.assert_called_once_with("wr_ocid")
+    assert result.id == "wr_ocid"
+
+
+# Additional coverage-focused tests exercising optional branches
+
+
+@pytest.mark.asyncio
+async def test_error_paths_all_tools(monkeypatch):
+    # Override client getter to force exceptions in each tool to hit except/log paths
+    def _raise():
+        raise RuntimeError("forced error")
+
+    monkeypatch.setattr(server, "get_load_balancer_client", _raise)
+
+    cases = [
+        (server.list_load_balancers.fn, {"compartment_id": "c"}),
+        (server.get_load_balancer.fn, {"load_balancer_id": "lb"}),
+        (
+            server.create_load_balancer.fn,
+            {
+                "compartment_id": "c",
+                "display_name": "d",
+                "shape_name": "s",
+                "subnet_ids": ["s1"],
+            },
+        ),
+        (server.update_load_balancer.fn, {"load_balancer_id": "lb"}),
+        (server.update_load_balancer_shape.fn, {"load_balancer_id": "lb"}),
+        (server.delete_load_balancer.fn, {"load_balancer_id": "lb"}),
+        (
+            server.update_load_balancer_network_security_groups.fn,
+            {"load_balancer_id": "lb"},
+        ),
+        (server.list_load_balancer_listeners.fn, {"load_balancer_id": "lb"}),
+        (
+            server.create_load_balancer_listener.fn,
+            {
+                "load_balancer_id": "lb",
+                "name": "n",
+                "default_backend_set_name": "b",
+                "port": 80,
+                "protocol": "HTTP",
+            },
+        ),
+        (
+            server.get_load_balancer_listener.fn,
+            {"load_balancer_id": "lb", "listener_name": "n"},
+        ),
+        (
+            server.update_load_balancer_listener.fn,
+            {"load_balancer_id": "lb", "listener_name": "n"},
+        ),
+        (
+            server.delete_load_balancer_listener.fn,
+            {"load_balancer_id": "lb", "listener_name": "n"},
+        ),
+        (server.list_load_balancer_backend_sets.fn, {"load_balancer_id": "lb"}),
+        (
+            server.get_load_balancer_backend_set.fn,
+            {"load_balancer_id": "lb", "backend_set_name": "bs"},
+        ),
+        (
+            server.create_load_balancer_backend_set.fn,
+            {
+                "load_balancer_id": "lb",
+                "name": "bs",
+                "policy": "ROUND_ROBIN",
+                "health_checker_protocol": "HTTP",
+            },
+        ),
+        (
+            server.update_load_balancer_backend_set.fn,
+            {"load_balancer_id": "lb", "name": "bs"},
+        ),
+        (
+            server.delete_load_balancer_backend_set.fn,
+            {"load_balancer_id": "lb", "name": "bs"},
+        ),
+        (
+            server.list_backends.fn,
+            {"load_balancer_id": "lb", "backend_set_name": "bs"},
+        ),
+        (
+            server.create_backend.fn,
+            {
+                "load_balancer_id": "lb",
+                "backend_set_name": "bs",
+                "ip_address": "1.1.1.1",
+                "port": 80,
+            },
+        ),
+        (
+            server.get_backend.fn,
+            {
+                "load_balancer_id": "lb",
+                "backend_set_name": "bs",
+                "backend_name": "1.1.1.1:80",
+            },
+        ),
+        (
+            server.update_backend.fn,
+            {
+                "load_balancer_id": "lb",
+                "backend_set_name": "bs",
+                "backend_name": "1.1.1.1:80",
+            },
+        ),
+        (
+            server.delete_backend.fn,
+            {
+                "load_balancer_id": "lb",
+                "backend_set_name": "bs",
+                "backend_name": "1.1.1.1:80",
+            },
+        ),
+        (server.list_load_balancer_certificates.fn, {"load_balancer_id": "lb"}),
+        (
+            server.create_load_balancer_certificate.fn,
+            {
+                "load_balancer_id": "lb",
+                "certificate_name": "c",
+                "public_certificate": "p",
+                "private_key": "k",
+            },
+        ),
+        (
+            server.delete_load_balancer_certificate.fn,
+            {"load_balancer_id": "lb", "certificate_name": "c"},
+        ),
+        (server.list_ssl_cipher_suites.fn, {"load_balancer_id": "lb"}),
+        (
+            server.create_ssl_cipher_suite.fn,
+            {"load_balancer_id": "lb", "name": "n", "ciphers": ["c"]},
+        ),
+        (
+            server.get_ssl_cipher_suite.fn,
+            {"load_balancer_id": "lb", "name": "n"},
+        ),
+        (
+            server.update_ssl_cipher_suite.fn,
+            {"load_balancer_id": "lb", "name": "n"},
+        ),
+        (
+            server.delete_ssl_cipher_suite.fn,
+            {"load_balancer_id": "lb", "name": "n"},
+        ),
+        (server.list_hostnames.fn, {"load_balancer_id": "lb"}),
+        (
+            server.create_hostname.fn,
+            {"load_balancer_id": "lb", "name": "h", "hostname": "x"},
+        ),
+        (
+            server.get_hostname.fn,
+            {"load_balancer_id": "lb", "name": "h"},
+        ),
+        (
+            server.update_hostname.fn,
+            {"load_balancer_id": "lb", "name": "h"},
+        ),
+        (
+            server.delete_hostname.fn,
+            {"load_balancer_id": "lb", "name": "h"},
+        ),
+        (server.list_rule_sets.fn, {"load_balancer_id": "lb"}),
+        (
+            server.create_rule_set.fn,
+            {"load_balancer_id": "lb", "name": "rs"},
+        ),
+        (
+            server.get_rule_set.fn,
+            {"load_balancer_id": "lb", "name": "rs"},
+        ),
+        (
+            server.update_rule_set.fn,
+            {"load_balancer_id": "lb", "name": "rs"},
+        ),
+        (
+            server.delete_rule_set.fn,
+            {"load_balancer_id": "lb", "name": "rs"},
+        ),
+        (server.list_routing_policies.fn, {"load_balancer_id": "lb"}),
+        (
+            server.create_routing_policy.fn,
+            {"load_balancer_id": "lb", "name": "rp"},
+        ),
+        (
+            server.get_routing_policy.fn,
+            {"load_balancer_id": "lb", "name": "rp"},
+        ),
+        (
+            server.update_routing_policy.fn,
+            {"load_balancer_id": "lb", "name": "rp"},
+        ),
+        (
+            server.delete_routing_policy.fn,
+            {"load_balancer_id": "lb", "name": "rp"},
+        ),
+        (server.get_load_balancer_health.fn, {"load_balancer_id": "lb"}),
+        (
+            server.get_backend_set_health.fn,
+            {"load_balancer_id": "lb", "backend_set_name": "bs"},
+        ),
+        (
+            server.get_backend_health.fn,
+            {
+                "load_balancer_id": "lb",
+                "backend_set_name": "bs",
+                "backend_name": "1.1.1.1:80",
+            },
+        ),
+        (server.list_load_balancer_healths.fn, {"compartment_id": "c"}),
+        (server.list_load_balancer_work_requests.fn, {"load_balancer_id": "lb"}),
+        (server.get_load_balancer_work_request.fn, {"work_request_id": "wr"}),
+    ]
+
+    for func, kwargs in cases:
+        with pytest.raises(RuntimeError):
+            func(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_get_load_balancer_backend_set(mock_client):
+    mock_bs = types.SimpleNamespace(name="bs1")
+    mock_client.get_backend_set.return_value = MockResponse(data=mock_bs)
+    res = server.get_load_balancer_backend_set.fn(
+        load_balancer_id="lb_ocid", backend_set_name="bs1"
+    )
+    mock_client.get_backend_set.assert_called_once_with("lb_ocid", "bs1")
+    assert res.name == "bs1"
+
+
+@pytest.mark.asyncio
+async def test_get_ssl_cipher_suite(mock_client):
+    mock_s = types.SimpleNamespace(name="s1", ciphers=["C1"])
+    mock_client.get_ssl_cipher_suite.return_value = MockResponse(data=mock_s)
+    res = server.get_ssl_cipher_suite.fn(load_balancer_id="lb_ocid", name="s1")
+    mock_client.get_ssl_cipher_suite.assert_called_once_with("lb_ocid", "s1")
+    assert res.name == "s1"
+
+
+@pytest.mark.asyncio
+async def test_create_backend_set_full_options(mock_client):
+    mock_client.create_backend_set.return_value = MockResponse(data={})
+    res = server.create_load_balancer_backend_set.fn(
+        load_balancer_id="lb",
+        name="bs",
+        policy="ROUND_ROBIN",
+        health_checker_protocol="HTTP",
+        health_checker_url_path="/health",
+        health_checker_port=8080,
+        health_checker_return_code=200,
+        health_checker_retries=2,
+        health_checker_timeout_in_millis=5000,
+        health_checker_interval_in_millis=10000,
+        health_checker_response_body_regex="OK",
+        health_checker_is_force_plain_text=True,
+        backends=[],
+        backend_max_connections=300,
+        ssl_protocols=["TLSv1.2"],
+        ssl_cipher_suite_name="suite",
+        ssl_server_order_preference="ENABLED",
+        ssl_certificate_name="cert",
+        ssl_certificate_ids=["cid"],
+        ssl_trusted_certificate_authority_ids=["tid"],
+        ssl_has_session_resumption=True,
+        ssl_verify_peer_certificate=False,
+        ssl_verify_depth=3,
+        session_persistence_cookie_name="app",
+        session_persistence_disable_fallback=True,
+        lb_cookie_cookie_name="lb",
+        lb_cookie_disable_fallback=True,
+        lb_cookie_domain="example.com",
+        lb_cookie_path="/",
+        lb_cookie_max_age_in_seconds=60,
+        lb_cookie_is_secure=True,
+        lb_cookie_is_http_only=True,
+    )
+    assert res is not None
+
+
+@pytest.mark.asyncio
+async def test_update_backend_set_full_options(mock_client):
+    # Provide current backend set with health checker for preservation logic
+    current_bs = types.SimpleNamespace(
+        policy="ROUND_ROBIN",
+        backends=[],
+        health_checker=types.SimpleNamespace(
+            protocol="HTTP",
+            url_path="/h",
+            port=80,
+            return_code=200,
+            retries=3,
+            timeout_in_millis=3000,
+            interval_in_millis=5000,
+            response_body_regex="OK",
+            is_force_plain_text=False,
+        ),
+    )
+    mock_client.get_backend_set.return_value = MockResponse(data=current_bs)
+    mock_client.update_backend_set.return_value = MockResponse(data={})
+
+    res = server.update_load_balancer_backend_set.fn(
+        load_balancer_id="lb",
+        name="bs",
+        policy="LEAST_CONNECTIONS",
+        backends=[],
+        health_checker_protocol="HTTP",
+        health_checker_url_path="/health",
+        health_checker_port=8080,
+        health_checker_return_code=200,
+        health_checker_retries=2,
+        health_checker_timeout_in_millis=5000,
+        health_checker_interval_in_millis=10000,
+        health_checker_response_body_regex="OK",
+        health_checker_is_force_plain_text=True,
+        ssl_protocols=["TLSv1.2"],
+        ssl_cipher_suite_name="suite",
+        ssl_server_order_preference="DISABLED",
+        ssl_certificate_name="cert",
+        ssl_certificate_ids=["cid"],
+        ssl_trusted_certificate_authority_ids=["tid"],
+        ssl_has_session_resumption=True,
+        ssl_verify_peer_certificate=True,
+        ssl_verify_depth=4,
+        session_persistence_cookie_name="app",
+        session_persistence_disable_fallback=False,
+        lb_cookie_cookie_name="lb",
+        lb_cookie_disable_fallback=False,
+        lb_cookie_domain="example.com",
+        lb_cookie_path="/",
+        lb_cookie_max_age_in_seconds=120,
+        lb_cookie_is_secure=True,
+        lb_cookie_is_http_only=False,
+    )
+    assert res is not None
+
+
+@pytest.mark.asyncio
+async def test_update_backend_set_preserve_existing(mock_client):
+    existing_backend = types.SimpleNamespace(
+        ip_address="1.1.1.1",
+        port=80,
+        weight=1,
+        max_connections=256,
+        backup=False,
+        drain=False,
+        offline=False,
+    )
+    current_bs = types.SimpleNamespace(
+        policy="ROUND_ROBIN",
+        backends=[existing_backend],
+        health_checker=types.SimpleNamespace(
+            protocol="HTTP",
+            url_path="/h",
+            port=80,
+            return_code=200,
+            retries=3,
+            timeout_in_millis=3000,
+            interval_in_millis=5000,
+            response_body_regex="OK",
+            is_force_plain_text=False,
+        ),
+    )
+    mock_client.get_backend_set.return_value = MockResponse(data=current_bs)
+    mock_client.update_backend_set.return_value = MockResponse(data={})
+
+    # Do not pass backends or HC details so preservation paths are used
+    out = server.update_load_balancer_backend_set.fn(
+        load_balancer_id="lb", name="bs", backends=None
+    )
+    assert out is not None

--- a/src/oci-load-balancer-mcp-server/pyproject.toml
+++ b/src/oci-load-balancer-mcp-server/pyproject.toml
@@ -1,0 +1,57 @@
+[project]
+name = "oracle.oci-load-balancer-mcp-server"
+
+version = "0.0.1"
+description = "An OCI Model Context Protocol server for load-balancer"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "fastmcp==2.12.2",
+    "oci==2.160.0",
+    "pydantic==2.12.3",
+]
+license = "UPL-1.0"
+license-files = ["LICENSE.txt"]
+authors = [
+    {name = "Oracle MCP", email = "237432095+oracle-mcp@users.noreply.github.com"},
+]
+
+classifiers = [
+    "License :: OSI Approved :: Universal Permissive License (UPL)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.13",
+]
+
+[project.scripts]
+"oracle.oci-load-balancer-mcp-server" = "oracle.oci_load_balancer_mcp_server.server:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.2",
+    "pytest-asyncio>=1.2.0",
+    "pytest-cov>=7.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["oracle"]
+
+[tool.coverage.run]
+omit = [
+    "**/__init__.py",
+    "**/tests/*",
+    "dist/*",
+    ".venv/*",
+]
+
+[tool.coverage.report]
+omit = [
+    "**/__init__.py",
+    "**/tests/*",
+]
+precision = 2
+fail_under = 90

--- a/src/oci-load-balancer-mcp-server/uv.lock
+++ b/src/oci-load-balancer-mcp-server/uv.lock
@@ -1,0 +1,1222 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
+name = "authlib"
+version = "1.6.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/9b/b1661026ff24bc641b76b78c5222d614776b0c085bcfdac9bd15a1cb4b35/authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e", size = 164894, upload-time = "2025-12-12T08:01:41.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/51/321e821856452f7386c4e9df866f196720b1ad0c5ea1623ea7399969ae3b/authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd", size = 244005, upload-time = "2025-12-12T08:01:40.209Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
+    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "circuitbreaker"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/ac/de7a92c4ed39cba31fe5ad9203b76a25ca67c530797f6bb420fff5f65ccb/circuitbreaker-2.1.3.tar.gz", hash = "sha256:1a4baee510f7bea3c91b194dcce7c07805fe96c4423ed5594b75af438531d084", size = 10787, upload-time = "2025-03-31T08:12:08.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl", hash = "sha256:87ba6a3ed03fdc7032bc175561c2b04d52ade9d5faf94ca2b035fbdc5e6b1dd1", size = 7737, upload-time = "2025-03-31T08:12:07.802Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/f9/e92df5e07f3fc8d4c7f9a0f146ef75446bf870351cd37b788cf5897f8079/coverage-7.13.1.tar.gz", hash = "sha256:b7593fe7eb5feaa3fbb461ac79aac9f9fc0387a5ca8080b0c6fe2ca27b091afd", size = 825862, upload-time = "2025-12-28T15:42:56.969Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/a4/e98e689347a1ff1a7f67932ab535cef82eb5e78f32a9e4132e114bbb3a0a/coverage-7.13.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cb237bfd0ef4d5eb6a19e29f9e528ac67ac3be932ea6b44fb6cc09b9f3ecff78", size = 218951, upload-time = "2025-12-28T15:41:16.653Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/7cbfe2bdc6e2f03d6b240d23dc45fdaf3fd270aaf2d640be77b7f16989ab/coverage-7.13.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1dcb645d7e34dcbcc96cd7c132b1fc55c39263ca62eb961c064eb3928997363b", size = 219325, upload-time = "2025-12-28T15:41:18.609Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f6/efdabdb4929487baeb7cb2a9f7dac457d9356f6ad1b255be283d58b16316/coverage-7.13.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3d42df8201e00384736f0df9be2ced39324c3907607d17d50d50116c989d84cd", size = 250309, upload-time = "2025-12-28T15:41:20.629Z" },
+    { url = "https://files.pythonhosted.org/packages/12/da/91a52516e9d5aea87d32d1523f9cdcf7a35a3b298e6be05d6509ba3cfab2/coverage-7.13.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fa3edde1aa8807de1d05934982416cb3ec46d1d4d91e280bcce7cca01c507992", size = 252907, upload-time = "2025-12-28T15:41:22.257Z" },
+    { url = "https://files.pythonhosted.org/packages/75/38/f1ea837e3dc1231e086db1638947e00d264e7e8c41aa8ecacf6e1e0c05f4/coverage-7.13.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9edd0e01a343766add6817bc448408858ba6b489039eaaa2018474e4001651a4", size = 254148, upload-time = "2025-12-28T15:41:23.87Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/43/f4f16b881aaa34954ba446318dea6b9ed5405dd725dd8daac2358eda869a/coverage-7.13.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:985b7836931d033570b94c94713c6dba5f9d3ff26045f72c3e5dbc5fe3361e5a", size = 250515, upload-time = "2025-12-28T15:41:25.437Z" },
+    { url = "https://files.pythonhosted.org/packages/84/34/8cba7f00078bd468ea914134e0144263194ce849ec3baad187ffb6203d1c/coverage-7.13.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ffed1e4980889765c84a5d1a566159e363b71d6b6fbaf0bebc9d3c30bc016766", size = 252292, upload-time = "2025-12-28T15:41:28.459Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a4/cffac66c7652d84ee4ac52d3ccb94c015687d3b513f9db04bfcac2ac800d/coverage-7.13.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8842af7f175078456b8b17f1b73a0d16a65dcbdc653ecefeb00a56b3c8c298c4", size = 250242, upload-time = "2025-12-28T15:41:30.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/78/9a64d462263dde416f3c0067efade7b52b52796f489b1037a95b0dc389c9/coverage-7.13.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ccd7a6fca48ca9c131d9b0a2972a581e28b13416fc313fb98b6d24a03ce9a398", size = 250068, upload-time = "2025-12-28T15:41:32.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c8/a8994f5fece06db7c4a97c8fc1973684e178599b42e66280dded0524ef00/coverage-7.13.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0403f647055de2609be776965108447deb8e384fe4a553c119e3ff6bfbab4784", size = 251846, upload-time = "2025-12-28T15:41:33.946Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f7/91fa73c4b80305c86598a2d4e54ba22df6bf7d0d97500944af7ef155d9f7/coverage-7.13.1-cp313-cp313-win32.whl", hash = "sha256:549d195116a1ba1e1ae2f5ca143f9777800f6636eab917d4f02b5310d6d73461", size = 221512, upload-time = "2025-12-28T15:41:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0b/0768b4231d5a044da8f75e097a8714ae1041246bb765d6b5563bab456735/coverage-7.13.1-cp313-cp313-win_amd64.whl", hash = "sha256:5899d28b5276f536fcf840b18b61a9fce23cc3aec1d114c44c07fe94ebeaa500", size = 222321, upload-time = "2025-12-28T15:41:37.371Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b8/bdcb7253b7e85157282450262008f1366aa04663f3e3e4c30436f596c3e2/coverage-7.13.1-cp313-cp313-win_arm64.whl", hash = "sha256:868a2fae76dfb06e87291bcbd4dcbcc778a8500510b618d50496e520bd94d9b9", size = 220949, upload-time = "2025-12-28T15:41:39.553Z" },
+    { url = "https://files.pythonhosted.org/packages/70/52/f2be52cc445ff75ea8397948c96c1b4ee14f7f9086ea62fc929c5ae7b717/coverage-7.13.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67170979de0dacac3f3097d02b0ad188d8edcea44ccc44aaa0550af49150c7dc", size = 219643, upload-time = "2025-12-28T15:41:41.567Z" },
+    { url = "https://files.pythonhosted.org/packages/47/79/c85e378eaa239e2edec0c5523f71542c7793fe3340954eafb0bc3904d32d/coverage-7.13.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f80e2bb21bfab56ed7405c2d79d34b5dc0bc96c2c1d2a067b643a09fb756c43a", size = 219997, upload-time = "2025-12-28T15:41:43.418Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9b/b1ade8bfb653c0bbce2d6d6e90cc6c254cbb99b7248531cc76253cb4da6d/coverage-7.13.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f83351e0f7dcdb14d7326c3d8d8c4e915fa685cbfdc6281f9470d97a04e9dfe4", size = 261296, upload-time = "2025-12-28T15:41:45.207Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/af/ebf91e3e1a2473d523e87e87fd8581e0aa08741b96265730e2d79ce78d8d/coverage-7.13.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bb3f6562e89bad0110afbe64e485aac2462efdce6232cdec7862a095dc3412f6", size = 263363, upload-time = "2025-12-28T15:41:47.163Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8b/fb2423526d446596624ac7fde12ea4262e66f86f5120114c3cfd0bb2befa/coverage-7.13.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77545b5dcda13b70f872c3b5974ac64c21d05e65b1590b441c8560115dc3a0d1", size = 265783, upload-time = "2025-12-28T15:41:49.03Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/26/ef2adb1e22674913b89f0fe7490ecadcef4a71fa96f5ced90c60ec358789/coverage-7.13.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4d240d260a1aed814790bbe1f10a5ff31ce6c21bc78f0da4a1e8268d6c80dbd", size = 260508, upload-time = "2025-12-28T15:41:51.035Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/7d/f0f59b3404caf662e7b5346247883887687c074ce67ba453ea08c612b1d5/coverage-7.13.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d2287ac9360dec3837bfdad969963a5d073a09a85d898bd86bea82aa8876ef3c", size = 263357, upload-time = "2025-12-28T15:41:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b1/29896492b0b1a047604d35d6fa804f12818fa30cdad660763a5f3159e158/coverage-7.13.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:0d2c11f3ea4db66b5cbded23b20185c35066892c67d80ec4be4bab257b9ad1e0", size = 260978, upload-time = "2025-12-28T15:41:54.589Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f2/971de1238a62e6f0a4128d37adadc8bb882ee96afbe03ff1570291754629/coverage-7.13.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:3fc6a169517ca0d7ca6846c3c5392ef2b9e38896f61d615cb75b9e7134d4ee1e", size = 259877, upload-time = "2025-12-28T15:41:56.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fc/0474efcbb590ff8628830e9aaec5f1831594874360e3251f1fdec31d07a3/coverage-7.13.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d10a2ed46386e850bb3de503a54f9fe8192e5917fcbb143bfef653a9355e9a53", size = 262069, upload-time = "2025-12-28T15:41:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4f/3c159b7953db37a7b44c0eab8a95c37d1aa4257c47b4602c04022d5cb975/coverage-7.13.1-cp313-cp313t-win32.whl", hash = "sha256:75a6f4aa904301dab8022397a22c0039edc1f51e90b83dbd4464b8a38dc87842", size = 222184, upload-time = "2025-12-28T15:41:59.763Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/6b57d28f81417f9335774f20679d9d13b9a8fb90cd6160957aa3b54a2379/coverage-7.13.1-cp313-cp313t-win_amd64.whl", hash = "sha256:309ef5706e95e62578cda256b97f5e097916a2c26247c287bbe74794e7150df2", size = 223250, upload-time = "2025-12-28T15:42:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7c/160796f3b035acfbb58be80e02e484548595aa67e16a6345e7910ace0a38/coverage-7.13.1-cp313-cp313t-win_arm64.whl", hash = "sha256:92f980729e79b5d16d221038dbf2e8f9a9136afa072f9d5d6ed4cb984b126a09", size = 221521, upload-time = "2025-12-28T15:42:03.275Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/8e/ba0e597560c6563fc0adb902fda6526df5d4aa73bb10adf0574d03bd2206/coverage-7.13.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:97ab3647280d458a1f9adb85244e81587505a43c0c7cff851f5116cd2814b894", size = 218996, upload-time = "2025-12-28T15:42:04.978Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8e/764c6e116f4221dc7aa26c4061181ff92edb9c799adae6433d18eeba7a14/coverage-7.13.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8f572d989142e0908e6acf57ad1b9b86989ff057c006d13b76c146ec6a20216a", size = 219326, upload-time = "2025-12-28T15:42:06.691Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a6/6130dc6d8da28cdcbb0f2bf8865aeca9b157622f7c0031e48c6cf9a0e591/coverage-7.13.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d72140ccf8a147e94274024ff6fd8fb7811354cf7ef88b1f0a988ebaa5bc774f", size = 250374, upload-time = "2025-12-28T15:42:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2b/783ded568f7cd6b677762f780ad338bf4b4750205860c17c25f7c708995e/coverage-7.13.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d3c9f051b028810f5a87c88e5d6e9af3c0ff32ef62763bf15d29f740453ca909", size = 252882, upload-time = "2025-12-28T15:42:10.515Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b2/9808766d082e6a4d59eb0cc881a57fc1600eb2c5882813eefff8254f71b5/coverage-7.13.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f398ba4df52d30b1763f62eed9de5620dcde96e6f491f4c62686736b155aa6e4", size = 254218, upload-time = "2025-12-28T15:42:12.208Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ea/52a985bb447c871cb4d2e376e401116520991b597c85afdde1ea9ef54f2c/coverage-7.13.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:132718176cc723026d201e347f800cd1a9e4b62ccd3f82476950834dad501c75", size = 250391, upload-time = "2025-12-28T15:42:14.21Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1d/125b36cc12310718873cfc8209ecfbc1008f14f4f5fa0662aa608e579353/coverage-7.13.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e549d642426e3579b3f4b92d0431543b012dcb6e825c91619d4e93b7363c3f9", size = 252239, upload-time = "2025-12-28T15:42:16.292Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/16/10c1c164950cade470107f9f14bbac8485f8fb8515f515fca53d337e4a7f/coverage-7.13.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:90480b2134999301eea795b3a9dbf606c6fbab1b489150c501da84a959442465", size = 250196, upload-time = "2025-12-28T15:42:18.54Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c6/cd860fac08780c6fd659732f6ced1b40b79c35977c1356344e44d72ba6c4/coverage-7.13.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e825dbb7f84dfa24663dd75835e7257f8882629fc11f03ecf77d84a75134b864", size = 250008, upload-time = "2025-12-28T15:42:20.365Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/a8c58d3d38f82a5711e1e0a67268362af48e1a03df27c03072ac30feefcf/coverage-7.13.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:623dcc6d7a7ba450bbdbeedbaa0c42b329bdae16491af2282f12a7e809be7eb9", size = 251671, upload-time = "2025-12-28T15:42:22.114Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/bc/fd4c1da651d037a1e3d53e8cb3f8182f4b53271ffa9a95a2e211bacc0349/coverage-7.13.1-cp314-cp314-win32.whl", hash = "sha256:6e73ebb44dca5f708dc871fe0b90cf4cff1a13f9956f747cc87b535a840386f5", size = 221777, upload-time = "2025-12-28T15:42:23.919Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/71acabdc8948464c17e90b5ffd92358579bd0910732c2a1c9537d7536aa6/coverage-7.13.1-cp314-cp314-win_amd64.whl", hash = "sha256:be753b225d159feb397bd0bf91ae86f689bad0da09d3b301478cd39b878ab31a", size = 222592, upload-time = "2025-12-28T15:42:25.619Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/c8/a6fb943081bb0cc926499c7907731a6dc9efc2cbdc76d738c0ab752f1a32/coverage-7.13.1-cp314-cp314-win_arm64.whl", hash = "sha256:228b90f613b25ba0019361e4ab81520b343b622fc657daf7e501c4ed6a2366c0", size = 221169, upload-time = "2025-12-28T15:42:27.629Z" },
+    { url = "https://files.pythonhosted.org/packages/16/61/d5b7a0a0e0e40d62e59bc8c7aa1afbd86280d82728ba97f0673b746b78e2/coverage-7.13.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:60cfb538fe9ef86e5b2ab0ca8fc8d62524777f6c611dcaf76dc16fbe9b8e698a", size = 219730, upload-time = "2025-12-28T15:42:29.306Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2c/8881326445fd071bb49514d1ce97d18a46a980712b51fee84f9ab42845b4/coverage-7.13.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:57dfc8048c72ba48a8c45e188d811e5efd7e49b387effc8fb17e97936dde5bf6", size = 220001, upload-time = "2025-12-28T15:42:31.319Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d7/50de63af51dfa3a7f91cc37ad8fcc1e244b734232fbc8b9ab0f3c834a5cd/coverage-7.13.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3f2f725aa3e909b3c5fdb8192490bdd8e1495e85906af74fe6e34a2a77ba0673", size = 261370, upload-time = "2025-12-28T15:42:32.992Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2c/d31722f0ec918fd7453b2758312729f645978d212b410cd0f7c2aed88a94/coverage-7.13.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ee68b21909686eeb21dfcba2c3b81fee70dcf38b140dcd5aa70680995fa3aa5", size = 263485, upload-time = "2025-12-28T15:42:34.759Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7a/2c114fa5c5fc08ba0777e4aec4c97e0b4a1afcb69c75f1f54cff78b073ab/coverage-7.13.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724b1b270cb13ea2e6503476e34541a0b1f62280bc997eab443f87790202033d", size = 265890, upload-time = "2025-12-28T15:42:36.517Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d9/f0794aa1c74ceabc780fe17f6c338456bbc4e96bd950f2e969f48ac6fb20/coverage-7.13.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:916abf1ac5cf7eb16bc540a5bf75c71c43a676f5c52fcb9fe75a2bd75fb944e8", size = 260445, upload-time = "2025-12-28T15:42:38.646Z" },
+    { url = "https://files.pythonhosted.org/packages/49/23/184b22a00d9bb97488863ced9454068c79e413cb23f472da6cbddc6cfc52/coverage-7.13.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:776483fd35b58d8afe3acbd9988d5de592ab6da2d2a865edfdbc9fdb43e7c486", size = 263357, upload-time = "2025-12-28T15:42:40.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bd/58af54c0c9199ea4190284f389005779d7daf7bf3ce40dcd2d2b2f96da69/coverage-7.13.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b6f3b96617e9852703f5b633ea01315ca45c77e879584f283c44127f0f1ec564", size = 260959, upload-time = "2025-12-28T15:42:42.808Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2a/6839294e8f78a4891bf1df79d69c536880ba2f970d0ff09e7513d6e352e9/coverage-7.13.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd63e7b74661fed317212fab774e2a648bc4bb09b35f25474f8e3325d2945cd7", size = 259792, upload-time = "2025-12-28T15:42:44.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c3/528674d4623283310ad676c5af7414b9850ab6d55c2300e8aa4b945ec554/coverage-7.13.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:933082f161bbb3e9f90d00990dc956120f608cdbcaeea15c4d897f56ef4fe416", size = 262123, upload-time = "2025-12-28T15:42:47.108Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c5/8c0515692fb4c73ac379d8dc09b18eaf0214ecb76ea6e62467ba7a1556ff/coverage-7.13.1-cp314-cp314t-win32.whl", hash = "sha256:18be793c4c87de2965e1c0f060f03d9e5aff66cfeae8e1dbe6e5b88056ec153f", size = 222562, upload-time = "2025-12-28T15:42:49.144Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0e/c0a0c4678cb30dac735811db529b321d7e1c9120b79bd728d4f4d6b010e9/coverage-7.13.1-cp314-cp314t-win_amd64.whl", hash = "sha256:0e42e0ec0cd3e0d851cb3c91f770c9301f48647cb2877cb78f74bdaa07639a79", size = 223670, upload-time = "2025-12-28T15:42:51.218Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/b177aa0011f354abf03a8f30a85032686d290fdeed4222b27d36b4372a50/coverage-7.13.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eaecf47ef10c72ece9a2a92118257da87e460e113b83cc0d2905cbbe931792b4", size = 221707, upload-time = "2025-12-28T15:42:53.034Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/48/d9f421cb8da5afaa1a64570d9989e00fb7955e6acddc5a12979f7666ef60/coverage-7.13.1-py3-none-any.whl", hash = "sha256:2016745cb3ba554469d02819d78958b571792bb68e31302610e898f80dd3a573", size = 210722, upload-time = "2025-12-28T15:42:54.901Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "44.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/d6/1411ab4d6108ab167d06254c5be517681f1e331f90edf1379895bcb87020/cryptography-44.0.3.tar.gz", hash = "sha256:fe19d8bc5536a91a24a8133328880a41831b6c5df54599a8417b62fe015d3053", size = 711096, upload-time = "2025-05-02T19:36:04.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/53/c776d80e9d26441bb3868457909b4e74dd9ccabd182e10b2b0ae7a07e265/cryptography-44.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:962bc30480a08d133e631e8dfd4783ab71cc9e33d5d7c1e192f0b7c06397bb88", size = 6670281, upload-time = "2025-05-02T19:34:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/06/af2cf8d56ef87c77319e9086601bef621bedf40f6f59069e1b6d1ec498c5/cryptography-44.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ffc61e8f3bf5b60346d89cd3d37231019c17a081208dfbbd6e1605ba03fa137", size = 3959305, upload-time = "2025-05-02T19:34:53.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/01/80de3bec64627207d030f47bf3536889efee8913cd363e78ca9a09b13c8e/cryptography-44.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58968d331425a6f9eedcee087f77fd3c927c88f55368f43ff7e0a19891f2642c", size = 4171040, upload-time = "2025-05-02T19:34:54.675Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/48/bb16b7541d207a19d9ae8b541c70037a05e473ddc72ccb1386524d4f023c/cryptography-44.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e28d62e59a4dbd1d22e747f57d4f00c459af22181f0b2f787ea83f5a876d7c76", size = 3963411, upload-time = "2025-05-02T19:34:56.61Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b2/7d31f2af5591d217d71d37d044ef5412945a8a8e98d5a2a8ae4fd9cd4489/cryptography-44.0.3-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:af653022a0c25ef2e3ffb2c673a50e5a0d02fecc41608f4954176f1933b12359", size = 3689263, upload-time = "2025-05-02T19:34:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/25/50/c0dfb9d87ae88ccc01aad8eb93e23cfbcea6a6a106a9b63a7b14c1f93c75/cryptography-44.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:157f1f3b8d941c2bd8f3ffee0af9b049c9665c39d3da9db2dc338feca5e98a43", size = 4196198, upload-time = "2025-05-02T19:35:00.988Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c9/55c6b8794a74da652690c898cb43906310a3e4e4f6ee0b5f8b3b3e70c441/cryptography-44.0.3-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:c6cd67722619e4d55fdb42ead64ed8843d64638e9c07f4011163e46bc512cf01", size = 3966502, upload-time = "2025-05-02T19:35:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f7/7cb5488c682ca59a02a32ec5f975074084db4c983f849d47b7b67cc8697a/cryptography-44.0.3-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b424563394c369a804ecbee9b06dfb34997f19d00b3518e39f83a5642618397d", size = 4196173, upload-time = "2025-05-02T19:35:05.018Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0b/2f789a8403ae089b0b121f8f54f4a3e5228df756e2146efdf4a09a3d5083/cryptography-44.0.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c91fc8e8fd78af553f98bc7f2a1d8db977334e4eea302a4bfd75b9461c2d8904", size = 4087713, upload-time = "2025-05-02T19:35:07.187Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/aa/330c13655f1af398fc154089295cf259252f0ba5df93b4bc9d9c7d7f843e/cryptography-44.0.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:25cd194c39fa5a0aa4169125ee27d1172097857b27109a45fadc59653ec06f44", size = 4299064, upload-time = "2025-05-02T19:35:08.879Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a8/8c540a421b44fd267a7d58a1fd5f072a552d72204a3f08194f98889de76d/cryptography-44.0.3-cp37-abi3-win32.whl", hash = "sha256:3be3f649d91cb182c3a6bd336de8b61a0a71965bd13d1a04a0e15b39c3d5809d", size = 2773887, upload-time = "2025-05-02T19:35:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0d/c4b1657c39ead18d76bbd122da86bd95bdc4095413460d09544000a17d56/cryptography-44.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:3883076d5c4cc56dbef0b898a74eb6992fdac29a7b9013870b34efe4ddb39a0d", size = 3209737, upload-time = "2025-05-02T19:35:12.12Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a3/ad08e0bcc34ad436013458d7528e83ac29910943cea42ad7dd4141a27bbb/cryptography-44.0.3-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:5639c2b16764c6f76eedf722dbad9a0914960d3489c0cc38694ddf9464f1bb2f", size = 6673501, upload-time = "2025-05-02T19:35:13.775Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f0/7491d44bba8d28b464a5bc8cc709f25a51e3eac54c0a4444cf2473a57c37/cryptography-44.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3ffef566ac88f75967d7abd852ed5f182da252d23fac11b4766da3957766759", size = 3960307, upload-time = "2025-05-02T19:35:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/c8/e5c5d0e1364d3346a5747cdcd7ecbb23ca87e6dea4f942a44e88be349f06/cryptography-44.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:192ed30fac1728f7587c6f4613c29c584abdc565d7417c13904708db10206645", size = 4170876, upload-time = "2025-05-02T19:35:18.138Z" },
+    { url = "https://files.pythonhosted.org/packages/73/96/025cb26fc351d8c7d3a1c44e20cf9a01e9f7cf740353c9c7a17072e4b264/cryptography-44.0.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7d5fe7195c27c32a64955740b949070f21cba664604291c298518d2e255931d2", size = 3964127, upload-time = "2025-05-02T19:35:19.864Z" },
+    { url = "https://files.pythonhosted.org/packages/01/44/eb6522db7d9f84e8833ba3bf63313f8e257729cf3a8917379473fcfd6601/cryptography-44.0.3-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3f07943aa4d7dad689e3bb1638ddc4944cc5e0921e3c227486daae0e31a05e54", size = 3689164, upload-time = "2025-05-02T19:35:21.449Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fb/d61a4defd0d6cee20b1b8a1ea8f5e25007e26aeb413ca53835f0cae2bcd1/cryptography-44.0.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cb90f60e03d563ca2445099edf605c16ed1d5b15182d21831f58460c48bffb93", size = 4198081, upload-time = "2025-05-02T19:35:23.187Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/50/457f6911d36432a8811c3ab8bd5a6090e8d18ce655c22820994913dd06ea/cryptography-44.0.3-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ab0b005721cc0039e885ac3503825661bd9810b15d4f374e473f8c89b7d5460c", size = 3967716, upload-time = "2025-05-02T19:35:25.426Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6e/dca39d553075980ccb631955c47b93d87d27f3596da8d48b1ae81463d915/cryptography-44.0.3-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3bb0847e6363c037df8f6ede57d88eaf3410ca2267fb12275370a76f85786a6f", size = 4197398, upload-time = "2025-05-02T19:35:27.678Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/9d/d1f2fe681eabc682067c66a74addd46c887ebacf39038ba01f8860338d3d/cryptography-44.0.3-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b0cc66c74c797e1db750aaa842ad5b8b78e14805a9b5d1348dc603612d3e3ff5", size = 4087900, upload-time = "2025-05-02T19:35:29.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f5/3599e48c5464580b73b236aafb20973b953cd2e7b44c7c2533de1d888446/cryptography-44.0.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6866df152b581f9429020320e5eb9794c8780e90f7ccb021940d7f50ee00ae0b", size = 4301067, upload-time = "2025-05-02T19:35:31.547Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/d2c48c8137eb39d0c193274db5c04a75dab20d2f7c3f81a7dcc3a8897701/cryptography-44.0.3-cp39-abi3-win32.whl", hash = "sha256:c138abae3a12a94c75c10499f1cbae81294a6f983b3af066390adee73f433028", size = 2775467, upload-time = "2025-05-02T19:35:33.805Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ad/51f212198681ea7b0deaaf8846ee10af99fba4e894f67b353524eab2bbe5/cryptography-44.0.3-cp39-abi3-win_amd64.whl", hash = "sha256:5d186f32e52e66994dce4f766884bcb9c68b8da62d61d9d215bfe5fb56d21334", size = 3210375, upload-time = "2025-05-02T19:35:35.369Z" },
+]
+
+[[package]]
+name = "cyclopts"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7b/663f3285c1ac0e5d0854bd9db2c87caa6fa3d1a063185e3394a6cdca9151/cyclopts-4.5.0.tar.gz", hash = "sha256:717ac4235548b58d500baf7e688aa4d024caf0ee68f61a012ffd5e29db3099f9", size = 161980, upload-time = "2026-01-16T02:07:16.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/a3/2e00fececc34a99ae3a5d5702a5dd29c5371e4ed016647301a2b9bcc1976/cyclopts-4.5.0-py3-none-any.whl", hash = "sha256:305b9aa90a9cd0916f0a450b43e50ad5df9c252680731a0719edfb9b20381bf5", size = 199772, upload-time = "2026-01-16T02:07:14.707Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "2.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "openapi-core" },
+    { name = "openapi-pydantic" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pyperclip" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/8a/c46759bb41a53187191e5b3d963c0bde54783ecc89186a93c4947607b8e4/fastmcp-2.12.2.tar.gz", hash = "sha256:6d13e2f9be57b99763fc22485f9f603daa23bfbca35a8172baa43b283d6fc1ff", size = 5244547, upload-time = "2025-09-03T21:28:09.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/7a8d564b1b9909dbfc36eb93d76410a4acfada6b1e13ee451a753bb6dbc2/fastmcp-2.12.2-py3-none-any.whl", hash = "sha256:0b58d68e819c82078d1fd51989d3d81f2be7382d527308b06df55f4d0a4ec94f", size = 312029, upload-time = "2025-09-03T21:28:08.62Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/45/41ebc679c2a4fced6a722f624c18d658dee42612b83ea24c1caf7c0eb3a8/jsonschema_path-0.3.4.tar.gz", hash = "sha256:8365356039f16cc65fddffafda5f58766e34bebab7d6d105616ab52bc4297001", size = 11159, upload-time = "2025-01-24T14:33:16.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/58/3485da8cb93d2f393bce453adeef16896751f14ba3e2024bc21dc9597646/jsonschema_path-0.3.4-py3-none-any.whl", hash = "sha256:f502191fdc2b22050f9a81c9237be9d27145b9001c55842bece5e94e382e52f8", size = 14810, upload-time = "2025-01-24T14:33:14.652Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a2/69df9c6ba6d316cfd81fe2381e464db3e6de5db45f8c43c6a23504abf8cb/lazy_object_proxy-1.12.0.tar.gz", hash = "sha256:1f5a462d92fd0cfb82f1fab28b51bfb209fabbe6aabf7f0d51472c0c124c0c61", size = 43681, upload-time = "2025-08-22T13:50:06.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/26/b74c791008841f8ad896c7f293415136c66cc27e7c7577de4ee68040c110/lazy_object_proxy-1.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:86fd61cb2ba249b9f436d789d1356deae69ad3231dc3c0f17293ac535162672e", size = 26745, upload-time = "2025-08-22T13:42:44.982Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/52/641870d309e5d1fb1ea7d462a818ca727e43bfa431d8c34b173eb090348c/lazy_object_proxy-1.12.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:81d1852fb30fab81696f93db1b1e55a5d1ff7940838191062f5f56987d5fcc3e", size = 71537, upload-time = "2025-08-22T13:42:46.141Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b6/919118e99d51c5e76e8bf5a27df406884921c0acf2c7b8a3b38d847ab3e9/lazy_object_proxy-1.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9045646d83f6c2664c1330904b245ae2371b5c57a3195e4028aedc9f999655", size = 71141, upload-time = "2025-08-22T13:42:47.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/47/1d20e626567b41de085cf4d4fb3661a56c159feaa73c825917b3b4d4f806/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:67f07ab742f1adfb3966c40f630baaa7902be4222a17941f3d85fd1dae5565ff", size = 69449, upload-time = "2025-08-22T13:42:48.49Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8d/25c20ff1a1a8426d9af2d0b6f29f6388005fc8cd10d6ee71f48bff86fdd0/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ba769017b944fcacbf6a80c18b2761a1795b03f8899acdad1f1c39db4409be", size = 70744, upload-time = "2025-08-22T13:42:49.608Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/67/8ec9abe15c4f8a4bcc6e65160a2c667240d025cbb6591b879bea55625263/lazy_object_proxy-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:7b22c2bbfb155706b928ac4d74c1a63ac8552a55ba7fff4445155523ea4067e1", size = 26568, upload-time = "2025-08-22T13:42:57.719Z" },
+    { url = "https://files.pythonhosted.org/packages/23/12/cd2235463f3469fd6c62d41d92b7f120e8134f76e52421413a0ad16d493e/lazy_object_proxy-1.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4a79b909aa16bde8ae606f06e6bbc9d3219d2e57fb3e0076e17879072b742c65", size = 27391, upload-time = "2025-08-22T13:42:50.62Z" },
+    { url = "https://files.pythonhosted.org/packages/60/9e/f1c53e39bbebad2e8609c67d0830cc275f694d0ea23d78e8f6db526c12d3/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:338ab2f132276203e404951205fe80c3fd59429b3a724e7b662b2eb539bb1be9", size = 80552, upload-time = "2025-08-22T13:42:51.731Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/6c513693448dcb317d9d8c91d91f47addc09553613379e504435b4cc8b3e/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c40b3c9faee2e32bfce0df4ae63f4e73529766893258eca78548bac801c8f66", size = 82857, upload-time = "2025-08-22T13:42:53.225Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1c/d9c4aaa4c75da11eb7c22c43d7c90a53b4fca0e27784a5ab207768debea7/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:717484c309df78cedf48396e420fa57fc8a2b1f06ea889df7248fdd156e58847", size = 80833, upload-time = "2025-08-22T13:42:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ae/29117275aac7d7d78ae4f5a4787f36ff33262499d486ac0bf3e0b97889f6/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a6b7ea5ea1ffe15059eb44bcbcb258f97bcb40e139b88152c40d07b1a1dfc9ac", size = 79516, upload-time = "2025-08-22T13:42:55.812Z" },
+    { url = "https://files.pythonhosted.org/packages/19/40/b4e48b2c38c69392ae702ae7afa7b6551e0ca5d38263198b7c79de8b3bdf/lazy_object_proxy-1.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:08c465fb5cd23527512f9bd7b4c7ba6cec33e28aad36fbbe46bf7b858f9f3f7f", size = 27656, upload-time = "2025-08-22T13:42:56.793Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/3a/277857b51ae419a1574557c0b12e0d06bf327b758ba94cafc664cb1e2f66/lazy_object_proxy-1.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c9defba70ab943f1df98a656247966d7729da2fe9c2d5d85346464bf320820a3", size = 26582, upload-time = "2025-08-22T13:49:49.366Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b6/c5e0fa43535bb9c87880e0ba037cdb1c50e01850b0831e80eb4f4762f270/lazy_object_proxy-1.12.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6763941dbf97eea6b90f5b06eb4da9418cc088fce0e3883f5816090f9afcde4a", size = 71059, upload-time = "2025-08-22T13:49:50.488Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8a/7dcad19c685963c652624702f1a968ff10220b16bfcc442257038216bf55/lazy_object_proxy-1.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdc70d81235fc586b9e3d1aeef7d1553259b62ecaae9db2167a5d2550dcc391a", size = 71034, upload-time = "2025-08-22T13:49:54.224Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ac/34cbfb433a10e28c7fd830f91c5a348462ba748413cbb950c7f259e67aa7/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0a83c6f7a6b2bfc11ef3ed67f8cbe99f8ff500b05655d8e7df9aab993a6abc95", size = 69529, upload-time = "2025-08-22T13:49:55.29Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6a/11ad7e349307c3ca4c0175db7a77d60ce42a41c60bcb11800aabd6a8acb8/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:256262384ebd2a77b023ad02fbcc9326282bcfd16484d5531154b02bc304f4c5", size = 70391, upload-time = "2025-08-22T13:49:56.35Z" },
+    { url = "https://files.pythonhosted.org/packages/59/97/9b410ed8fbc6e79c1ee8b13f8777a80137d4bc189caf2c6202358e66192c/lazy_object_proxy-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7601ec171c7e8584f8ff3f4e440aa2eebf93e854f04639263875b8c2971f819f", size = 26988, upload-time = "2025-08-22T13:49:57.302Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/2d/649d80a0ecf6a1f82632ca44bec21c0461a9d9fc8934d38cb5b319f2db5e/mcp-1.25.0.tar.gz", hash = "sha256:56310361ebf0364e2d438e5b45f7668cbb124e158bb358333cd06e49e83a6802", size = 605387, upload-time = "2025-12-19T10:19:56.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl", hash = "sha256:b37c38144a666add0862614cc79ec276e97d72aa8ca26d622818d4e278b9721a", size = 233076, upload-time = "2025-12-19T10:19:55.416Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
+name = "oci"
+version = "2.160.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "circuitbreaker" },
+    { name = "cryptography" },
+    { name = "pyopenssl" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/7b/c9d7fc28f11c25c7875db3584eab5d52ccb2d7df553d07ac47f19a14d075/oci-2.160.0.tar.gz", hash = "sha256:f8e3410204c1405b40247179550cf74f5145a8e17025c4f2a92f2b9ffdc7d26b", size = 15601606, upload-time = "2025-09-09T04:17:43.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/51/752375a4e0d2de371c2788414157eda337417010d2ef7383cd7140388f1e/oci-2.160.0-py3-none-any.whl", hash = "sha256:3dba1ec671ebea23f255fabf836cb0fd08aea0913a8df85610fccaa5a4344ee9", size = 31715365, upload-time = "2025-09-09T04:17:34.998Z" },
+]
+
+[[package]]
+name = "openapi-core"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "isodate" },
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "more-itertools" },
+    { name = "openapi-schema-validator" },
+    { name = "openapi-spec-validator" },
+    { name = "typing-extensions" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/65/ee75f25b9459a02df6f713f8ffde5dacb57b8b4e45145cde4cab28b5abba/openapi_core-0.22.0.tar.gz", hash = "sha256:b30490dfa74e3aac2276105525590135212352f5dd7e5acf8f62f6a89ed6f2d0", size = 109242, upload-time = "2025-12-22T19:19:49.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/8e/a1bf9e7d1b170122aa33b6cf2c788b68824712427deb19795eb7db1b8dd5/openapi_core-0.22.0-py3-none-any.whl", hash = "sha256:8fb7c325f2db4ef6c60584b1870f90eeb3183aa47e30643715c5003b7677a149", size = 108384, upload-time = "2025-12-22T19:19:47.904Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "openapi-schema-validator"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-specifications" },
+    { name = "rfc3339-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/f3/5507ad3325169347cd8ced61c232ff3df70e2b250c49f0fe140edb4973c6/openapi_schema_validator-0.6.3.tar.gz", hash = "sha256:f37bace4fc2a5d96692f4f8b31dc0f8d7400fd04f3a937798eaf880d425de6ee", size = 11550, upload-time = "2025-01-10T18:08:22.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/c6/ad0fba32775ae749016829dace42ed80f4407b171da41313d1a3a5f102e4/openapi_schema_validator-0.6.3-py3-none-any.whl", hash = "sha256:f3b9870f4e556b5a62a1c39da72a6b4b16f3ad9c73dc80084b1b11e74ba148a3", size = 8755, upload-time = "2025-01-10T18:08:19.758Z" },
+]
+
+[[package]]
+name = "openapi-spec-validator"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "lazy-object-proxy" },
+    { name = "openapi-schema-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/af/fe2d7618d6eae6fb3a82766a44ed87cd8d6d82b4564ed1c7cfb0f6378e91/openapi_spec_validator-0.7.2.tar.gz", hash = "sha256:cc029309b5c5dbc7859df0372d55e9d1ff43e96d678b9ba087f7c56fc586f734", size = 36855, upload-time = "2025-06-07T14:48:56.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/dd/b3fd642260cb17532f66cc1e8250f3507d1e580483e209dc1e9d13bd980d/openapi_spec_validator-0.7.2-py3-none-any.whl", hash = "sha256:4bbdc0894ec85f1d1bea1d6d9c8b2c3c8d7ccaa13577ef40da9c006c9fd0eb60", size = 39713, upload-time = "2025-06-07T14:48:54.077Z" },
+]
+
+[[package]]
+name = "oracle-oci-load-balancer-mcp-server"
+version = "0.0.1"
+source = { editable = "." }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "oci" },
+    { name = "pydantic" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", specifier = "==2.12.2" },
+    { name = "oci", specifier = "==2.160.0" },
+    { name = "pydantic", specifier = "==2.12.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/93/8f2c2075b180c12c1e9f6a09d1a985bc2036906b13dff1d8917e395f2048/pathable-0.4.4.tar.gz", hash = "sha256:6905a3cd17804edfac7875b5f6c9142a218c7caef78693c2dbbbfbac186d88b2", size = 8124, upload-time = "2025-01-10T18:43:13.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/eb/b6260b31b1a96386c0a880edebe26f89669098acea8e0318bff6adb378fd/pathable-0.4.4-py3-none-any.whl", hash = "sha256:5ae9e94793b6ef5a4cbe0a7ce9dbbefc1eec38df253763fd0aeeacf2762dbbc2", size = 9592, upload-time = "2025-01-10T18:43:11.88Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/1e/4f0a3233767010308f2fd6bd0814597e3f63f1dc98304a9112b8759df4ff/pydantic-2.12.3.tar.gz", hash = "sha256:1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74", size = 819383, upload-time = "2025-10-17T15:04:21.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/6b/83661fa77dcefa195ad5f8cd9af3d1a7450fd57cc883ad04d65446ac2029/pydantic-2.12.3-py3-none-any.whl", hash = "sha256:6986454a854bc3bc6e5443e1369e06a3a456af9d339eda45510f517d9ea5c6bf", size = 462431, upload-time = "2025-10-17T15:04:19.346Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/18/d0944e8eaaa3efd0a91b0f1fc537d3be55ad35091b6a87638211ba691964/pydantic_core-2.41.4.tar.gz", hash = "sha256:70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5", size = 457557, upload-time = "2025-10-14T10:23:47.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/d0/c20adabd181a029a970738dfe23710b52a31f1258f591874fcdec7359845/pydantic_core-2.41.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:85e050ad9e5f6fe1004eec65c914332e52f429bc0ae12d6fa2092407a462c746", size = 2105688, upload-time = "2025-10-14T10:20:54.448Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b6/0ce5c03cec5ae94cca220dfecddc453c077d71363b98a4bbdb3c0b22c783/pydantic_core-2.41.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7393f1d64792763a48924ba31d1e44c2cfbc05e3b1c2c9abb4ceeadd912cced", size = 1910807, upload-time = "2025-10-14T10:20:56.115Z" },
+    { url = "https://files.pythonhosted.org/packages/68/3e/800d3d02c8beb0b5c069c870cbb83799d085debf43499c897bb4b4aaff0d/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94dab0940b0d1fb28bcab847adf887c66a27a40291eedf0b473be58761c9799a", size = 1956669, upload-time = "2025-10-14T10:20:57.874Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a4/24271cc71a17f64589be49ab8bd0751f6a0a03046c690df60989f2f95c2c/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de7c42f897e689ee6f9e93c4bec72b99ae3b32a2ade1c7e4798e690ff5246e02", size = 2051629, upload-time = "2025-10-14T10:21:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/68/de/45af3ca2f175d91b96bfb62e1f2d2f1f9f3b14a734afe0bfeff079f78181/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:664b3199193262277b8b3cd1e754fb07f2c6023289c815a1e1e8fb415cb247b1", size = 2224049, upload-time = "2025-10-14T10:21:01.801Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/ae4e1ff84672bf869d0a77af24fd78387850e9497753c432875066b5d622/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d95b253b88f7d308b1c0b417c4624f44553ba4762816f94e6986819b9c273fb2", size = 2342409, upload-time = "2025-10-14T10:21:03.556Z" },
+    { url = "https://files.pythonhosted.org/packages/18/62/273dd70b0026a085c7b74b000394e1ef95719ea579c76ea2f0cc8893736d/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1351f5bbdbbabc689727cb91649a00cb9ee7203e0a6e54e9f5ba9e22e384b84", size = 2069635, upload-time = "2025-10-14T10:21:05.385Z" },
+    { url = "https://files.pythonhosted.org/packages/30/03/cf485fff699b4cdaea469bc481719d3e49f023241b4abb656f8d422189fc/pydantic_core-2.41.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1affa4798520b148d7182da0615d648e752de4ab1a9566b7471bc803d88a062d", size = 2194284, upload-time = "2025-10-14T10:21:07.122Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/7e/c8e713db32405dfd97211f2fc0a15d6bf8adb7640f3d18544c1f39526619/pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7b74e18052fea4aa8dea2fb7dbc23d15439695da6cbe6cfc1b694af1115df09d", size = 2137566, upload-time = "2025-10-14T10:21:08.981Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f7/db71fd4cdccc8b75990f79ccafbbd66757e19f6d5ee724a6252414483fb4/pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:285b643d75c0e30abda9dc1077395624f314a37e3c09ca402d4015ef5979f1a2", size = 2316809, upload-time = "2025-10-14T10:21:10.805Z" },
+    { url = "https://files.pythonhosted.org/packages/76/63/a54973ddb945f1bca56742b48b144d85c9fc22f819ddeb9f861c249d5464/pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f52679ff4218d713b3b33f88c89ccbf3a5c2c12ba665fb80ccc4192b4608dbab", size = 2311119, upload-time = "2025-10-14T10:21:12.583Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/03/5d12891e93c19218af74843a27e32b94922195ded2386f7b55382f904d2f/pydantic_core-2.41.4-cp313-cp313-win32.whl", hash = "sha256:ecde6dedd6fff127c273c76821bb754d793be1024bc33314a120f83a3c69460c", size = 1981398, upload-time = "2025-10-14T10:21:14.584Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d8/fd0de71f39db91135b7a26996160de71c073d8635edfce8b3c3681be0d6d/pydantic_core-2.41.4-cp313-cp313-win_amd64.whl", hash = "sha256:d081a1f3800f05409ed868ebb2d74ac39dd0c1ff6c035b5162356d76030736d4", size = 2030735, upload-time = "2025-10-14T10:21:16.432Z" },
+    { url = "https://files.pythonhosted.org/packages/72/86/c99921c1cf6650023c08bfab6fe2d7057a5142628ef7ccfa9921f2dda1d5/pydantic_core-2.41.4-cp313-cp313-win_arm64.whl", hash = "sha256:f8e49c9c364a7edcbe2a310f12733aad95b022495ef2a8d653f645e5d20c1564", size = 1973209, upload-time = "2025-10-14T10:21:18.213Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0d/b5706cacb70a8414396efdda3d72ae0542e050b591119e458e2490baf035/pydantic_core-2.41.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ed97fd56a561f5eb5706cebe94f1ad7c13b84d98312a05546f2ad036bafe87f4", size = 1877324, upload-time = "2025-10-14T10:21:20.363Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2d/cba1fa02cfdea72dfb3a9babb067c83b9dff0bbcb198368e000a6b756ea7/pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a870c307bf1ee91fc58a9a61338ff780d01bfae45922624816878dce784095d2", size = 1884515, upload-time = "2025-10-14T10:21:22.339Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ea/3df927c4384ed9b503c9cc2d076cf983b4f2adb0c754578dfb1245c51e46/pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d25e97bc1f5f8f7985bdc2335ef9e73843bb561eb1fa6831fdfc295c1c2061cf", size = 2042819, upload-time = "2025-10-14T10:21:26.683Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ee/df8e871f07074250270a3b1b82aad4cd0026b588acd5d7d3eb2fcb1471a3/pydantic_core-2.41.4-cp313-cp313t-win_amd64.whl", hash = "sha256:d405d14bea042f166512add3091c1af40437c2e7f86988f3915fabd27b1e9cd2", size = 1995866, upload-time = "2025-10-14T10:21:28.951Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/de/b20f4ab954d6d399499c33ec4fafc46d9551e11dc1858fb7f5dca0748ceb/pydantic_core-2.41.4-cp313-cp313t-win_arm64.whl", hash = "sha256:19f3684868309db5263a11bace3c45d93f6f24afa2ffe75a647583df22a2ff89", size = 1970034, upload-time = "2025-10-14T10:21:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/54/28/d3325da57d413b9819365546eb9a6e8b7cbd9373d9380efd5f74326143e6/pydantic_core-2.41.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:e9205d97ed08a82ebb9a307e92914bb30e18cdf6f6b12ca4bedadb1588a0bfe1", size = 2102022, upload-time = "2025-10-14T10:21:32.809Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/24/b58a1bc0d834bf1acc4361e61233ee217169a42efbdc15a60296e13ce438/pydantic_core-2.41.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:82df1f432b37d832709fbcc0e24394bba04a01b6ecf1ee87578145c19cde12ac", size = 1905495, upload-time = "2025-10-14T10:21:34.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a4/71f759cc41b7043e8ecdaab81b985a9b6cad7cec077e0b92cff8b71ecf6b/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3b4cc4539e055cfa39a3763c939f9d409eb40e85813257dcd761985a108554", size = 1956131, upload-time = "2025-10-14T10:21:36.924Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/64/1e79ac7aa51f1eec7c4cda8cbe456d5d09f05fdd68b32776d72168d54275/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b1eb1754fce47c63d2ff57fdb88c351a6c0150995890088b33767a10218eaa4e", size = 2052236, upload-time = "2025-10-14T10:21:38.927Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e3/a3ffc363bd4287b80f1d43dc1c28ba64831f8dfc237d6fec8f2661138d48/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6ab5ab30ef325b443f379ddb575a34969c333004fca5a1daa0133a6ffaad616", size = 2223573, upload-time = "2025-10-14T10:21:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/28/27/78814089b4d2e684a9088ede3790763c64693c3d1408ddc0a248bc789126/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:31a41030b1d9ca497634092b46481b937ff9397a86f9f51bd41c4767b6fc04af", size = 2342467, upload-time = "2025-10-14T10:21:44.018Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/4de0e2a1159cb85ad737e03306717637842c88c7fd6d97973172fb183149/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a44ac1738591472c3d020f61c6df1e4015180d6262ebd39bf2aeb52571b60f12", size = 2063754, upload-time = "2025-10-14T10:21:46.466Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/50/8cb90ce4b9efcf7ae78130afeb99fd1c86125ccdf9906ef64b9d42f37c25/pydantic_core-2.41.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d72f2b5e6e82ab8f94ea7d0d42f83c487dc159c5240d8f83beae684472864e2d", size = 2196754, upload-time = "2025-10-14T10:21:48.486Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3b/ccdc77af9cd5082723574a1cc1bcae7a6acacc829d7c0a06201f7886a109/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c4d1e854aaf044487d31143f541f7aafe7b482ae72a022c664b2de2e466ed0ad", size = 2137115, upload-time = "2025-10-14T10:21:50.63Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ba/e7c7a02651a8f7c52dc2cff2b64a30c313e3b57c7d93703cecea76c09b71/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b568af94267729d76e6ee5ececda4e283d07bbb28e8148bb17adad93d025d25a", size = 2317400, upload-time = "2025-10-14T10:21:52.959Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ba/6c533a4ee8aec6b812c643c49bb3bd88d3f01e3cebe451bb85512d37f00f/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6d55fb8b1e8929b341cc313a81a26e0d48aa3b519c1dbaadec3a6a2b4fcad025", size = 2312070, upload-time = "2025-10-14T10:21:55.419Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ae/f10524fcc0ab8d7f96cf9a74c880243576fd3e72bd8ce4f81e43d22bcab7/pydantic_core-2.41.4-cp314-cp314-win32.whl", hash = "sha256:5b66584e549e2e32a1398df11da2e0a7eff45d5c2d9db9d5667c5e6ac764d77e", size = 1982277, upload-time = "2025-10-14T10:21:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/dc/e5aa27aea1ad4638f0c3fb41132f7eb583bd7420ee63204e2d4333a3bbf9/pydantic_core-2.41.4-cp314-cp314-win_amd64.whl", hash = "sha256:557a0aab88664cc552285316809cab897716a372afaf8efdbef756f8b890e894", size = 2024608, upload-time = "2025-10-14T10:21:59.557Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/51d89cc2612bd147198e120a13f150afbf0bcb4615cddb049ab10b81b79e/pydantic_core-2.41.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f1ea6f48a045745d0d9f325989d8abd3f1eaf47dd00485912d1a3a63c623a8d", size = 1967614, upload-time = "2025-10-14T10:22:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c2/472f2e31b95eff099961fa050c376ab7156a81da194f9edb9f710f68787b/pydantic_core-2.41.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6c1fe4c5404c448b13188dd8bd2ebc2bdd7e6727fa61ff481bcc2cca894018da", size = 1876904, upload-time = "2025-10-14T10:22:04.062Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/07/ea8eeb91173807ecdae4f4a5f4b150a520085b35454350fc219ba79e66a3/pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:523e7da4d43b113bf8e7b49fa4ec0c35bf4fe66b2230bfc5c13cc498f12c6c3e", size = 1882538, upload-time = "2025-10-14T10:22:06.39Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/29/b53a9ca6cd366bfc928823679c6a76c7a4c69f8201c0ba7903ad18ebae2f/pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5729225de81fb65b70fdb1907fcf08c75d498f4a6f15af005aabb1fdadc19dfa", size = 2041183, upload-time = "2025-10-14T10:22:08.812Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/3d/f8c1a371ceebcaf94d6dd2d77c6cf4b1c078e13a5837aee83f760b4f7cfd/pydantic_core-2.41.4-cp314-cp314t-win_amd64.whl", hash = "sha256:de2cfbb09e88f0f795fd90cf955858fc2c691df65b1f21f0aa00b99f3fbc661d", size = 1993542, upload-time = "2025-10-14T10:22:11.332Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ac/9fc61b4f9d079482a290afe8d206b8f490e9fd32d4fc03ed4fc698214e01/pydantic_core-2.41.4-cp314-cp314t-win_arm64.whl", hash = "sha256:d34f950ae05a83e0ede899c595f312ca976023ea1db100cd5aa188f7005e3ab0", size = 1973897, upload-time = "2025-10-14T10:22:13.444Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "24.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/d4/1067b82c4fc674d6f6e9e8d26b3dff978da46d351ca3bac171544693e085/pyopenssl-24.3.0.tar.gz", hash = "sha256:49f7a019577d834746bc55c5fce6ecbcec0f2b4ec5ce1cf43a9a173b8138bb36", size = 178944, upload-time = "2024-11-27T20:43:12.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/22/40f9162e943f86f0fc927ebc648078be87def360d9d8db346619fb97df2b/pyOpenSSL-24.3.0-py3-none-any.whl", hash = "sha256:e474f5a473cd7f92221cc04976e48f4d11502804657a08a989fb3be5514c904a", size = 56111, upload-time = "2024-11-27T20:43:21.112Z" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/96/804520d0850c7db98e5ccb70282e29208723f0964e88ffd9d0da2f52ea09/python_multipart-0.0.21.tar.gz", hash = "sha256:7137ebd4d3bbf70ea1622998f902b97a29434a9e8dc40eb203bbcf7c2a2cba92", size = 37196, upload-time = "2025-12-17T09:24:22.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/76/03af049af4dcee5d27442f71b6924f01f3efb5d2bd34f23fcd563f2cc5f5/python_multipart-0.0.21-py3-none-any.whl", hash = "sha256:cf7a6713e01c87aa35387f4774e812c4361150938d20d232800f75ffcf266090", size = 24541, upload-time = "2025-12-17T09:24:21.153Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775, upload-time = "2025-01-25T08:48:14.241Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/00d280c03ffd39aaee0e86ec81e2d3b9253036a0f93f51d10503adef0e65/sse_starlette-3.2.0.tar.gz", hash = "sha256:8127594edfb51abe44eac9c49e59b0b01f1039d0c7461c6fd91d4e03b70da422", size = 27253, upload-time = "2026-01-17T13:11:05.62Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/7f/832f015020844a8b8f7a9cbc103dd76ba8e3875004c41e08440ea3a2b41a/sse_starlette-3.2.0-py3-none-any.whl", hash = "sha256:5876954bd51920fc2cd51baee47a080eb88a37b5b784e615abb0b283f801cdbf", size = 12763, upload-time = "2026-01-17T13:11:03.775Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/70/1469ef1d3542ae7c2c7b72bd5e3a4e6ee69d7978fa8a3af05a38eca5becf/werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67", size = 864754, upload-time = "2026-01-08T17:49:23.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/e4/8d97cca767bcc1be76d16fb76951608305561c6e056811587f36cb1316a8/werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc", size = 225025, upload-time = "2026-01-08T17:49:21.859Z" },
+]

--- a/tests/e2e/features/mocks/services/load_balancer_data.py
+++ b/tests/e2e/features/mocks/services/load_balancer_data.py
@@ -1,0 +1,228 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+# Canonical IDs
+TENANCY_ID = "ocid1.tenancy.oc1..mock"
+LB_ID = "ocid1.loadbalancer.oc1..mock-lb-1"
+WORK_REQUEST_ID = "ocid1.loadbalancerworkrequest.oc1..wr1"
+
+# Core load balancer object as returned by GetLoadBalancer
+LOAD_BALANCER_OBJ = {
+    "id": LB_ID,
+    "compartmentId": TENANCY_ID,
+    "displayName": "mock-lb",
+    "lifecycleState": "ACTIVE",
+    "timeCreated": "2026-01-01T00:00:00Z",
+    "ipAddresses": [
+        {"ipAddress": "192.168.0.3", "isPublic": False},
+    ],
+    "shapeName": "Flexible",
+    "isPrivate": False,
+    "isDeleteProtectionEnabled": False,
+    "isRequestIdEnabled": False,
+    "requestIdHeader": "X-Request-Id",
+    "subnetIds": ["ocid1.subnet.oc1..mock-subnet-1"],
+    "networkSecurityGroupIds": [],
+    # Maps on the LB document
+    "listeners": {
+        "listener1": {
+            "name": "listener1",
+            "defaultBackendSetName": "backendset1",
+            "port": 80,
+            "protocol": "HTTP",
+            "hostnameNames": [],
+            "pathRouteSetName": None,
+            "sslConfiguration": None,
+            "connectionConfiguration": {"idleTimeout": 1200},
+            "ruleSetNames": [],
+            "routingPolicyName": None,
+        }
+    },
+    "hostnames": {
+        "host1": {
+            "name": "host1",
+            "hostname": "app.example.com",
+        }
+    },
+    "sslCipherSuites": {
+        "suite1": {
+            "name": "suite1",
+            "ciphers": ["TLS_AES_128_GCM_SHA256"],
+        }
+    },
+    "certificates": {
+        "cert1": {
+            "certificateName": "cert1",
+            "publicCertificate": "---PUBLIC---",
+            "caCertificate": "---CA---",
+        }
+    },
+    "backendSets": {
+        "backendset1": {
+            "name": "backendset1",
+            "policy": "ROUND_ROBIN",
+            "backends": [
+                {
+                    "name": "10.0.0.3:8080",
+                    "ipAddress": "10.0.0.3",
+                    "port": 8080,
+                    "weight": 3,
+                    "maxConnections": 300,
+                    "backup": False,
+                    "drain": False,
+                    "offline": False,
+                },
+                {
+                    "name": "10.0.0.4:8080",
+                    "ipAddress": "10.0.0.4",
+                    "port": 8080,
+                    "weight": 1,
+                    "maxConnections": 256,
+                    "backup": False,
+                    "drain": False,
+                    "offline": False,
+                },
+            ],
+            "backendMaxConnections": 300,
+            "healthChecker": {
+                "protocol": "HTTP",
+                "isForcePlainText": False,
+                "urlPath": "/health",
+                "port": 8080,
+                "returnCode": 200,
+                "retries": 3,
+                "timeoutInMillis": 3000,
+                "intervalInMillis": 10000,
+                "responseBodyRegex": "^OK$",
+            },
+            "sslConfiguration": None,
+            "sessionPersistenceConfiguration": None,
+            "lbCookieSessionPersistenceConfiguration": None,
+        }
+    },
+    "pathRouteSets": {},
+    "ruleSets": {
+        "ruleset1": {
+            "name": "ruleset1",
+            "items": [
+                {
+                    "action": "ADD_HTTP_REQUEST_HEADER",
+                    "header": "x-test",
+                    "value": "demo",
+                }
+            ],
+        }
+    },
+    "routingPolicies": {
+        "policy1": {
+            "name": "policy1",
+            "conditionLanguageVersion": "V1",
+            "rules": [
+                {
+                    "name": "r1",
+                    "condition": "true",
+                    "actions": [
+                        {
+                            "name": "FORWARD_TO_BACKENDSET",
+                            "backendSetName": "backendset1",
+                        }
+                    ],
+                }
+            ],
+        }
+    },
+}
+
+# Collections for list endpoints
+LOAD_BALANCERS = [
+    {
+        "id": LB_ID,
+        "compartmentId": TENANCY_ID,
+        "displayName": "mock-lb",
+        "lifecycleState": "ACTIVE",
+        "timeCreated": "2026-01-01T00:00:00Z",
+        "shapeName": "Flexible",
+        "isPrivate": False,
+    }
+]
+
+BACKEND_SETS = [LOAD_BALANCER_OBJ["backendSets"]["backendset1"]]
+BACKENDS = LOAD_BALANCER_OBJ["backendSets"]["backendset1"]["backends"]
+CERTIFICATES = [
+    {
+        "certificateName": "cert1",
+        "publicCertificate": "---PUBLIC---",
+        "caCertificate": "---CA---",
+    }
+]
+SSL_CIPHER_SUITES = [
+    {
+        "name": "suite1",
+        "ciphers": ["TLS_AES_128_GCM_SHA256"],
+    }
+]
+HOSTNAMES = [
+    {
+        "name": "host1",
+        "hostname": "app.example.com",
+    }
+]
+RULE_SETS = [LOAD_BALANCER_OBJ["ruleSets"]["ruleset1"]]
+ROUTING_POLICIES = [
+    {
+        "name": "policy1",
+        "conditionLanguageVersion": "V1",
+        "rules": LOAD_BALANCER_OBJ["routingPolicies"]["policy1"]["rules"],
+    }
+]
+
+# Health
+LOAD_BALANCER_HEALTH = {
+    "status": "OK",
+    "warningStateBackendSetNames": [],
+    "criticalStateBackendSetNames": [],
+    "unknownStateBackendSetNames": [],
+    "totalBackendSetCount": 1,
+}
+
+BACKEND_SET_HEALTH = {
+    "status": "OK",
+    "warningStateBackendNames": [],
+    "criticalStateBackendNames": [],
+    "unknownStateBackendNames": [],
+    "totalBackendCount": 2,
+}
+
+BACKEND_HEALTH = {
+    "status": "OK",
+    "healthCheckResults": [
+        {
+            "subnetId": "ocid1.subnet.oc1..mock-subnet-1",
+            "sourceIpAddress": "192.168.0.7",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "healthCheckStatus": "OK",
+        }
+    ],
+}
+
+HEALTH_SUMMARIES = [
+    {"loadBalancerId": LB_ID, "status": "OK"},
+]
+
+# Work Requests
+WORK_REQUESTS = [
+    {
+        "id": WORK_REQUEST_ID,
+        "loadBalancerId": LB_ID,
+        "type": "CreateListener",
+        "compartmentId": TENANCY_ID,
+        "lifecycleState": "SUCCEEDED",
+        "message": "OK",
+        "timeAccepted": "2026-01-01T00:00:00Z",
+        "timeFinished": "2026-01-01T00:00:10Z",
+        "errorDetails": [],
+    }
+]

--- a/tests/e2e/features/mocks/services/load_balancer_routes.py
+++ b/tests/e2e/features/mocks/services/load_balancer_routes.py
@@ -1,0 +1,623 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from _common import oci_res
+from flask import Blueprint, jsonify, request
+from load_balancer_data import (  # BACKENDS,; TENANCY_ID,
+    BACKEND_HEALTH,
+    BACKEND_SET_HEALTH,
+    BACKEND_SETS,
+    CERTIFICATES,
+    HEALTH_SUMMARIES,
+    HOSTNAMES,
+    LB_ID,
+    LOAD_BALANCER_HEALTH,
+    LOAD_BALANCER_OBJ,
+    LOAD_BALANCERS,
+    ROUTING_POLICIES,
+    RULE_SETS,
+    SSL_CIPHER_SUITES,
+    WORK_REQUESTS,
+)
+
+load_balancer_bp = Blueprint("load_balancer", __name__, url_prefix="/20170115")
+
+
+# Helpers
+
+
+def _find_backend_set(name: str):
+    return next((b for b in BACKEND_SETS if b.get("name") == name), None)
+
+
+def _find_backend(backend_set_name: str, backend_name: str):
+    bs = _find_backend_set(backend_set_name)
+    if not bs:
+        return None
+    return next(
+        (b for b in bs.get("backends", []) if b.get("name") == backend_name), None
+    )
+
+
+def _find_ssl_cipher_suite(name: str):
+    return next((s for s in SSL_CIPHER_SUITES if s.get("name") == name), None)
+
+
+def _find_hostname(name: str):
+    return next((h for h in HOSTNAMES if h.get("name") == name), None)
+
+
+def _find_rule_set(name: str):
+    return next((r for r in RULE_SETS if r.get("name") == name), None)
+
+
+def _find_routing_policy(name: str):
+    return next((r for r in ROUTING_POLICIES if r.get("name") == name), None)
+
+
+def _find_certificate(name: str):
+    return next((c for c in CERTIFICATES if c.get("certificateName") == name), None)
+
+
+# Load Balancers
+
+
+@load_balancer_bp.route("/loadBalancers", methods=["GET"])
+def list_load_balancers():
+    compartment_id = request.args.get("compartmentId")
+    display_name = request.args.get("displayName")
+    items = LOAD_BALANCERS
+    if compartment_id:
+        items = [i for i in items if i.get("compartmentId") == compartment_id]
+    if display_name:
+        items = [i for i in items if i.get("displayName") == display_name]
+    return oci_res(items)
+
+
+@load_balancer_bp.route("/loadBalancers", methods=["POST"])
+def create_load_balancer():
+    # Return 204 accepted with opc-work-request-id semantics
+    return "", 204
+
+
+@load_balancer_bp.route("/loadBalancers/<load_balancer_id>", methods=["GET"])
+def get_load_balancer(load_balancer_id):
+    # Accept either the OCID or the display name for convenience in E2E flows
+    if load_balancer_id not in (LB_ID, LOAD_BALANCER_OBJ.get("displayName")):
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(LOAD_BALANCER_OBJ)
+
+
+@load_balancer_bp.route("/loadBalancers/<load_balancer_id>", methods=["PUT"])
+def update_load_balancer(load_balancer_id):
+    return "", 204
+
+
+@load_balancer_bp.route("/loadBalancers/<load_balancer_id>", methods=["DELETE"])
+def delete_load_balancer(load_balancer_id):
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/updateShape", methods=["PUT"]
+)
+def update_shape(load_balancer_id):
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/networkSecurityGroups", methods=["PUT"]
+)
+def update_nsgs(load_balancer_id):
+    return "", 204
+
+
+# Listeners
+
+
+@load_balancer_bp.route("/loadBalancers/<load_balancer_id>/listeners", methods=["POST"])
+def create_listener(load_balancer_id):
+    body = request.get_json(force=True, silent=True) or {}
+    name = body.get("name")
+    if name:
+        # Store/minimally normalize into LB object so subsequent GET works
+        listener = {
+            "name": name,
+            "defaultBackendSetName": body.get("defaultBackendSetName"),
+            "port": body.get("port"),
+            "protocol": body.get("protocol"),
+            "hostnameNames": body.get("hostnameNames", []),
+            "pathRouteSetName": body.get("pathRouteSetName"),
+            "sslConfiguration": body.get("sslConfiguration"),
+            "connectionConfiguration": body.get("connectionConfiguration"),
+            "ruleSetNames": body.get("ruleSetNames", []),
+            "routingPolicyName": body.get("routingPolicyName"),
+        }
+        LOAD_BALANCER_OBJ.setdefault("listeners", {})[name] = listener
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/listeners/<listener_name>", methods=["PUT"]
+)
+def update_listener(load_balancer_id, listener_name):
+    body = request.get_json(force=True, silent=True) or {}
+    lmap = LOAD_BALANCER_OBJ.setdefault("listeners", {})
+    if listener_name in lmap:
+        listener = lmap[listener_name]
+        # Update only provided fields
+        for key, target_key in [
+            ("defaultBackendSetName", "defaultBackendSetName"),
+            ("port", "port"),
+            ("protocol", "protocol"),
+            ("hostnameNames", "hostnameNames"),
+            ("pathRouteSetName", "pathRouteSetName"),
+            ("sslConfiguration", "sslConfiguration"),
+            ("connectionConfiguration", "connectionConfiguration"),
+            ("ruleSetNames", "ruleSetNames"),
+            ("routingPolicyName", "routingPolicyName"),
+        ]:
+            if key in body:
+                listener[target_key] = body.get(key)
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/listeners/<listener_name>", methods=["DELETE"]
+)
+def delete_listener(load_balancer_id, listener_name):
+    LOAD_BALANCER_OBJ.setdefault("listeners", {}).pop(listener_name, None)
+    return "", 204
+
+
+# Backend sets
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/backendSets", methods=["GET"]
+)
+def list_backend_sets(load_balancer_id):
+    items = list(LOAD_BALANCER_OBJ.get("backendSets", {}).values())
+    return oci_res(items)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/backendSets", methods=["POST"]
+)
+def create_backend_set(load_balancer_id):
+    body = request.get_json(force=True, silent=True) or {}
+    name = body.get("name")
+    if name:
+        bs = {
+            "name": name,
+            "policy": body.get("policy"),
+            "backends": body.get("backends", []),
+            "backendMaxConnections": body.get("backendMaxConnections"),
+            "healthChecker": body.get("healthChecker"),
+            "sslConfiguration": body.get("sslConfiguration"),
+            "sessionPersistenceConfiguration": body.get(
+                "sessionPersistenceConfiguration"
+            ),
+            "lbCookieSessionPersistenceConfiguration": body.get(
+                "lbCookieSessionPersistenceConfiguration"
+            ),
+        }
+        # Update both dict map and list view
+        LOAD_BALANCER_OBJ.setdefault("backendSets", {})[name] = bs
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/backendSets/<backend_set_name>", methods=["GET"]
+)
+def get_backend_set(load_balancer_id, backend_set_name):
+    bs = _find_backend_set(backend_set_name)
+    if not bs:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(bs)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/backendSets/<backend_set_name>", methods=["PUT"]
+)
+def update_backend_set(load_balancer_id, backend_set_name):
+    body = request.get_json(force=True, silent=True) or {}
+    bs = _find_backend_set(backend_set_name)
+    if bs:
+        for key in [
+            "policy",
+            "backends",
+            "backendMaxConnections",
+            "healthChecker",
+            "sslConfiguration",
+            "sessionPersistenceConfiguration",
+            "lbCookieSessionPersistenceConfiguration",
+        ]:
+            if key in body:
+                bs[key] = body.get(key)
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/backendSets/<backend_set_name>",
+    methods=["DELETE"],
+)
+def delete_backend_set(load_balancer_id, backend_set_name):
+    # Remove from LB map
+    LOAD_BALANCER_OBJ.setdefault("backendSets", {}).pop(backend_set_name, None)
+    return "", 204
+
+
+# Backends
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/backendSets/<backend_set_name>/backends",
+    methods=["GET"],
+)
+def list_backends(load_balancer_id, backend_set_name):
+    bs = _find_backend_set(backend_set_name)
+    items = (bs or {}).get("backends", [])
+    return oci_res(items)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/backendSets/<backend_set_name>/backends",
+    methods=["POST"],
+)
+def create_backend(load_balancer_id, backend_set_name):
+    body = request.get_json(force=True, silent=True) or {}
+    bs = _find_backend_set(backend_set_name)
+    if bs is not None:
+        ip = body.get("ipAddress")
+        port = body.get("port")
+        backend = {
+            "name": f"{ip}:{port}",
+            "ipAddress": ip,
+            "port": port,
+            "weight": body.get("weight"),
+            "maxConnections": body.get("maxConnections"),
+            "backup": body.get("backup", False),
+            "drain": body.get("drain", False),
+            "offline": body.get("offline", False),
+        }
+        bs.setdefault("backends", []).append(backend)
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/backendSets/<backend_set_name>/backends/<backend_name>",
+    methods=["GET"],
+)
+def get_backend(load_balancer_id, backend_set_name, backend_name):
+    b = _find_backend(backend_set_name, backend_name)
+    if not b:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(b)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/backendSets/<backend_set_name>/backends/<backend_name>",
+    methods=["PUT"],
+)
+def update_backend(load_balancer_id, backend_set_name, backend_name):
+    body = request.get_json(force=True, silent=True) or {}
+    b = _find_backend(backend_set_name, backend_name)
+    if b:
+        for key in ["weight", "maxConnections", "backup", "drain", "offline"]:
+            if key in body:
+                b[key] = body.get(key)
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/backendSets/<backend_set_name>/backends/<backend_name>",
+    methods=["DELETE"],
+)
+def delete_backend(load_balancer_id, backend_set_name, backend_name):
+    bs = _find_backend_set(backend_set_name)
+    if bs is not None:
+        bs["backends"] = [
+            b for b in bs.get("backends", []) if b.get("name") != backend_name
+        ]
+    return "", 204
+
+
+# Certificates
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/certificates", methods=["GET"]
+)
+def list_certificates(load_balancer_id):
+    return oci_res(CERTIFICATES)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/certificates", methods=["POST"]
+)
+def create_certificate(load_balancer_id):
+    body = request.get_json(force=True, silent=True) or {}
+    name = body.get("certificateName")
+    if name:
+        CERTIFICATES.append(
+            {
+                "certificateName": name,
+                "publicCertificate": body.get("publicCertificate", "---PUBLIC---"),
+                "caCertificate": body.get("caCertificate", "---CA---"),
+            }
+        )
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/certificates/<certificate_name>",
+    methods=["DELETE"],
+)
+def delete_certificate(load_balancer_id, certificate_name):
+    global CERTIFICATES
+    CERTIFICATES = [
+        c for c in CERTIFICATES if c.get("certificateName") != certificate_name
+    ]
+    return "", 204
+
+
+# SSL Cipher Suites
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/sslCipherSuites", methods=["GET"]
+)
+def list_ssl_cipher_suites(load_balancer_id):
+    return oci_res(SSL_CIPHER_SUITES)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/sslCipherSuites", methods=["POST"]
+)
+def create_ssl_cipher_suite(load_balancer_id):
+    body = request.get_json(force=True, silent=True) or {}
+    name = body.get("name")
+    if name and not _find_ssl_cipher_suite(name):
+        SSL_CIPHER_SUITES.append({"name": name, "ciphers": body.get("ciphers", [])})
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/sslCipherSuites/<name>", methods=["GET"]
+)
+def get_ssl_cipher_suite(load_balancer_id, name):
+    s = _find_ssl_cipher_suite(name)
+    if not s:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(s)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/sslCipherSuites/<name>", methods=["PUT"]
+)
+def update_ssl_cipher_suite(load_balancer_id, name):
+    body = request.get_json(force=True, silent=True) or {}
+    s = _find_ssl_cipher_suite(name)
+    if s:
+        if "ciphers" in body:
+            s["ciphers"] = body.get("ciphers")
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/sslCipherSuites/<name>", methods=["DELETE"]
+)
+def delete_ssl_cipher_suite(load_balancer_id, name):
+    global SSL_CIPHER_SUITES
+    SSL_CIPHER_SUITES = [s for s in SSL_CIPHER_SUITES if s.get("name") != name]
+    return "", 204
+
+
+# Hostnames
+
+
+@load_balancer_bp.route("/loadBalancers/<load_balancer_id>/hostnames", methods=["GET"])
+def list_hostnames(load_balancer_id):
+    return oci_res(HOSTNAMES)
+
+
+@load_balancer_bp.route("/loadBalancers/<load_balancer_id>/hostnames", methods=["POST"])
+def create_hostname(load_balancer_id):
+    body = request.get_json(force=True, silent=True) or {}
+    name = body.get("name")
+    hostname = body.get("hostname")
+    if name and hostname:
+        HOSTNAMES.append({"name": name, "hostname": hostname})
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/hostnames/<name>", methods=["GET"]
+)
+def get_hostname(load_balancer_id, name):
+    h = _find_hostname(name)
+    if not h:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(h)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/hostnames/<name>", methods=["PUT"]
+)
+def update_hostname(load_balancer_id, name):
+    body = request.get_json(force=True, silent=True) or {}
+    h = _find_hostname(name)
+    if h and "hostname" in body:
+        h["hostname"] = body.get("hostname")
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/hostnames/<name>", methods=["DELETE"]
+)
+def delete_hostname(load_balancer_id, name):
+    global HOSTNAMES
+    HOSTNAMES = [h for h in HOSTNAMES if h.get("name") != name]
+    return "", 204
+
+
+# Rule sets
+
+
+@load_balancer_bp.route("/loadBalancers/<load_balancer_id>/ruleSets", methods=["GET"])
+def list_rule_sets(load_balancer_id):
+    return oci_res(RULE_SETS)
+
+
+@load_balancer_bp.route("/loadBalancers/<load_balancer_id>/ruleSets", methods=["POST"])
+def create_rule_set(load_balancer_id):
+    body = request.get_json(force=True, silent=True) or {}
+    name = body.get("name")
+    if name and not _find_rule_set(name):
+        RULE_SETS.append({"name": name, "items": body.get("items", [])})
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/ruleSets/<name>", methods=["GET"]
+)
+def get_rule_set(load_balancer_id, name):
+    r = _find_rule_set(name)
+    if not r:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(r)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/ruleSets/<name>", methods=["PUT"]
+)
+def update_rule_set(load_balancer_id, name):
+    body = request.get_json(force=True, silent=True) or {}
+    r = _find_rule_set(name)
+    if r and "items" in body:
+        r["items"] = body.get("items")
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/ruleSets/<name>", methods=["DELETE"]
+)
+def delete_rule_set(load_balancer_id, name):
+    global RULE_SETS
+    RULE_SETS = [r for r in RULE_SETS if r.get("name") != name]
+    return "", 204
+
+
+# Routing Policies
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/routingPolicies", methods=["GET"]
+)
+def list_routing_policies(load_balancer_id):
+    return oci_res(ROUTING_POLICIES)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/routingPolicies", methods=["POST"]
+)
+def create_routing_policy(load_balancer_id):
+    body = request.get_json(force=True, silent=True) or {}
+    name = body.get("name")
+    if name and not _find_routing_policy(name):
+        ROUTING_POLICIES.append(
+            {
+                "name": name,
+                "conditionLanguageVersion": body.get("conditionLanguageVersion", "V1"),
+                "rules": body.get("rules", []),
+            }
+        )
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/routingPolicies/<name>", methods=["GET"]
+)
+def get_routing_policy(load_balancer_id, name):
+    r = _find_routing_policy(name)
+    if not r:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(r)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/routingPolicies/<name>", methods=["PUT"]
+)
+def update_routing_policy(load_balancer_id, name):
+    body = request.get_json(force=True, silent=True) or {}
+    r = _find_routing_policy(name)
+    if r:
+        if "conditionLanguageVersion" in body:
+            r["conditionLanguageVersion"] = body.get("conditionLanguageVersion")
+        if "rules" in body:
+            r["rules"] = body.get("rules")
+    return "", 204
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/routingPolicies/<name>", methods=["DELETE"]
+)
+def delete_routing_policy(load_balancer_id, name):
+    global ROUTING_POLICIES
+    ROUTING_POLICIES = [r for r in ROUTING_POLICIES if r.get("name") != name]
+    return "", 204
+
+
+# Health endpoints
+
+
+@load_balancer_bp.route("/loadBalancers/<load_balancer_id>/health", methods=["GET"])
+def get_load_balancer_health(load_balancer_id):
+    return oci_res(LOAD_BALANCER_HEALTH)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/backendSets/<backend_set_name>/health",
+    methods=["GET"],
+)
+def get_backend_set_health(load_balancer_id, backend_set_name):
+    return oci_res(BACKEND_SET_HEALTH)
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/backendSets/<backend_set_name>/backends/<backend_name>/health",
+    methods=["GET"],
+)
+def get_backend_health(load_balancer_id, backend_set_name, backend_name):
+    return oci_res(BACKEND_HEALTH)
+
+
+@load_balancer_bp.route("/loadBalancerHealths", methods=["GET"])
+def list_lb_healths():
+    compartment_id = request.args.get("compartmentId")
+    items = HEALTH_SUMMARIES
+    if compartment_id:
+        items = [i for i in items if LB_ID]
+    return oci_res(items)
+
+
+# Work Requests
+
+
+@load_balancer_bp.route(
+    "/loadBalancers/<load_balancer_id>/workRequests", methods=["GET"]
+)
+def list_work_requests(load_balancer_id):
+    return oci_res(WORK_REQUESTS)
+
+
+@load_balancer_bp.route("/loadBalancerWorkRequests/<work_request_id>", methods=["GET"])
+def get_work_request(work_request_id):
+    wr = next((w for w in WORK_REQUESTS if w.get("id") == work_request_id), None)
+    if not wr:
+        return jsonify({"code": "NotAuthorizedOrNotFound"}), 404
+    return oci_res(wr)

--- a/tests/e2e/features/oci-load-balancer-mcp-server.feature
+++ b/tests/e2e/features/oci-load-balancer-mcp-server.feature
@@ -1,0 +1,93 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+# Feature: OCI Load Balancer MCP Server
+#
+#   Background:
+#     Given the MCP server is running with OCI tools
+#     And the ollama model with the tools is properly working
+#
+#   Scenario: List the load balancer tools available in the agent
+#     When I send a request with the prompt "What load balancer mcp tools do you have"
+#     Then the response should contain a list of load balancer tools available
+#
+#   Scenario: List the load balancers for a compartment
+#     When I send a request with the prompt "list my load balancers"
+#     Then the response should contain a list of load balancers
+#
+#   Scenario: Create a load balancer
+#     When I send a request with the prompt "create a flexible load balancer named mock-lb in root compartment"
+#     Then the response should confirm creation of a load balancer
+#
+#   Scenario: Get load balancer details
+#     When I send a request with the prompt "get the details of load balancer mock-lb"
+#     Then the response should contain the details of a load balancer
+#
+#   Scenario: Delete a load balancer
+#     When I send a request with the prompt "delete the load balancer mock-lb in root compartment"
+#     Then the response should confirm deletion of a load balancer
+#
+#   Scenario: List listeners for a load balancer
+#     When I send a request with the prompt "list listeners for load balancer mock-lb"
+#     Then the response should contain a list of listeners
+#
+#   Scenario: List backend sets and backends for a load balancer
+#     When I send a request with the prompt "show backend sets and backends for load balancer mock-lb"
+#     Then the response should contain a list of backend sets and backends
+#
+#   Scenario: List certificates and SSL cipher suites for a load balancer
+#     When I send a request with the prompt "list certificates and ssl ciphers for load balancer mock-lb"
+#     Then the response should contain a list of certificates and cipher suites
+#
+#   Scenario: List hostnames, rule sets, and routing policies for a load balancer
+#     When I send a request with the prompt "list hostnames, rule sets, and routing policies for load balancer mock-lb"
+#     Then the response should contain hostnames, rule sets, and routing policies
+#
+#   Scenario: Show health summaries and work requests for a load balancer
+#     When I send a request with the prompt "show health and recent work requests for load balancer mock-lb"
+#     Then the response should contain health summaries and work requests
+#
+#   # Expanded coverage scenarios
+#   Scenario: Manage a listener lifecycle on a load balancer
+#     When I send a request with the prompt "on load balancer mock-lb create a listener named lhttp on port 80 using HTTP with default backend set backendset1, then get listener lhttp, then update listener lhttp to use port 81, then delete listener lhttp"
+#     Then the response should confirm listener operations
+#
+#   Scenario: Manage a backend set lifecycle on a load balancer
+#     When I send a request with the prompt "on load balancer mock-lb create a backend set named bes2 with policy ROUND_ROBIN and http health check on /health, then get backend set bes2, then update backend set bes2 to use backend max connections 400, then delete backend set bes2"
+#     Then the response should confirm backend set operations
+#
+#   Scenario: Manage a backend lifecycle in a backend set
+#     When I send a request with the prompt "for load balancer mock-lb and backend set backendset1 add backend 10.0.0.5:8080 with weight 1, then get backend 10.0.0.5:8080, then update backend 10.0.0.5:8080 to be offline, then delete backend 10.0.0.5:8080"
+#     Then the response should confirm backend operations
+#
+#   Scenario: Manage certificates on a load balancer
+#     When I send a request with the prompt "for load balancer mock-lb create a certificate named cert2 with provided PEMs, then delete certificate cert2"
+#     Then the response should confirm certificate operations
+#
+#   Scenario: Manage SSL cipher suites on a load balancer
+#     When I send a request with the prompt "for load balancer mock-lb create ssl cipher suite suite2 with ciphers TLS_AES_256_GCM_SHA384, then get ssl cipher suite suite2, then update ssl cipher suite suite2 to include TLS_CHACHA20_POLY1305_SHA256, then delete ssl cipher suite suite2"
+#     Then the response should confirm ssl cipher suite operations
+#
+#   Scenario: Manage hostnames on a load balancer
+#     When I send a request with the prompt "for load balancer mock-lb create hostname host2 with value api.example.com, then get hostname host2, then update hostname host2 to value api2.example.com, then delete hostname host2"
+#     Then the response should confirm hostname operations
+#
+#   Scenario: Manage rule sets on a load balancer
+#     When I send a request with the prompt "for load balancer mock-lb create rule set rs2 with an ADD_HTTP_REQUEST_HEADER rule, then get rule set rs2, then update rule set rs2 to new items, then delete rule set rs2"
+#     Then the response should confirm rule set operations
+#
+#   Scenario: Manage routing policies on a load balancer
+#     When I send a request with the prompt "for load balancer mock-lb create routing policy rp2 with a forward rule to backendset1, then get routing policy rp2, then update routing policy rp2, then delete routing policy rp2"
+#     Then the response should confirm routing policy operations
+#
+#   Scenario: Get detailed health for load balancer, backend set, and backend
+#     When I send a request with the prompt "for load balancer mock-lb show the overall health, the health for backend set backendset1, and the health for backend 10.0.0.3:8080"
+#     Then the response should contain load balancer health
+#     And the response should contain backend set health
+#     And the response should contain backend health
+#
+#   Scenario: Get work requests and details for a load balancer
+#     When I send a request with the prompt "for load balancer mock-lb list work requests and then get the details of the first work request"
+#     Then the response should contain work request details
+#

--- a/tests/e2e/features/steps/oci-load-balancer-mcp-server-steps.py
+++ b/tests/e2e/features/steps/oci-load-balancer-mcp-server-steps.py
@@ -1,0 +1,425 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from behave import then
+
+
+@then("the response should contain a list of load balancer tools available")
+def step_impl_lb_tools_available(context):
+    response_json = context.response.json()
+    assert (
+        "content" in response_json["message"]
+    ), "Response does not contain a content key."
+    content = response_json["message"]["content"].lower()
+    # Check for representative tool names from the LB server
+    expected = [
+        "list_load_balancers",
+        "get_load_balancer",
+        "create_load_balancer",
+        "update_load_balancer",
+        "delete_load_balancer",
+        "list_load_balancer_listeners",
+        "create_load_balancer_listener",
+        "get_load_balancer_listener",
+        "update_load_balancer_listener",
+        "delete_load_balancer_listener",
+        "list_load_balancer_backend_sets",
+        "get_load_balancer_backend_set",
+        "create_load_balancer_backend_set",
+        "update_load_balancer_backend_set",
+        "delete_load_balancer_backend_set",
+        "list_backends",
+        "get_backend",
+        "create_backend",
+        "update_backend",
+        "delete_backend",
+        "list_load_balancer_certificates",
+        "create_load_balancer_certificate",
+        "delete_load_balancer_certificate",
+        "list_ssl_cipher_suites",
+        "get_ssl_cipher_suite",
+        "create_ssl_cipher_suite",
+        "update_ssl_cipher_suite",
+        "delete_ssl_cipher_suite",
+        "list_hostnames",
+        "get_hostname",
+        "create_hostname",
+        "update_hostname",
+        "delete_hostname",
+        "list_rule_sets",
+        "get_rule_set",
+        "create_rule_set",
+        "update_rule_set",
+        "delete_rule_set",
+        "list_routing_policies",
+        "get_routing_policy",
+        "create_routing_policy",
+        "update_routing_policy",
+        "delete_routing_policy",
+        "get_load_balancer_health",
+        "get_backend_set_health",
+        "get_backend_health",
+        "list_load_balancer_healths",
+        "list_load_balancer_work_requests",
+        "get_load_balancer_work_request",
+    ]
+    assert any(
+        t in content for t in expected
+    ), "Load balancer tools could not be queried."
+
+
+@then("the response should contain a list of load balancers")
+def step_impl_list_lbs(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    # Accept OCID or known display name from mocks, or a clear list mention
+    assert (
+        "ocid1.loadbalancer" in content
+        or "mock-lb" in content
+        or "load balancers" in content
+    ), "List of load balancers not found."
+
+
+@then("the response should contain the details of a load balancer")
+def step_impl_get_lb(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    assert (
+        "ocid1.loadbalancer" in content
+        or "mock-lb" in content
+        or "display name" in content
+        or "shape" in content
+        or "load balancer" in content
+        or "lifecycle" in content
+        or "id" in content
+    ), "Load balancer details not found."
+
+
+@then("the response should confirm creation of a load balancer")
+def step_impl_create_lb(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    # Look for create confirmation, work request OCID, or known status
+    assert (
+        "created" in content
+        or "provision" in content
+        or "ocid1.loadbalancer" in content
+        or "work request" in content
+        or "accepted" in content
+    ), "Load balancer creation not confirmed in response."
+
+
+@then("the response should confirm deletion of a load balancer")
+def step_impl_delete_lb(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    # Look for delete confirmation, work request OCID, or expected terms
+    assert (
+        "deleted" in content
+        or "deletion" in content
+        or "terminated" in content
+        or "removed" in content
+        or "ocid1.loadbalancer" in content
+        or "work request" in content
+        or "accepted" in content
+        or "success" in content
+        or "ok" in content
+        or "load balancer" in content
+    ), "Load balancer deletion not confirmed in response."
+
+
+@then("the response should contain a list of listeners")
+def step_impl_list_listeners(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    assert any(
+        k in content for k in ["listener", "listeners", "port", "protocol"]
+    ), "Listeners list not found."
+
+
+@then("the response should contain a list of backend sets and backends")
+def step_impl_backend_sets_backends(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    assert any(
+        k in content for k in ["backendset", "backend set", "policy"]
+    ), "Backend sets not found."
+    assert any(k in content for k in ["backend", "ip", "port"]), "Backends not found."
+
+
+@then("the response should contain a list of certificates and cipher suites")
+def step_impl_certs_and_suites(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    assert any(k in content for k in ["certificate", "cert"]), "Certificates not found."
+    assert any(
+        k in content for k in ["cipher", "cipher suite", "tls"]
+    ), "SSL cipher suites not found."
+
+
+@then("the response should contain hostnames, rule sets, and routing policies")
+def step_impl_hostnames_rules_routing(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    assert any(k in content for k in ["hostname", "host"]), "Hostnames not found."
+    assert any(
+        k in content for k in ["rule set", "ruleset", "rule"]
+    ), "Rule sets not found."
+    assert any(
+        k in content for k in ["routing policy", "routing policies", "routing"]
+    ), "Routing policies not found."
+
+
+@then("the response should contain health summaries and work requests")
+def step_impl_health_and_work_requests(context):
+    result = context.response.json()
+    assert "content" in result["message"], "Response does not contain a content key."
+    content = result["message"]["content"].lower()
+    assert "health" in content, "Health information not found."
+    assert any(
+        k in content for k in ["work request", "work requests", "work id", "wr"]
+    ), "Work requests not found."
+
+
+@then("the response should confirm listener operations")
+def step_impl_listener_ops(context):
+    content = context.response.json()["message"]["content"].lower()
+    assert "listener" in content, "Listener keyword missing."
+    assert (
+        "create" in content
+        or "created" in content
+        or "add" in content
+        or "added" in content
+    ), "Listener create not confirmed."
+    assert (
+        "update" in content
+        or "updated" in content
+        or "modify" in content
+        or "modified" in content
+    ), "Listener update not confirmed."
+    assert (
+        "delete" in content
+        or "deleted" in content
+        or "remove" in content
+        or "removed" in content
+    ), "Listener delete not confirmed."
+
+
+@then("the response should confirm backend set operations")
+def step_impl_backend_set_ops(context):
+    content = context.response.json()["message"]["content"].lower()
+    assert (
+        "backend set" in content or "backendset" in content
+    ), "Backend set keyword missing."
+    assert (
+        "create" in content
+        or "created" in content
+        or "add" in content
+        or "added" in content
+    ), "Backend set create not confirmed."
+    assert (
+        "update" in content
+        or "updated" in content
+        or "modify" in content
+        or "modified" in content
+    ), "Backend set update not confirmed."
+    assert (
+        "delete" in content
+        or "deleted" in content
+        or "remove" in content
+        or "removed" in content
+    ), "Backend set delete not confirmed."
+
+
+@then("the response should confirm backend operations")
+def step_impl_backend_ops(context):
+    content = context.response.json()["message"]["content"].lower()
+    assert "backend" in content, "Backend keyword missing."
+    assert (
+        "create" in content
+        or "created" in content
+        or "add" in content
+        or "added" in content
+    ), "Backend create not confirmed."
+    assert (
+        "update" in content
+        or "updated" in content
+        or "modify" in content
+        or "modified" in content
+        or "offline" in content
+    ), "Backend update not confirmed."
+    assert (
+        "delete" in content
+        or "deleted" in content
+        or "remove" in content
+        or "removed" in content
+    ), "Backend delete not confirmed."
+
+
+@then("the response should confirm certificate operations")
+def step_impl_certificate_ops(context):
+    content = context.response.json()["message"]["content"].lower()
+    assert "certificate" in content, "Certificate keyword missing."
+    assert (
+        "create" in content
+        or "created" in content
+        or "add" in content
+        or "added" in content
+        or "accepted" in content
+    ), "Certificate create not confirmed."
+    assert (
+        "delete" in content
+        or "deleted" in content
+        or "remove" in content
+        or "removed" in content
+    ), "Certificate delete not confirmed."
+
+
+@then("the response should confirm ssl cipher suite operations")
+def step_impl_cipher_suite_ops(context):
+    content = context.response.json()["message"]["content"].lower()
+    assert "cipher" in content, "Cipher suite keyword missing."
+    assert (
+        "create" in content
+        or "created" in content
+        or "add" in content
+        or "added" in content
+    ), "Cipher suite create not confirmed."
+    assert (
+        "get" in content or "fetched" in content or "retrieved" in content
+    ), "Cipher suite get not confirmed."
+    assert (
+        "update" in content
+        or "updated" in content
+        or "modify" in content
+        or "modified" in content
+    ), "Cipher suite update not confirmed."
+    assert (
+        "delete" in content
+        or "deleted" in content
+        or "remove" in content
+        or "removed" in content
+    ), "Cipher suite delete not confirmed."
+
+
+@then("the response should confirm hostname operations")
+def step_impl_hostname_ops(context):
+    content = context.response.json()["message"]["content"].lower()
+    assert "hostname" in content, "Hostname keyword missing."
+    assert (
+        "create" in content
+        or "created" in content
+        or "add" in content
+        or "added" in content
+    ), "Hostname create not confirmed."
+    assert (
+        "get" in content or "fetched" in content or "retrieved" in content
+    ), "Hostname get not confirmed."
+    assert (
+        "update" in content
+        or "updated" in content
+        or "modify" in content
+        or "modified" in content
+    ), "Hostname update not confirmed."
+    assert (
+        "delete" in content
+        or "deleted" in content
+        or "remove" in content
+        or "removed" in content
+    ), "Hostname delete not confirmed."
+
+
+@then("the response should confirm rule set operations")
+def step_impl_rule_set_ops(context):
+    content = context.response.json()["message"]["content"].lower()
+    assert "rule set" in content or "ruleset" in content, "Rule set keyword missing."
+    assert (
+        "create" in content
+        or "created" in content
+        or "add" in content
+        or "added" in content
+    ), "Rule set create not confirmed."
+    assert (
+        "get" in content or "fetched" in content or "retrieved" in content
+    ), "Rule set get not confirmed."
+    assert (
+        "update" in content
+        or "updated" in content
+        or "modify" in content
+        or "modified" in content
+    ), "Rule set update not confirmed."
+    assert (
+        "delete" in content
+        or "deleted" in content
+        or "remove" in content
+        or "removed" in content
+    ), "Rule set delete not confirmed."
+
+
+@then("the response should confirm routing policy operations")
+def step_impl_routing_policy_ops(context):
+    content = context.response.json()["message"]["content"].lower()
+    assert (
+        "routing policy" in content or "routing policies" in content
+    ), "Routing policy keyword missing."
+    assert (
+        "create" in content
+        or "created" in content
+        or "add" in content
+        or "added" in content
+    ), "Routing policy create not confirmed."
+    assert (
+        "get" in content or "fetched" in content or "retrieved" in content
+    ), "Routing policy get not confirmed."
+    assert (
+        "update" in content
+        or "updated" in content
+        or "modify" in content
+        or "modified" in content
+    ), "Routing policy update not confirmed."
+    assert (
+        "delete" in content
+        or "deleted" in content
+        or "remove" in content
+        or "removed" in content
+    ), "Routing policy delete not confirmed."
+
+
+@then("the response should contain load balancer health")
+def step_impl_lb_health(context):
+    content = context.response.json()["message"]["content"].lower()
+    assert "health" in content and ("load balancer" in content or "overall" in content)
+
+
+@then("the response should contain backend set health")
+def step_impl_bs_health(context):
+    content = context.response.json()["message"]["content"].lower()
+    assert "health" in content and ("backend set" in content or "backendset" in content)
+
+
+@then("the response should contain backend health")
+def step_impl_backend_health(context):
+    content = context.response.json()["message"]["content"].lower()
+    assert "health" in content and "backend" in content
+
+
+@then("the response should contain work request details")
+def step_impl_work_request_details(context):
+    content = context.response.json()["message"]["content"].lower()
+    assert (
+        "work request" in content
+        or "ocid1.loadbalancerworkrequest" in content
+        or "succeeded" in content
+        or "createlistener" in content
+    ), "Work request details not found."


### PR DESCRIPTION
# Description

This PR adds Load balancer MCP server/tools, and unit tests. Also includes a stab at end to end tests, however, just the existence of the Load balancer MCP causes _other_ end to end tests to fail... So the LB end to end tests are commented out here.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

`make test`
Verify the LB unit tests pass.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
