### PR TITLE
ci: targeted builds and runner reliability improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,11 +74,37 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Get directories
         id: get-directories
         run: |
-          directories=$(ls src | grep -v dbtools-mcp-server | grep -v mysql-mcp-server | grep -v oci-pricing-mcp-server | grep -v oracle-db-doc-mcp-server | grep -v oracle-db-mcp-java-toolkit | jq -R -s -c 'split("\n")[:-1]')
+          EXCLUDED="dbtools-mcp-server|mysql-mcp-server|oci-pricing-mcp-server|oracle-db-doc-mcp-server|oracle-db-mcp-java-toolkit"
+          ALL=$(ls src | grep -vE "$EXCLUDED")
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE=${{ github.event.pull_request.base.sha }}
+
+            # If build infrastructure changed, test everything
+            INFRA=$(git diff --name-only "$BASE" HEAD | grep -E '^(requirements.*\.txt|\.github/|Makefile)' | head -1 || true)
+
+            if [ -n "$INFRA" ]; then
+              DIRS="$ALL"
+            else
+              # Only build servers with changed files under src/<server>/
+              DIRS=$(git diff --name-only "$BASE" HEAD \
+                | grep '^src/' \
+                | cut -d'/' -f2 \
+                | sort -u \
+                | grep -vE "$EXCLUDED" || true)
+            fi
+          else
+            # Push to main — build everything
+            DIRS="$ALL"
+          fi
+
+          directories=$(echo "$DIRS" | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "directories=$directories" >> $GITHUB_OUTPUT
 
   combined-coverage:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: get-directories
+    timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         directory: ${{ fromJson(needs.get-directories.outputs.directories) }}
     steps:
@@ -21,6 +23,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          cache: 'pip'
 
       - name: Install requirements
         run: pip install -r requirements-dev.txt
@@ -89,6 +92,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          cache: 'pip'
 
       - name: Install requirements
         run: pip install -r requirements-dev.txt

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -1,0 +1,43 @@
+name: Label conflicting PRs
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 6 * * *'  # daily at 06:00 UTC
+
+jobs:
+  label-conflicts:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Label or unlabel conflicting PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+
+          # Get all open non-draft PRs
+          PRS=$(gh api "repos/$REPO/pulls?state=open&per_page=100" --jq '.[] | select(.draft == false) | .number')
+
+          for PR in $PRS; do
+            MERGEABLE=$(gh api "repos/$REPO/pulls/$PR" --jq '.mergeable')
+
+            # mergeable can be null while GitHub is computing it — skip those
+            if [ "$MERGEABLE" = "false" ]; then
+              echo "PR #$PR has conflicts — applying 'needs rebase'"
+              gh api "repos/$REPO/issues/$PR/labels" -f "labels[]=needs rebase" > /dev/null
+            elif [ "$MERGEABLE" = "true" ]; then
+              # Remove the label if conflict is resolved
+              HAS_LABEL=$(gh api "repos/$REPO/issues/$PR/labels" --jq '[.[].name] | contains(["needs rebase"])')
+              if [ "$HAS_LABEL" = "true" ]; then
+                echo "PR #$PR conflicts resolved — removing 'needs rebase'"
+                gh api -X DELETE "repos/$REPO/issues/$PR/labels/needs%20rebase" > /dev/null
+              fi
+            fi
+          done


### PR DESCRIPTION
## Problem

Every PR triggered a full build across all ~22 MCP servers, regardless of which server was actually changed. A PR touching one server would spin up 22 runners, download ~80 packages each, and run for 60+ seconds — wasteful and slow.

Additionally, the builds were fragile: a single flaky runner (e.g. a PyPI network timeout mid-install) would cascade-cancel all other matrix jobs.

## Changes

### 1. Affected-files-only builds on PRs

`get-directories` now uses `git diff` against the PR base SHA to detect which `src/<server>/` directories were actually changed, and only runs those matrix jobs.

| Scenario | Builds triggered |
|----------|-----------------|
| PR touches `src/oci-compute-mcp-server/**` only | `oci-compute-mcp-server` only |
| PR touches `requirements*.txt`, `.github/`, or `Makefile` | all servers (infra change) |
| Push to `main` | all servers (full integration check) |
| PR touches only docs/READMEs at root | none (matrix skipped) |

### 2. pip caching (`cache: 'pip'`)

Added to both `build` and `combined-coverage` jobs. After the first run, the ~80 shared packages (fastmcp, oci, pydantic, etc.) are served from the runner cache instead of re-downloaded from PyPI on every job.

### 3. `fail-fast: false` on the matrix

Previously one flaky runner (e.g. a network timeout) would cascade-cancel all other matrix jobs. Now each job fails independently.

### 4. `timeout-minutes: 15` on the build job

Replaces GitHub's 6-hour default with a hard ceiling appropriate for these builds.