### PR TITLE
chore: clarify quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ For macOS/Linux:
 ```json
 {
   "mcpServers": {
-    "oracle-oci-api-mcp-server": {
+    "oracle-oci-cloud-mcp-server": {
       "command": "uvx",
       "args": [
-        "oracle.oci-api-mcp-server@latest"
+        "oracle.oci-cloud-mcp-server@latest"
       ],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
@@ -58,7 +58,7 @@ For macOS/Linux:
 To connect to an MCP server running in HTTP streaming mode:
 Assuming you started the server by running:
 ```bash
-ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8888 uvx oracle.oci-api-mcp-server
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8888 uvx oracle.oci-cloud-mcp-server
 ```
 then place the following in your MCP client configuration:
 :warning: NOTE: the `type` attribute differs across MCP clients; some use `http` as the
@@ -67,7 +67,7 @@ transport value while others (like Cline) expect `streamableHttp`.
 ```json
 {
   "mcpServers": {
-    "oracle-oci-api-mcp-server": {
+    "oracle-oci-cloud-mcp-server": {
       "type": "streamableHttp",
       "url": "http://127.0.0.1:8888/mcp"
     }
@@ -86,12 +86,12 @@ https://podman.io/docs/installation
 
 ### Building the Container Image
 
-You can build the container image using the following command. The command shows building the container image for the oci-api-mcp-server.
+You can build the container image using the following command. The command shows building the container image for the oci-cloud-mcp-server.
 
 ```sh
-SUBDIRS=src/oci-api-mcp-server make containerize
+SUBDIRS=src/oci-cloud-mcp-server make containerize
 ```
-The above command builds the container image tagged as `oracle.oci-api-mcp-server:latest`.
+The above command builds the container image tagged as `oracle.oci-cloud-mcp-server:latest`.
 
 ### MCP Client Configuration
 
@@ -99,7 +99,7 @@ For examples of configuring MCP clients to run the server using podman, see the 
 
 Alternatively, if you want to use HTTP transport using the podman container, then start the MCP server using the following command and configure your client as mentioned in Quickstart section above.
 ```bash
-podman run -v "/path/to/your/.oci:/app/.oci" -e ORACLE_MCP_HOST=0.0.0.0 -e ORACLE_MCP_PORT=8888 -p 8888:8888 oracle.oci-api-mcp-server:latest
+podman run -v "/path/to/your/.oci:/app/.oci" -e ORACLE_MCP_HOST=0.0.0.0 -e ORACLE_MCP_PORT=8888 -p 8888:8888 oracle.oci-cloud-mcp-server:latest
 ```
 ⚠️ **NOTE**: Ensure that all the fields that are paths to files in `/path/to/your/.oci/config` uses the **~** character so that the path resolves both inside and outside the container; for example: 
 ```bash
@@ -155,11 +155,11 @@ For macOS/Linux:
 ```json
 {
   "mcpServers": {
-    "oracle-oci-api-mcp-server": {
+    "oracle-oci-cloud-mcp-server": {
       "type": "stdio",
       "command": "uvx",
       "args": [
-        "oracle.oci-api-mcp-server@latest"
+        "oracle.oci-cloud-mcp-server@latest"
       ],
       "env": {
         "OCI_CONFIG_PROFILE": "<profile_name>",
@@ -170,18 +170,18 @@ For macOS/Linux:
 }
 ```
 
-Alternatively, to run using podman (example for oracle.oci-api-mcp-server):
+Alternatively, to run using podman (example for oracle.oci-cloud-mcp-server):
 
 ```json
 {
   "mcpServers": {
-    "oracle-oci-api-mcp-server": {
+    "oracle-oci-cloud-mcp-server": {
       "autoApprove": [],
       "disabled": false,
       "timeout": 60,
       "type": "stdio",
       "command": "podman",
-      "args": ["run", "-i", "--rm", "-v", "/path/to/your/.oci:/app/.oci", "oracle.oci-api-mcp-server:latest"],
+      "args": ["run", "-i", "--rm", "-v", "/path/to/your/.oci:/app/.oci", "oracle.oci-cloud-mcp-server:latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "INFO"
       }
@@ -222,11 +222,11 @@ For macOS/Linux:
 ```json
 {
   "mcpServers": {
-    "oracle-oci-api-mcp-server": {
+    "oracle-oci-cloud-mcp-server": {
       "type": "stdio",
       "command": "uvx",
       "args": [
-        "oracle.oci-api-mcp-server"
+        "oracle.oci-cloud-mcp-server"
       ],
       "env": {
         "OCI_CONFIG_PROFILE": "<profile_name>",
@@ -237,15 +237,15 @@ For macOS/Linux:
 }
 ```
 
-Alternatively, to run using podman (example for oracle-oci-api-mcp-server):
+Alternatively, to run using podman (example for oracle-oci-cloud-mcp-server):
 
 ```json
 {
   "mcpServers": {
-    "oracle-oci-api-mcp-server": {
+    "oracle-oci-cloud-mcp-server": {
       "type": "stdio",
       "command": "podman",
-      "args": ["run", "-i", "--rm", "-v", "/path/to/your/.oci:/app/.oci", "oracle.oci-api-mcp-server:latest"],
+      "args": ["run", "-i", "--rm", "-v", "/path/to/your/.oci:/app/.oci", "oracle.oci-cloud-mcp-server:latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "INFO"
       }
@@ -294,11 +294,11 @@ For macOS/Linux:
 ```json
 {
   "mcpServers": {
-    "oracle-oci-api-mcp-server": {
+    "oracle-oci-cloud-mcp-server": {
       "type": "stdio",
       "command": "uvx",
       "args": [
-        "oracle.oci-api-mcp-server"
+        "oracle.oci-cloud-mcp-server"
       ],
       "env": {
         "OCI_CONFIG_PROFILE": "<profile_name>",
@@ -309,15 +309,15 @@ For macOS/Linux:
 }
 ```
 
-Alternatively, to run using podman (example for oracle-oci-api-mcp-server):
+Alternatively, to run using podman (example for oracle-oci-cloud-mcp-server):
 
 ```json
 {
   "mcpServers": {
-    "oracle-oci-api-mcp-server": {
+    "oracle-oci-cloud-mcp-server": {
       "type": "stdio",
       "command": "podman",
-      "args": ["run", "-i", "--rm", "-v", "/path/to/your/.oci:/app/.oci", "oracle.oci-api-mcp-server:latest"],
+      "args": ["run", "-i", "--rm", "-v", "/path/to/your/.oci:/app/.oci", "oracle.oci-cloud-mcp-server:latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "INFO"
       }
@@ -368,11 +368,11 @@ For macOS/Linux:
 ```json
 {
   "mcpServers": {
-    "oracle-oci-api-mcp-server": {
+    "oracle-oci-cloud-mcp-server": {
       "command": "uv",
       "args": [
         "run",
-        "oracle.oci-api-mcp-server"
+        "oracle.oci-cloud-mcp-server"
       ],
       "env": {
         "VIRTUAL_ENV": "<path to your cloned repo>/mcp/.venv",
@@ -410,12 +410,12 @@ update it as needed. For instance:
 ```json
 {
   "mcpServers": {
-    "oracle-oci-api-mcp-server": {
+    "oracle-oci-cloud-mcp-server": {
       "type": "stdio",
       "command": "uv",
       "args": [
         "run",
-        "oracle.oci-api-mcp-server"
+        "oracle.oci-cloud-mcp-server"
       ],
       "env": {
         "VIRTUAL_ENV": "<path to your cloned repo>/oci-mcp/.venv",
@@ -437,7 +437,7 @@ make install
 
 then start the server:
 ```bash
-VIRTUAL_ENV=$(pwd)/.venv ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8888 uv run oracle.oci-api-mcp-server
+VIRTUAL_ENV=$(pwd)/.venv ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8888 uv run oracle.oci-cloud-mcp-server
 ```
 
 ### Inspector
@@ -483,7 +483,7 @@ uv run --index=https://test.pypi.org/simple <mcp server package>
 ```
 example:
 ```bash
-uv run --index=https://test.pypi.org/simple oracle.oci-api-mcp-server
+uv run --index=https://test.pypi.org/simple oracle.oci-cloud-mcp-server
 ```
 
 ### Publish packages

--- a/src/oci-api-mcp-server/README.md
+++ b/src/oci-api-mcp-server/README.md
@@ -5,18 +5,57 @@
 This server provides tools to run OCI CLI commands to interact with the OCI services.
 It includes tools to help with OCI command execution and provide helpful information.
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-api-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-api": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-api-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-api-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-api-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-api": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-cloud-guard-mcp-server/README.md
+++ b/src/oci-cloud-guard-mcp-server/README.md
@@ -5,18 +5,57 @@
 This package implements certain functions of the [OCI Cloud Guard Service](https://docs.oracle.com/en-us/iaas/Content/cloud-guard/home.htm).
 It includes tools to help with managing cloud guard problems.
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-cloud-guard-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-cloud-guard": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-cloud-guard-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-cloud-guard-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-cloud-guard-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-cloud-guard": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-cloud-mcp-server/README.md
+++ b/src/oci-cloud-mcp-server/README.md
@@ -6,18 +6,57 @@ This server provides tools to interact with Oracle Cloud Infrastructure (OCI) se
 - Invoke any OCI SDK client operation by fully-qualified client class and method name
 - Discover available operations for a given OCI client
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-cloud-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-cloud": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-cloud-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-cloud-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-cloud-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-cloud": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-compute-instance-agent-mcp-server/README.md
+++ b/src/oci-compute-instance-agent-mcp-server/README.md
@@ -4,18 +4,57 @@
 
 This server provides tools for interacting with Oracle Cloud Infrastructure (OCI) Compute Instance Agent service.
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-compute-instance-agent-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-compute-instance-agent": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-compute-instance-agent-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-compute-instance-agent-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-compute-instance-agent-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-compute-instance-agent": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-compute-mcp-server/README.md
+++ b/src/oci-compute-mcp-server/README.md
@@ -5,18 +5,57 @@
 This server provides tools to interact with the OCI Compute resources.
 It includes tools to help with managing compute instances.
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-compute-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-compute": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-compute-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-compute-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-compute-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-compute": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-database-mcp-server/README.md
+++ b/src/oci-database-mcp-server/README.md
@@ -4,10 +4,57 @@
 
 This server provides tools to interact with the OCI Database service.
 
-## Running the server
+## MCP client configuration (recommended)
 
-```sh
-uv run oracle.oci-database-mcp-server
+Most users should configure their MCP client to launch the server, rather than starting it manually.
+
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-database": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-database-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
+```
+
+## Run the server locally (HTTP transport)
+
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-database-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-database": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Environment Variables

--- a/src/oci-faaas-mcp-server/README.md
+++ b/src/oci-faaas-mcp-server/README.md
@@ -4,10 +4,57 @@
 
 This server provides tools for interacting with Oracle Cloud Infrastructure (OCI) Fusion Applications (FAaaS) via the OCI Python SDK `oci.fusion_apps.FusionApplicationsClient`.
 
-## Running the server
+## MCP client configuration (recommended)
 
-```sh
-uv run oracle.oci-faaas-mcp-server
+Most users should configure their MCP client to launch the server, rather than starting it manually.
+
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-faaas": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-faaas-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
+```
+
+## Run the server locally (HTTP transport)
+
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-faaas-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-faaas": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-identity-mcp-server/README.md
+++ b/src/oci-identity-mcp-server/README.md
@@ -4,18 +4,28 @@
 
 This server provides tools to interact with the OCI Identity service.
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-identity-mcp-server
-```
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
 
-### HTTP streaming transport mode
-
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-identity-mcp-server
+```json
+{
+  "mcpServers": {
+    "oci-identity": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-identity-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT",
+        "TENANCY_ID_OVERRIDE": ""
+      }
+    }
+  }
+}
 ```
 
 ## Environment Variables
@@ -24,6 +34,36 @@ The server supports the following environment variables:
 
 - `OCI_CONFIG_PROFILE`: OCI configuration profile name (default: "DEFAULT")
 - `TENANCY_ID_OVERRIDE`: Overrides the tenancy ID from the config file
+
+## Run the server locally (HTTP transport)
+
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-identity-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-identity": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
+```
 
 ## Tools
 

--- a/src/oci-logging-mcp-server/README.md
+++ b/src/oci-logging-mcp-server/README.md
@@ -5,18 +5,57 @@
 This server provides tools to interact with the OCI Logging resources.
 It includes tools to help with managing logging configurations.
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-logging-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-logging": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-logging-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-logging-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-logging-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-logging": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-migration-mcp-server/README.md
+++ b/src/oci-migration-mcp-server/README.md
@@ -4,18 +4,57 @@
 
 This server provides tools for interacting with Oracle Cloud Infrastructure (OCI) Migration service.
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-migration-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-migration": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-migration-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-migration-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-migration-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-migration": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-monitoring-mcp-server/README.md
+++ b/src/oci-monitoring-mcp-server/README.md
@@ -4,18 +4,57 @@
 
 This server provides tools for interacting with Oracle Cloud Infrastructure (OCI) Monitoring service.
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-monitoring-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-monitoring": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-monitoring-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-monitoring-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-monitoring-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-monitoring": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-network-load-balancer-mcp-server/README.md
+++ b/src/oci-network-load-balancer-mcp-server/README.md
@@ -5,18 +5,57 @@
 This server provides tools to interact with the OCI Network Load Balancer resources.
 It includes tools to help with managing network load balancers.
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-network-load-balancer-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-network-load-balancer": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-network-load-balancer-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-network-load-balancer-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-network-load-balancer-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-network-load-balancer": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-networking-mcp-server/README.md
+++ b/src/oci-networking-mcp-server/README.md
@@ -5,18 +5,57 @@
 This server provides tools to interact with the OCI Networking resources.
 It includes tools to help with managing network configurations.
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-networking-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-networking": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-networking-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-networking-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-networking-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-networking": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-object-storage-mcp-server/README.md
+++ b/src/oci-object-storage-mcp-server/README.md
@@ -5,18 +5,57 @@
 This server provides tools to interact with the OCI Object Storage resources.
 It includes tools to help with managing object storage configurations.
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-object-storage-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-object-storage": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-object-storage-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-object-storage-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-object-storage-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-object-storage": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-pricing-mcp-server/README.md
+++ b/src/oci-pricing-mcp-server/README.md
@@ -151,6 +151,34 @@ Test-only helpers (used by functional tests; **not needed** for normal use):
 }
 ```
 
+## Run the server locally (HTTP transport)
+
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-pricing-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+```json
+{
+  "mcpServers": {
+    "oci-pricing": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
+```
+
 ## API Tools
 
 1. **`pricing_get_sku(part_number, currency=None, max_pages=None)`**

--- a/src/oci-registry-mcp-server/README.md
+++ b/src/oci-registry-mcp-server/README.md
@@ -6,18 +6,57 @@ This server provides tools to interact with the OCI Registry resources.
 It includes tools to help with managing container repositories.
 
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-registry-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-registry": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-registry-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-registry-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-registry-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-registry": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-resource-search-mcp-server/README.md
+++ b/src/oci-resource-search-mcp-server/README.md
@@ -5,18 +5,57 @@
 This server provides tools for interacting with Oracle Cloud Infrastructure (OCI) Resource Search service.
 
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-resource-search-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-resource-search": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-resource-search-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-resource-search-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-resource-search-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-resource-search": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-usage-mcp-server/README.md
+++ b/src/oci-usage-mcp-server/README.md
@@ -5,18 +5,57 @@
 This server provides tools for interacting with Oracle Cloud Infrastructure (OCI) Usage service.
 
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uvx oracle.oci-usage-mcp-server
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-usage": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-usage-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
-### HTTP streaming transport mode
+## Run the server locally (HTTP transport)
 
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uvx oracle.oci-usage-mcp-server
+Most MCP clients run this server for you over **stdio** (see above). If you want to run the server as a standalone
+service and connect to it over HTTP (**streamable HTTP**), you can.
+
+1) Start the server in HTTP mode (choose host/port):
+
+```bash
+ORACLE_MCP_HOST=127.0.0.1 ORACLE_MCP_PORT=8000 uvx oracle.oci-usage-mcp-server
+```
+
+This will expose the MCP endpoint at:
+
+`http://127.0.0.1:8000/mcp`
+
+2) Configure your MCP client to connect via `streamableHttp`:
+
+> Note: MCP client configuration varies by client/tooling. Some clients refer to streamable HTTP as just `http`.
+
+```json
+{
+  "mcpServers": {
+    "oci-usage": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
 ```
 
 ## Tools


### PR DESCRIPTION
# Description

Update READMEs to clarify usage instructions for individual servers and recommend new users start with the oci-cloud-mcp-server instead of the CLI wrapper oci-api-mcp-server.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change ~~requires~~ is a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
