### PR TITLE
chore: add krisrice as code owner for src/oci-*

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@ CODEOWNERS @krisrice
 
 .git*/ @krisrice @AlaaShaker @gebhardtr
 scripts/ @krisrice @AlaaShaker @gebhardtr
-src/oci-* @AlaaShaker @gebhardtr
+src/oci-* @krisrice @AlaaShaker @gebhardtr
 tests/ @krisrice @AlaaShaker @gebhardtr
 Makefile @krisrice @AlaaShaker @gebhardtr
 *.md @krisrice @AlaaShaker @gebhardtr


### PR DESCRIPTION
Add @krisrice to the `src/oci-*` CODEOWNERS entry so that krisrice can approve PRs touching those paths independently, alongside @AlaaShaker and @gebhardtr.