### PR TITLE
Add new tool and enhancements to create_extract and create_replicat

### DIFF
--- a/src/oracle-goldengate-mcp-server/README.md
+++ b/src/oracle-goldengate-mcp-server/README.md
@@ -44,7 +44,7 @@ If you are using Git (recommended to get updates and pull additional required fi
 Clone:
 
 ```sh
-git clone https://github.com/julientestut/mcp.git
+git clone https://github.com/oracle/mcp.git
 cd mcp/src/oracle-goldengate-mcp-server
 ```
 
@@ -206,6 +206,7 @@ Optional variables are also supported:
 | list_extracts | Return the list of Extract processes. |
 | list_replicats | Return the list of Replicat processes. |
 | list_distribution_paths | Return the list of Distribution Paths. |
+| list_data_streams | Return the list of Data Streams. |
 | list_trails | Return the list of trails. |
 | get_extract_status | Return the status of an Extract. |
 | get_replicat_status | Return the status of a Replicat. |

--- a/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/api.py
+++ b/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/api.py
@@ -38,6 +38,10 @@ def list_distribution_paths() -> str:
     return "/services/v2/sources"
 
 
+def list_data_streams() -> str:
+    return "/services/distsrvr/v2/stream"
+
+
 def list_trails() -> str:
     return "/services/adminsrvr/v2/trails"
 

--- a/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/models.py
+++ b/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/models.py
@@ -67,6 +67,14 @@ class CreateExtractOptions(CamelModel):
     where: str | None = Field(None, description="WHERE clause")
 
 
+class ExtractBeginAtCsn(CamelModel):
+    csn: int = Field(..., ge=0, description="Start Extract at the specified CSN")
+
+
+class CreateExtractBegin(CamelModel):
+    at: ExtractBeginAtCsn = Field(..., description="Structured begin position for Extract, such as a CSN")
+
+
 class CreateReplicatSource(CamelModel):
     container: str | None = Field(None, description="Optional source container or PDB")
     schema_name: str = Field(..., alias="schema", min_length=1, description="Source schema name")
@@ -101,6 +109,11 @@ class CreateReplicatOptions(CamelModel):
     trim_spaces: bool | None = Field(None, alias="trimSpaces", description="TRIMSPACES option")
     trim_var_spaces: bool | None = Field(None, alias="trimVarSpaces", description="TRIMVARSPACES option")
     where: str | None = Field(None, description="WHERE clause")
+
+
+class CreateReplicatBegin(CamelModel):
+    sequence: int = Field(..., ge=0, description="Trail sequence number to start reading from")
+    offset: int = Field(..., ge=0, description="Trail RBA offset to start reading from")
 
 
 class IntegratedParamsObject(CamelModel):

--- a/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/server.py
+++ b/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/server.py
@@ -26,8 +26,10 @@ from .extract_config import build_advanced_extract_parameters
 from .http_client import HttpClient
 from .map_statement import build_map_statement, normalize_map_statement
 from .models import (
+    CreateExtractBegin,
     CreateExtractOptions,
     CreateExtractSource,
+    CreateReplicatBegin,
     CreateReplicatOptions,
     CreateReplicatSource,
     ExtractAdvancedParameters,
@@ -71,6 +73,12 @@ def _verify_deployment_connectivity() -> None:
         client.get(api.list_domains())
     except Exception as exc:
         _log_startup("ERROR", f"Failed to connect to GoldenGate deployment: {deployment_url} ({exc})")
+        exc_message = str(exc)
+        if " 401 " in exc_message or "401 {" in exc_message or "401" in exc_message:
+            _log_startup(
+                "ERROR",
+                "Authentication to the GoldenGate deployment failed. Verify OGG_USERNAME and the configured password source. If using OGG_PASSWORD_SECRET_OCID, ensure the OCI Secret contains the current GoldenGate password.",
+            )
         raise
     _log_startup("INFO", f"Successfully connected to GoldenGate deployment: {deployment_url}")
 
@@ -85,6 +93,18 @@ def _serialize_model(model: Any | None) -> dict[str, Any] | None:
 def _none_if_fieldinfo(value: Any) -> Any:
     """Convert undecorated FastMCP default FieldInfo values to None for direct Python calls."""
     return None if isinstance(value, FieldInfo) else value
+
+
+def _resolve_begin_value(begin: Any, default: Any = "now") -> Any:
+    """Normalize begin parameter values for GoldenGate payloads."""
+    begin = _none_if_fieldinfo(begin)
+    if begin is None:
+        return default
+    if isinstance(begin, str):
+        return begin.strip() or default
+    if hasattr(begin, "model_dump"):
+        return begin.model_dump(by_alias=True, exclude_none=True)
+    return begin
 
 
 @mcp.tool(description="Return the list of GoldenGate domains available in OCI GoldenGate deployment. Domains group connections in GoldenGate.")
@@ -133,6 +153,12 @@ def list_replicats() -> str:
 def list_distribution_paths() -> str:
     """Return the list of Distribution Paths available in OCI GoldenGate deployment. A Distribution Path is used to send data to another GoldenGate deployment."""
     return _ok(client.get(api.list_distribution_paths()))
+
+
+@mcp.tool(description="Return the list of Data Streams available in OCI GoldenGate deployment. A Data Stream exposes GoldenGate data for downstream consumers over AsyncAPI channels.")
+def list_data_streams() -> str:
+    """Return the list of Data Streams available in OCI GoldenGate deployment. A Data Stream exposes GoldenGate data for downstream consumers over AsyncAPI channels."""
+    return _ok(client.get(api.list_data_streams()))
 
 
 @mcp.tool(description="Retrieve a collection of all known trails available in OCI GoldenGate deployment. A trail is a file that stores the captured data. A trail can only have two alphanumeric characters.")
@@ -219,12 +245,17 @@ def create_extract(
     tableStatement: str | None = Field(None, description="Raw TABLE statement(s) for Extract"),
     source: CreateExtractSource | None = Field(None, description="Structured source mapping used to build TABLE statements"),
     options: CreateExtractOptions | None = Field(None, description="Optional structured TABLE statement options"),
+    begin: str | CreateExtractBegin | None = Field(
+        None,
+        description="Optional start position for Extract. Defaults to 'now'. Accepts an ISO-8601 timestamp string or structured CSN payload like {at: {csn: 11}}.",
+    ),
     advanced: ExtractAdvancedParameters | None = Field(None, description="Advanced GoldenGate Extract parameters"),
 ) -> str:
     """Creates a new Extract in OCI GoldenGate deployment to capture data from schemas and tables. The Extract name can have, at most, 8 alphanumeric characters."""
     tableStatement = _none_if_fieldinfo(tableStatement)
     source = _none_if_fieldinfo(source)
     options = _none_if_fieldinfo(options)
+    begin = _none_if_fieldinfo(begin)
     advanced = _none_if_fieldinfo(advanced)
 
     if tableStatement and tableStatement.strip():
@@ -251,7 +282,7 @@ def create_extract(
         "credentials": {"domain": domainName, "alias": connectionName},
         "managedProcessSettings": DEFAULT_MANAGED_PROCESS_SETTINGS,
         "registration": {"optimized": False},
-        "begin": "now",
+        "begin": _resolve_begin_value(begin),
         "targets": [{"name": trailName}],
     }
     return _ok(client.post(api.create_extract(extractName), payload))
@@ -321,12 +352,17 @@ def create_replicat(
     mapStatement: str | None = Field(None, description="Raw MAP statement(s) for Replicat"),
     source: CreateReplicatSource | None = Field(None, description="Structured source mapping used to build MAP statements"),
     options: CreateReplicatOptions | None = Field(None, description="Optional structured MAP statement options"),
+    begin: str | CreateReplicatBegin | None = Field(
+        None,
+        description="Optional start position for Replicat. Defaults to 'now'. Accepts an ISO-8601 timestamp string or structured trail position like {sequence: 145, offset: 5}.",
+    ),
     advanced: ReplicatAdvancedParameters | None = Field(None, description="Advanced GoldenGate Replicat parameters"),
 ) -> str:
     """Creates a new Replicat in OCI GoldenGate deployment to replicate data into a target. Supports raw mapStatement or structured source/options. Optionally accepts a checkpointTable, otherwise use list_checkpoint_tables to find a checkpoint table."""
     mapStatement = _none_if_fieldinfo(mapStatement)
     source = _none_if_fieldinfo(source)
     options = _none_if_fieldinfo(options)
+    begin = _none_if_fieldinfo(begin)
     advanced = _none_if_fieldinfo(advanced)
 
     if mapStatement and mapStatement.strip():
@@ -360,6 +396,7 @@ def create_replicat(
         "mode": adv.get("mode") or {"type": "nonintegrated", "parallel": True},
         "registration": "none",
         "status": "stopped",
+        "begin": _resolve_begin_value(begin),
     }
     mode_type = (payload["mode"] or {}).get("type", "nonintegrated")
     if mode_type != "parallel":
@@ -593,7 +630,7 @@ def main() -> None:
     except Exception:
         _log_startup(
             "ERROR",
-            "Startup aborted. Verify the deployment is started and the configured baseUrl is reachable.",
+            "Startup aborted. Verify the deployment is started, the configured baseUrl is reachable, and if you received HTTP 401, check OGG_USERNAME and the password or OGG_PASSWORD_SECRET_OCID secret value.",
         )
         if os.getenv("OGG_MCP_DEBUG", "false").strip().lower() == "true":
             traceback.print_exc(file=sys.stderr)

--- a/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/tests/test_goldengate_tools.py
+++ b/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/tests/test_goldengate_tools.py
@@ -18,7 +18,9 @@ os.environ.setdefault("OGG_PASSWORD", "pass")
 
 from oracle.oracle_goldengate_mcp_server import server  # noqa: E402
 from oracle.oracle_goldengate_mcp_server.models import (  # noqa: E402
+    CreateExtractBegin,
     CreateExtractSource,
+    CreateReplicatBegin,
     ExtractAdvancedParameters,
 )
 
@@ -63,6 +65,12 @@ class TestGoldenGateTools(unittest.TestCase):
             m.assert_called_once_with(server.api.list_distribution_paths())
             self._assert_json(out, {"ok": True})
 
+    def test_list_data_streams(self):
+        with patch.object(server.client, "get", return_value={"ok": True}) as m:
+            out = server.list_data_streams()
+            m.assert_called_once_with(server.api.list_data_streams())
+            self._assert_json(out, {"ok": True})
+
     def test_list_trails(self):
         with patch.object(server.client, "get", return_value={"ok": True}) as m:
             out = server.list_trails()
@@ -97,6 +105,37 @@ class TestGoldenGateTools(unittest.TestCase):
             )
             self._assert_json(out, {"ok": True})
 
+    def test_create_extract_defaults_begin_to_now(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            server.create_extract("E1", "AA", "D", "C", tableStatement="TABLE S.T;", advanced=None)
+            self.assertEqual(m.call_args.args[1]["begin"], "now")
+
+    def test_create_extract_accepts_timestamp_begin(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            server.create_extract(
+                "E1",
+                "AA",
+                "D",
+                "C",
+                tableStatement="TABLE S.T;",
+                begin="2026-04-21T10:33:00+02:00",
+                advanced=None,
+            )
+            self.assertEqual(m.call_args.args[1]["begin"], "2026-04-21T10:33:00+02:00")
+
+    def test_create_extract_accepts_csn_begin(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            server.create_extract(
+                "E1",
+                "AA",
+                "D",
+                "C",
+                tableStatement="TABLE S.T;",
+                begin=CreateExtractBegin(at={"csn": 11}),
+                advanced=None,
+            )
+            self.assertEqual(m.call_args.args[1]["begin"], {"at": {"csn": 11}})
+
     def test_update_extract(self):
         with patch.object(server.client, "patch", return_value={"ok": True}) as m:
             out = server.update_extract("E1", trailName="AA", domainName="D", connectionName="C", tableStatement="TABLE S.T;", advanced=None)
@@ -116,6 +155,37 @@ class TestGoldenGateTools(unittest.TestCase):
                 server.DEFAULT_MANAGED_PROCESS_SETTINGS,
             )
             self._assert_json(out, {"ok": True})
+
+    def test_create_replicat_defaults_begin_to_now(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            server.create_replicat("R1", "AA", "D", "C", mapStatement="MAP S.T, TARGET S2.T2;", advanced=None)
+            self.assertEqual(m.call_args.args[1]["begin"], "now")
+
+    def test_create_replicat_accepts_timestamp_begin(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            server.create_replicat(
+                "R1",
+                "AA",
+                "D",
+                "C",
+                mapStatement="MAP S.T, TARGET S2.T2;",
+                begin="2026-04-21T10:33:00+02:00",
+                advanced=None,
+            )
+            self.assertEqual(m.call_args.args[1]["begin"], "2026-04-21T10:33:00+02:00")
+
+    def test_create_replicat_accepts_trail_position_begin(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            server.create_replicat(
+                "R1",
+                "AA",
+                "D",
+                "C",
+                mapStatement="MAP S.T, TARGET S2.T2;",
+                begin=CreateReplicatBegin(sequence=145, offset=5),
+                advanced=None,
+            )
+            self.assertEqual(m.call_args.args[1]["begin"], {"sequence": 145, "offset": 5})
 
     def test_update_replicat(self):
         with patch.object(server.client, "patch", return_value={"ok": True}) as m:


### PR DESCRIPTION
# Description

This PR includes a new tool (list_data_streams to list Data Streams) and updates to create_extract and create_replicat.

Fixes # 210

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Tested against OCI GoldenGate deployments (GoldenGate for Oracle 23.10 and 23.26)
- Create Extract
- Create Data Stream
- List Data Streams
- Retrieve Extract statistics and report files

**Test Configuration**:
* Firmware version: N/A
* Hardware: N/A
* Toolchain: Python 3.x, pytest
* SDK: N/A

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
