### PR TITLE
fix(oci-pricing-mcp-server): use project dependencies when running in a container

### DIFF
--- a/src/oci-pricing-mcp-server/Dockerfile
+++ b/src/oci-pricing-mcp-server/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY . /app
-RUN pip install -U pip && pip install fastmcp httpx babel pycountry
-CMD ["python", "oci-pricing-mcp-server.py"]
+RUN pip install --no-cache-dir uv && \
+    uv --no-cache sync --locked --all-extras
+CMD ["uv", "run",  "oci-pricing-mcp-server.py"]

--- a/src/oci-pricing-mcp-server/README.md
+++ b/src/oci-pricing-mcp-server/README.md
@@ -218,5 +218,5 @@ docker run --rm -it \
   -e PROBE_SKU_OK=B93113 \
   -e PROBE_CCY=JPY \
   oci-pricing-mcp:dev \
-  python -m unittest discover -s . -p 'test_*.py' -v
+  uv run python -m unittest discover -s . -p 'test_*.py' -v
 ```


### PR DESCRIPTION
# Description

Ensure we're installing and using the server/project dependencies when running the server in a container.

Related to: https://github.com/oracle/mcp/pull/217, will ensure the container dependencies are updated when we update the project dependencies.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Test setup:
```bash
cd src/oci-pricing-mcp-server
podman build -t localhost/oci-pricing-mcp-server .
podman run -it localhost/oci-pricing-mcp-server:latest
```

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
