### PR TITLE
chore: add standardized MCP client quick-start to servers missing it

### DIFF
--- a/src/mysql-mcp-server/README.md
+++ b/src/mysql-mcp-server/README.md
@@ -56,41 +56,44 @@ see the [OCI SDK documentation](https://docs.oracle.com/en-us/iaas/Content/API/C
 - `MySQL AI`
 - `HeatWave`
 
-## MCP Server Configuration
+## MCP client configuration (recommended)
 
-Installation is dependent on the MCP Client being used, it usually consists of adding the MCP Server invocation in a json config file, for example with Claude UI on Windows it looks like this:
+Most users should configure their MCP client to launch the server, rather than starting it manually.
+
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
 ```json
 {
   "mcpServers": {
-    "mysqltools": {
-      "command": "uv",
+    "mysql": {
+      "type": "stdio",
+      "command": "uvx",
       "args": [
-        "--directory",
-        "C:\\ABSOLUTE\\PATH\\TO\\PARENT\\FOLDER\\mysql-mcp-server",
-        "run",
-        "oracle.mysql_mcp_server"
-      ]
+        "oracle.mysql-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT",
+        "MYSQL_MCP_CONFIG": "/path/to/your/config.json"
+      }
     }
   }
 }
 ```
-**Note**: On Windows you may have to provide the suffix *.exe* to "oracle.mysql_mcp_server".
 
+Example with `TENANCY_ID_OVERRIDE`:
 
-
-Example with TENANCY_ID_OVERRIDE::
 ```json
 {
   "mcpServers": {
-    "mysqltools": {
-      "command": "uv",
+    "mysql": {
+      "type": "stdio",
+      "command": "uvx",
       "args": [
-        "--directory",
-        "C:\\ABSOLUTE\\PATH\\TO\\PARENT\\FOLDER\\mysql-mcp-server",
-        "run",
-        "oracle.mysql_mcp_server"
+        "oracle.mysql-mcp-server"
       ],
       "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT",
+        "MYSQL_MCP_CONFIG": "/path/to/your/config.json",
         "TENANCY_ID_OVERRIDE": "ocid1.tenancy.oc1..deadbeef"
       }
     }

--- a/src/oci-limits-mcp-server/README.md
+++ b/src/oci-limits-mcp-server/README.md
@@ -4,11 +4,27 @@
 
 This MCP server exposes Oracle Cloud Infrastructure Limits APIs through tools mirroring public endpoints.
 
-## Running the Server
+## MCP client configuration (recommended)
 
-To run the server:
-```sh
-uv run oracle.oci-limits-mcp-server
+Most users should configure their MCP client to launch the server, rather than starting it manually.
+
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-limits": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-limits-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
 ## Tools

--- a/src/oci-load-balancer-mcp-server/README.md
+++ b/src/oci-load-balancer-mcp-server/README.md
@@ -1,3 +1,26 @@
 # OCI Load Balancer MCP Server
 
 This server provides tools for interacting with Oracle Cloud Infrastructure (OCI) Load Balancer service.
+
+## MCP client configuration (recommended)
+
+Most users should configure their MCP client to launch the server, rather than starting it manually.
+
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-load-balancer": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-load-balancer-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
+```

--- a/src/oci-recovery-mcp-server/README.md
+++ b/src/oci-recovery-mcp-server/README.md
@@ -7,6 +7,29 @@ OCI Model Context Protocol (MCP) server exposing Oracle Cloud Recovery Service o
 - List Protected Databases with rich filtering (compartment, lifecycle_state, display_name, id, protection_policy_id, recovery_service_subnet_id, limit, page, sort_order, sort_by, opc_request_id, region).
 - Mapping of OCI SDK models to Pydantic for safe, serializable responses.
 
+## MCP client configuration (recommended)
+
+Most users should configure their MCP client to launch the server, rather than starting it manually.
+
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
+
+```json
+{
+  "mcpServers": {
+    "oci-recovery": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-recovery-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
+```
+
 ## Install
 
 From this repository root:
@@ -23,23 +46,6 @@ cd src/oci-recovery-mcp-server
 uv build
 uv pip install .
 ```
-
-## Usage
-
-Run the MCP server (HTTP transport is optional):
-
-```
-# environment variables (optional)
-export ORACLE_MCP_HOST=127.0.0.1
-export ORACLE_MCP_PORT=7337
-
-# run
-uv run oracle.oci-recovery-mcp-server
-```
-
-The server reads OCI auth from your OCI CLI config/profile:
-- Uses the profile in $OCI_CONFIG_PROFILE (defaults to DEFAULT)
-- Uses security token file signer with the private key specified in config
 
 ## Tools
 

--- a/src/oci-support-mcp-server/README.md
+++ b/src/oci-support-mcp-server/README.md
@@ -4,18 +4,27 @@
 
 This MCP server provides tools to interact with Oracle Cloud Infrastructure (OCI) Support resources via the CIMS API. The server enables listing and managing support tickets, validating users making it easy to automate and monitor support operations.
 
-## Running the server
+## MCP client configuration (recommended)
 
-### STDIO transport mode (for local testing)
+Most users should configure their MCP client to launch the server, rather than starting it manually.
 
-```sh
-uv oracle.oci-support-mcp-server
-```
+Add a stanza like this to your MCP client config (often called `mcp.json`; example shown is **stdio**):
 
-### HTTP streaming transport mode
-
-```sh
-ORACLE_MCP_HOST=<hostname/IP address> ORACLE_MCP_PORT=<port number> uv oracle.oci-support-mcp-server
+```json
+{
+  "mcpServers": {
+    "oci-support": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oci-support-mcp-server"
+      ],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT"
+      }
+    }
+  }
+}
 ```
 
 ## Tools
@@ -43,15 +52,15 @@ You must provide credentials in the standard OCI CLI config file (see [OCI docs]
 ```json
 {
   "mcpServers": {
-    "oracle-oci-support-mcp-server": {
+    "oci-support": {
       "type": "stdio",
-      "command": "uv",
+      "command": "uvx",
       "args": [
         "oracle.oci-support-mcp-server"
       ],
       "env": {
-        "OCI_CONFIG_PROFILE": "<profile>",        // OCI CLI profile with private key & fingerprint
-        "OCI_CONFIG_FILE": "/.oci/config"        // Path to the OCI CLI config file (typically ~/.oci/config)
+        "OCI_CONFIG_PROFILE": "DEFAULT",
+        "OCI_CONFIG_FILE": "~/.oci/config"
       }
     }
   }

--- a/src/oracle-goldengate-mcp-server/README.md
+++ b/src/oracle-goldengate-mcp-server/README.md
@@ -5,6 +5,33 @@
 This server provides tools to interact with Oracle GoldenGate deployments through the GoldenGate Administration REST APIs.
 It includes tools for administration, process lifecycle management, and operational monitoring.
 
+## MCP client configuration (recommended)
+
+Most users should configure their MCP client to launch the server, rather than starting it manually.
+
+GoldenGate requires several environment variables for connectivity. Add a stanza like this to your MCP client config (often called `mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "oracle-goldengate": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "oracle.oracle-goldengate-mcp-server"
+      ],
+      "env": {
+        "OGG_BASE_URL": "https://<your-goldengate-host>",
+        "OGG_USERNAME": "<your-username>",
+        "OGG_PASSWORD": "<your-password>"
+      }
+    }
+  }
+}
+```
+
+See [Environment configuration](#environment-configuration) below for all supported variables, including OCI Vault-based password retrieval.
+
 ## Running the server
 
 ### 1) Obtain the code


### PR DESCRIPTION
## Summary

Companion to PR #147 (`rigebha/server-readmes`). Six servers added to the repo after that PR was opened were missing the standardized `## MCP client configuration (recommended)` quick-start section.

Also removes HTTP transport examples per repo policy — HTTP is only permitted when protected by IDCS or an equivalent identity provider.

## Servers updated

| Server | Change |
|--------|--------|
| `oci-limits-mcp-server` | Replaced bare `uv run` section with standardized `uvx` stdio config |
| `oci-load-balancer-mcp-server` | Added client config section (README was nearly empty) |
| `oci-recovery-mcp-server` | Added client config section; removed HTTP transport env var examples |
| `oci-support-mcp-server` | Replaced old running section (had HTTP transport); fixed duplicate auth example (`uv`→`uvx`, invalid JSON comments, wrong config path) |
| `mysql-mcp-server` | Replaced Windows-only `uv --directory` examples with `uvx` + proper env vars |
| `oracle-goldengate-mcp-server` | Added client config section with required GoldenGate env vars |

## Not included

- `dbtools-mcp-server` — standalone `.py` script with no `pyproject.toml`, cannot be installed via `uvx`
- `oracle-db-doc-mcp-server` — requires a locally built index before use; needs a separate, tailored quick-start