### PR TITLE
fix: in oci_database_mcp_server handle API key auth when security_tok…

### DIFF
--- a/src/oci-database-mcp-server/oracle/oci_database_mcp_server/server.py
+++ b/src/oci-database-mcp-server/oracle/oci_database_mcp_server/server.py
@@ -290,17 +290,23 @@ def get_database_client(region: str = None):
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = config["security_token_file"]
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
-    if region is None:
-        return oci.database.DatabaseClient(config, signer=signer)
-    regional_config = config.copy()
-    regional_config["region"] = region
-    return oci.database.DatabaseClient(regional_config, signer=signer)
-
+    if "security_token_file" in config:
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        token_file = config["security_token_file"]
+        with open(token_file, "r") as f:
+            token = f.read()
+        signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+        if region is None:
+            return oci.database.DatabaseClient(config, signer=signer)
+        regional_config = config.copy()
+        regional_config["region"] = region
+        return oci.database.DatabaseClient(regional_config, signer=signer)
+    else:
+        if region is None:
+            return oci.database.DatabaseClient(config)
+        regional_config = config.copy()
+        regional_config["region"] = region
+        return oci.database.DatabaseClient(regional_config)
 
 def call_create_pdb(client, details, opc_retry_token=None, opc_request_id=None):
     kwargs = {"create_pluggable_database_details": details.__dict__}


### PR DESCRIPTION
…en_file is absent

The original code unconditionally accessed config['security_token_file'], causing a KeyError for users authenticating with API keys. Added a check so token-based auth is only used when the key is present in the config.

# Description

The `get_database_client()` function in `src/oci-database-mcp-server/oracle/oci_database_mcp_server/server.py` unconditionally accessed `config["security_token_file"]`, causing a `KeyError` for any user authenticating with standard API keys. This is because API key-based OCI configs do not include a `security_token_file` entry — only token-based (session) auth configs do.

The fix adds a conditional check (`if "security_token_file" in config`) so that token-based signing is only used when the key is actually present, and API key auth falls through to the standard `DatabaseClient` instantiation.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The fix was verified by running the MCP server locally against a real OCI tenancy using standard API key authentication (no `security_token_file` in `~/.oci/config`). Prior to the fix, any call to `list_autonomous_databases` (and all other database operations) would fail immediately with `KeyError: 'security_token_file'`. After the fix, all operations complete successfully.

**Test Configuration**:
* OCI CLI config: API key auth (`~/.oci/config`, DEFAULT profile, no security token)
* OCI SDK: `oci==2.160.0`
* Python: 3.13
* Platform: macOS
* MCP server version: `oracle.oci-database-mcp-server 1.0.4`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
