### PR TITLE
Improve test coverage to get consistent 90% coverage

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -71,7 +71,7 @@ Include license headers at the top of each source file:
 
 ```python
 """
-Copyright (c) 2025, Oracle and/or its affiliates.
+Copyright (c) 2026, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
@@ -210,3 +210,9 @@ def list_instances(
 3. **Descriptions**: Write clear, informative descriptions for each parameter
 4. **Validation**: Use Field constraints like `ge`, `le`, `min_length`, `max_length`
 5. **Literals**: Use `Literal` for parameters with a fixed set of valid values
+
+## Test cases
+
+Target 90% coverage for unit tests on the MCP server itself.
+
+End-to-end tests under `e2e/` are not required, but good to add if they can be created without impacting other tests.

--- a/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/tests/test_migration_models.py
+++ b/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/tests/test_migration_models.py
@@ -52,6 +52,26 @@ class TestMigrationModels:
         res = models._oci_to_dict(Dummy())
         assert res == {"a": 1}
 
+    def test_oci_to_dict_dict_fallback_when_oci_to_dict_raises(self, monkeypatch):
+        def raising(_):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(models.oci.util, "to_dict", raising, raising=False)
+
+        data = {"a": 1}
+        assert models._oci_to_dict(data) == data
+
+    def test_oci_to_dict_returns_none_without_dict_fallback(self, monkeypatch):
+        class Slotted:
+            __slots__ = ()
+
+        def raising(_):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(models.oci.util, "to_dict", raising, raising=False)
+
+        assert models._oci_to_dict(Slotted()) is None
+
     def test_map_migration_full(self):
         src = SimpleNamespace(
             id="mig1",

--- a/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/tests/test_migration_tools.py
+++ b/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/tests/test_migration_tools.py
@@ -70,6 +70,32 @@ class TestMigrationTools:
 
 
 class TestServer:
+    def test_oci_client_kwargs_omits_signer_when_absent(self):
+        kwargs = server._get_oci_client_kwargs()
+
+        assert "signer" not in kwargs
+        assert "circuit_breaker_strategy" in kwargs
+        assert "circuit_breaker_callback" in kwargs
+
+    def test_http_signer_requires_access_token(self, monkeypatch):
+        monkeypatch.setattr(server, "get_access_token", lambda: None)
+        monkeypatch.setenv("ORACLE_MCP_HOST", "127.0.0.1")
+        monkeypatch.setenv("ORACLE_MCP_PORT", "8888")
+
+        with pytest.raises(RuntimeError, match="authenticated IDCS access token"):
+            server._get_http_config_and_signer()
+
+    def test_http_signer_requires_idcs_credentials(self, monkeypatch):
+        monkeypatch.setattr(server, "get_access_token", lambda: MagicMock(token="token"))
+        monkeypatch.setenv("ORACLE_MCP_HOST", "127.0.0.1")
+        monkeypatch.setenv("ORACLE_MCP_PORT", "8888")
+        monkeypatch.delenv("IDCS_DOMAIN", raising=False)
+        monkeypatch.delenv("IDCS_CLIENT_ID", raising=False)
+        monkeypatch.delenv("IDCS_CLIENT_SECRET", raising=False)
+
+        with pytest.raises(RuntimeError, match="IDCS authentication"):
+            server._get_http_config_and_signer()
+
     def test_http_signer_requires_region(self, monkeypatch):
         monkeypatch.setattr(server, "get_access_token", lambda: MagicMock(token="token"))
         monkeypatch.setenv("ORACLE_MCP_HOST", "127.0.0.1")
@@ -80,6 +106,31 @@ class TestServer:
 
         with pytest.raises(RuntimeError, match="OCI_REGION"):
             server._get_http_config_and_signer()
+
+    @patch("oracle.oci_migration_mcp_server.server.oci.auth.signers.TokenExchangeSigner")
+    def test_http_signer_returns_config_and_token_exchange_signer(self, mock_signer, monkeypatch):
+        monkeypatch.setattr(server, "get_access_token", lambda: MagicMock(token="token"))
+        monkeypatch.setenv("ORACLE_MCP_HOST", "127.0.0.1")
+        monkeypatch.setenv("ORACLE_MCP_PORT", "8888")
+        monkeypatch.setenv("IDCS_DOMAIN", "idcs.example.com")
+        monkeypatch.setenv("IDCS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("IDCS_CLIENT_SECRET", "client-secret")
+        monkeypatch.setenv("OCI_REGION", "us-phoenix-1")
+
+        config, signer = server._get_http_config_and_signer()
+
+        assert config == {
+            "region": "us-phoenix-1",
+            "additional_user_agent": f"oci-migration-mcp/{server.__version__}",
+        }
+        mock_signer.assert_called_once_with(
+            "token",
+            "https://idcs.example.com",
+            "client-id",
+            "client-secret",
+            region="us-phoenix-1",
+        )
+        assert signer is mock_signer.return_value
 
     @patch("oracle.oci_migration_mcp_server.server.OCIProvider")
     @patch("oracle.oci_migration_mcp_server.server.mcp.run")
@@ -142,6 +193,17 @@ class TestServer:
 
         server.main()
         mock_mcp_run.assert_called_once_with()
+
+    @patch("os.getenv")
+    def test_main_with_http_transport_requires_auth_config(self, mock_getenv):
+        mock_env = {
+            "ORACLE_MCP_HOST": "1.2.3.4",
+            "ORACLE_MCP_PORT": "8888",
+        }
+        mock_getenv.side_effect = lambda x, d=None: mock_env.get(x, d)
+
+        with pytest.raises(RuntimeError, match="HTTP transport requires IDCS authentication"):
+            server.main()
 
 
 @pytest.mark.asyncio
@@ -274,6 +336,26 @@ async def test_list_migrations_exception_propagates(mock_get_client):
 
 
 class TestGetClient:
+    @patch("oracle.oci_migration_mcp_server.server.oci.cloud_migrations.MigrationClient")
+    @patch("oracle.oci_migration_mcp_server.server._get_oci_client_kwargs")
+    @patch("oracle.oci_migration_mcp_server.server._get_http_config_and_signer")
+    def test_get_migration_client_with_http_signer(
+        self,
+        mock_http_config,
+        mock_client_kwargs,
+        mock_client,
+    ):
+        config = {"region": "us-phoenix-1"}
+        signer = object()
+        mock_http_config.return_value = config, signer
+        mock_client_kwargs.return_value = {"signer": signer}
+
+        result = server.get_migration_client()
+
+        mock_client_kwargs.assert_called_once_with(signer)
+        mock_client.assert_called_once_with(config, signer=signer)
+        assert result is mock_client.return_value
+
     @patch("oracle.oci_migration_mcp_server.server.oci.cloud_migrations.MigrationClient")
     @patch("oracle.oci_migration_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
     @patch("oracle.oci_migration_mcp_server.server.oci.signer.load_private_key_from_file")

--- a/src/oci-migration-mcp-server/pyproject.toml
+++ b/src/oci-migration-mcp-server/pyproject.toml
@@ -51,4 +51,4 @@ omit = [
 
 [tool.coverage.report]
 precision = 2
-fail_under = 53.84
+fail_under = 90

--- a/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/tests/test_goldengate_tools.py
+++ b/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/tests/test_goldengate_tools.py
@@ -6,7 +6,9 @@ https://oss.oracle.com/licenses/upl.
 
 import json
 import os
+import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from pydantic import ValidationError
@@ -19,15 +21,58 @@ os.environ.setdefault("OGG_PASSWORD", "pass")
 from oracle.oracle_goldengate_mcp_server import server  # noqa: E402
 from oracle.oracle_goldengate_mcp_server.models import (  # noqa: E402
     CreateExtractBegin,
+    CreateExtractOptions,
     CreateExtractSource,
     CreateReplicatBegin,
+    CreateReplicatOptions,
+    CreateReplicatSource,
     ExtractAdvancedParameters,
+    ReplicatAdvancedParameters,
 )
 
 
 class TestGoldenGateTools(unittest.TestCase):
     def _assert_json(self, actual: str, expected: dict):
         self.assertEqual(json.loads(actual), expected)
+
+    def test_log_startup_writes_file_and_ignores_file_errors(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = os.path.join(tmpdir, "startup.log")
+            with patch.dict(os.environ, {"GG_MCP_LOG_FILE": log_file}):
+                server._log_startup("INFO", "hello")
+            with open(log_file, encoding="utf-8") as f:
+                self.assertIn("[INFO] hello", f.read())
+
+        with patch.dict(os.environ, {"GG_MCP_LOG_FILE": "/no/such/dir/startup.log"}):
+            server._log_startup("INFO", "ignored")
+
+    def test_verify_deployment_connectivity_success(self):
+        with patch.object(server.client, "get", return_value={"ok": True}) as get, patch.object(
+            server, "_log_startup"
+        ) as log:
+            server._verify_deployment_connectivity()
+
+        get.assert_called_once_with(server.api.list_domains())
+        self.assertEqual(log.call_args_list[-1].args[0], "INFO")
+        self.assertIn("Successfully connected", log.call_args_list[-1].args[1])
+
+    def test_verify_deployment_connectivity_logs_401_details(self):
+        with (
+            patch.object(server.client, "get", side_effect=RuntimeError("401 Unauthorized")),
+            patch.object(server, "_log_startup") as log,
+            self.assertRaises(RuntimeError),
+        ):
+            server._verify_deployment_connectivity()
+
+        messages = [call.args[1] for call in log.call_args_list]
+        self.assertTrue(any("Authentication to the GoldenGate deployment failed" in msg for msg in messages))
+
+    def test_resolve_begin_value_variants(self):
+        self.assertEqual(server._resolve_begin_value(None), "now")
+        self.assertEqual(server._resolve_begin_value("  "), "now")
+        self.assertEqual(server._resolve_begin_value("2026-04-21T10:33:00Z"), "2026-04-21T10:33:00Z")
+        self.assertEqual(server._resolve_begin_value(CreateReplicatBegin(sequence=2, offset=9)), {"sequence": 2, "offset": 9})
+        self.assertEqual(server._resolve_begin_value({"sequence": 1}), {"sequence": 1})
 
     def test_list_domains(self):
         with patch.object(server.client, "get", return_value={"ok": True}) as m:
@@ -95,6 +140,43 @@ class TestGoldenGateTools(unittest.TestCase):
             self.assertEqual(m.call_args.args[0], server.api.create_connection("OracleGoldenGate", "conn", "user", "pwd"))
             self._assert_json(out, {"ok": True})
 
+    def test_create_connection_defaults_domain(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            out = server.create_connection("conn", "user", "pwd", " ")
+            self.assertEqual(m.call_args.args[0], server.api.create_connection(server.DEFAULT_DOMAIN, "conn", "user", "pwd"))
+            self._assert_json(out, {"ok": True})
+
+    def test_add_trandata_schema_and_table_payloads(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            out = server.add_trandata_schema("D", "C", "HR")
+            m.assert_called_once_with(
+                server.api.add_trandata_schema("D", "C"),
+                {
+                    "schemaName": "HR",
+                    "nonvalidatedKeysAllowed": False,
+                    "schedulingColumns": True,
+                    "allColumns": False,
+                    "prepareCsnMode": "nowait",
+                    "operation": "add",
+                },
+            )
+            self._assert_json(out, {"ok": True})
+
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            out = server.add_trandata_table("D", "C", "HR", "EMP")
+            m.assert_called_once_with(
+                server.api.add_trandata_table("D", "C"),
+                {
+                    "tableName": "HR.EMP",
+                    "primaryKey": True,
+                    "schedulingColumns": True,
+                    "allColumns": False,
+                    "prepareCsnMode": "nowait",
+                    "operation": "add",
+                },
+            )
+            self._assert_json(out, {"ok": True})
+
     def test_create_extract(self):
         with patch.object(server.client, "post", return_value={"ok": True}) as m:
             out = server.create_extract("E1", "AA", "D", "C", tableStatement="TABLE S.T;", advanced=None)
@@ -146,6 +228,25 @@ class TestGoldenGateTools(unittest.TestCase):
             )
             self._assert_json(out, {"ok": True})
 
+    def test_update_extract_builds_structured_source_and_exttrail_target(self):
+        with patch.object(server.client, "patch", return_value={"ok": True}) as m:
+            out = server.update_extract(
+                "E1",
+                trailName="AA",
+                domainName="D",
+                connectionName="C",
+                source=CreateExtractSource(schema="S", table="T"),
+                options=CreateExtractOptions(targetDef="target.def"),
+                advanced=ExtractAdvancedParameters(extTrail="BB"),
+            )
+
+        self._assert_json(out, {"ok": True})
+        payload = m.call_args.args[1]
+        self.assertIn("TABLE S.T, TARGETDEF target.def;", payload["config"])
+        self.assertEqual(payload["targets"], [{"name": "BB"}])
+        self.assertEqual(payload["begin"], "now")
+        self.assertEqual(payload["credentials"], {"domain": "D", "alias": "C"})
+
     def test_create_replicat(self):
         with patch.object(server.client, "post", return_value={"ok": True}) as m:
             out = server.create_replicat("R1", "AA", "D", "C", mapStatement="MAP S.T, TARGET S2.T2;", advanced=None)
@@ -155,6 +256,36 @@ class TestGoldenGateTools(unittest.TestCase):
                 server.DEFAULT_MANAGED_PROCESS_SETTINGS,
             )
             self._assert_json(out, {"ok": True})
+
+    def test_create_replicat_requires_map_statement_or_source(self):
+        with self.assertRaises(ValueError):
+            server.create_replicat("R1", "AA", "D", "C")
+
+    def test_create_replicat_with_structured_source_checkpoint_and_parallel_mode(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            out = server.create_replicat(
+                "R1",
+                "AA",
+                "D",
+                "C",
+                source=CreateReplicatSource(schema="S", table="T", targetTable="D.T"),
+                options=CreateReplicatOptions(targetDef="target.def"),
+                advanced=ReplicatAdvancedParameters(
+                    credential="USERIDALIAS TARGET DOMAIN D",
+                    checkpointTable="D.CHKPT",
+                    modeType="parallel",
+                    modeParallel=True,
+                    additionalParameters=["ASSUMETARGETDEFS"],
+                ),
+            )
+
+        self._assert_json(out, {"ok": True})
+        payload = m.call_args.args[1]
+        self.assertIn("USERIDALIAS TARGET DOMAIN D", payload["config"])
+        self.assertIn("MAP S.T, TARGET D.T, TARGETDEF target.def;", payload["config"])
+        self.assertEqual(payload["checkpoint"], {"table": "D.CHKPT"})
+        self.assertEqual(payload["mode"], {"type": "parallel", "parallel": True})
+        self.assertNotIn("source", payload)
 
     def test_create_replicat_defaults_begin_to_now(self):
         with patch.object(server.client, "post", return_value={"ok": True}) as m:
@@ -197,17 +328,78 @@ class TestGoldenGateTools(unittest.TestCase):
             )
             self._assert_json(out, {"ok": True})
 
+    def test_update_replicat_structured_source_requires_target_table(self):
+        source_without_target = SimpleNamespace(
+            model_dump=lambda **_kwargs: {"schema": "S", "table": "T"}
+        )
+
+        with self.assertRaises(ValueError):
+            server.update_replicat("R1", source=source_without_target)
+
+    def test_update_replicat_uses_advanced_credentials_and_parallel_mode(self):
+        with patch.object(server.client, "patch", return_value={"ok": True}) as m:
+            out = server.update_replicat(
+                "R1",
+                trailName="AA",
+                source=CreateReplicatSource(schema="S", table="T", targetTable="D.T"),
+                advanced=ReplicatAdvancedParameters(
+                    credential="USERIDALIAS TARGET DOMAIN D",
+                    modeType="parallel",
+                    modeParallel=False,
+                ),
+            )
+
+        self._assert_json(out, {"ok": True})
+        payload = m.call_args.args[1]
+        self.assertIn("USERIDALIAS TARGET DOMAIN D", payload["config"])
+        self.assertEqual(payload["mode"], {"type": "parallel", "parallel": False})
+        self.assertNotIn("source", payload)
+        self.assertNotIn("credentials", payload)
+
     def test_create_distribution_path(self):
         with patch.object(server.client, "post", return_value={"ok": True}) as m:
             out = server.create_distribution_path("P1", "src.example.com", "AA", "tgt.example.com", targetAuthenticationMethod=None)
             self.assertEqual(m.call_args.args[0], server.api.create_distribution_path("P1", "src.example.com", "AA", "tgt.example.com", 443, "OAuth", None, None))
             self._assert_json(out, {"ok": True})
 
+    def test_create_distribution_path_with_alias_authentication(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            out = server.create_distribution_path(
+                "P1",
+                "src.example.com",
+                "AA",
+                "tgt.example.com",
+                targetPort=9443,
+                targetAuthenticationMethod="Alias",
+                targetDomain="D",
+                targetAlias="A",
+            )
+
+        self.assertEqual(m.call_args.args[0], server.api.create_distribution_path("P1", "src.example.com", "AA", "tgt.example.com", 9443, "Alias", "D", "A"))
+        self.assertEqual(m.call_args.args[1]["target"]["authenticationMethod"], {"domain": "D", "alias": "A"})
+        self._assert_json(out, {"ok": True})
+
     def test_create_data_stream(self):
         with patch.object(server.client, "post", return_value={"ok": True}) as m:
             out = server.create_data_stream("DS1", "AA")
             self.assertEqual(m.call_args.args[0], server.api.create_data_stream("DS1", "AA", None, None, None))
             self._assert_json(out, {"ok": True})
+
+    def test_create_data_stream_with_custom_options(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            out = server.create_data_stream(
+                "DS1",
+                "AA",
+                qualityOfService="atLeastOnce",
+                cloudEventsFormat=True,
+                bufferSize=2048,
+            )
+
+        payload = m.call_args.args[1]
+        self.assertEqual(payload["qualityOfService"], "atLeastOnce")
+        self.assertTrue(payload["cloudEventsFormat"])
+        self.assertEqual(payload["bufferSize"], 2048)
+        self._assert_json(out, {"ok": True})
 
     def test_start(self):
         with patch.object(server.client, "post", return_value={"ok": True}) as m:
@@ -330,6 +522,27 @@ class TestGoldenGateTools(unittest.TestCase):
             self.assertEqual(arg_payload["source"]["table"], "T")
             sent_payload = m.call_args.args[1]
             self.assertIn("EXTTRAIL AB", sent_payload["config"])
+
+    def test_main_runs_after_successful_connectivity(self):
+        with patch.object(server, "_verify_deployment_connectivity") as verify, patch.object(server.mcp, "run") as run:
+            server.main()
+
+        verify.assert_called_once_with()
+        run.assert_called_once_with(transport="stdio")
+
+    def test_main_exits_after_failed_connectivity_and_debug_trace(self):
+        with (
+            patch.object(server, "_verify_deployment_connectivity", side_effect=RuntimeError("boom")),
+            patch.object(server, "_log_startup") as log,
+            patch.object(server.traceback, "print_exc") as print_exc,
+            patch.dict(os.environ, {"OGG_MCP_DEBUG": "true"}),
+            self.assertRaises(SystemExit) as exc,
+        ):
+            server.main()
+
+        self.assertEqual(exc.exception.code, 1)
+        self.assertTrue(any("Startup aborted" in call.args[1] for call in log.call_args_list))
+        print_exc.assert_called_once()
 
 
 class TestModelValidation(unittest.TestCase):

--- a/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/tests/test_support_modules.py
+++ b/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/tests/test_support_modules.py
@@ -7,6 +7,7 @@ https://oss.oracle.com/licenses/upl.
 from __future__ import annotations
 
 import base64
+import http.client
 import json
 from pathlib import Path
 
@@ -25,6 +26,12 @@ from oracle.oracle_goldengate_mcp_server import (
 
 def test_map_statement_normalize_and_build() -> None:
     assert map_statement.normalize_map_statement("S.T, TARGET D.T") == "MAP S.T, TARGET D.T;"
+    assert map_statement.normalize_map_statement("MAP S.T, TARGET D.T;") == "MAP S.T, TARGET D.T;"
+
+    minimal = map_statement.build_map_statement(
+        {"source": {"schema": "S", "table": "T", "targetTable": "D.T"}}
+    )
+    assert minimal == "MAP S.T, TARGET D.T;"
 
     built = map_statement.build_map_statement(
         {
@@ -69,6 +76,28 @@ def test_map_statement_normalize_and_build() -> None:
     assert "NOHANDLECOLLISIONS" in built
     assert built.endswith(";")
 
+    alternatives = map_statement.build_map_statement(
+        {
+            "source": {"schema": "S", "table": "T", "targetTable": "D.T"},
+            "options": {
+                "targetDef": "target.def",
+                "handleCollisions": True,
+                "insertAppend": False,
+                "mapAllColumns": True,
+                "mapInvisibleColumns": False,
+                "trimSpaces": False,
+                "trimVarSpaces": True,
+            },
+        }
+    )
+    assert "TARGETDEF target.def" in alternatives
+    assert "HANDLECOLLISIONS" in alternatives
+    assert "NOINSERTAPPEND" in alternatives
+    assert "MAPALLCOLUMNS" in alternatives
+    assert "NOMAPINVISIBLECOLUMNS" in alternatives
+    assert "NOTRIMSPACES" in alternatives
+    assert "TRIMVARSPACES" in alternatives
+
 
 @pytest.mark.parametrize(
     "payload,error",
@@ -90,6 +119,10 @@ def test_map_statement_validation_errors(payload: dict, error: str) -> None:
 
 def test_table_statement_normalize_and_build() -> None:
     assert table_statement.normalize_table_statement("S.T") == "TABLE S.T;"
+    assert table_statement.normalize_table_statement("TABLE S.T;") == "TABLE S.T;"
+
+    minimal = table_statement.build_table_statement({"source": {"schema": "S", "table": "T"}})
+    assert minimal == "TABLE S.T;"
 
     built = table_statement.build_table_statement(
         {
@@ -131,6 +164,24 @@ def test_table_statement_normalize_and_build() -> None:
     assert "NOTRIMSPACES" in built
     assert "TRIMVARSPACES" in built
 
+    alternatives = table_statement.build_table_statement(
+        {
+            "source": {"schema": "S", "table": "T"},
+            "options": {
+                "colsExcept": ["SECRET"],
+                "targetDef": "target.def",
+                "getBeforeCols": ["ID", "NAME"],
+                "trimSpaces": True,
+                "trimVarSpaces": False,
+            },
+        }
+    )
+    assert "COLSEXCEPT (SECRET)" in alternatives
+    assert "TARGETDEF target.def" in alternatives
+    assert "GETBEFORECOLS (ID, NAME)" in alternatives
+    assert "TRIMSPACES" in alternatives
+    assert "NOTRIMVARSPACES" in alternatives
+
 
 @pytest.mark.parametrize(
     "payload,error",
@@ -148,6 +199,22 @@ def test_table_statement_validation_errors(payload: dict, error: str) -> None:
 
 
 def test_extract_config_builders() -> None:
+    assert extract_config._normalize_boolean(False) == "FALSE"
+    assert extract_config._normalize_boolean(0) == "0"
+    assert extract_config._build_integrated_params_clause(None) is None
+    assert extract_config._build_integrated_params_clause(" parallelism 2 ") == "INTEGRATEDPARAMS (parallelism 2)"
+    assert extract_config._build_integrated_params_clause([" wait ", " "]) == "INTEGRATEDPARAMS (wait)"
+    assert extract_config._build_integrated_params_clause({"keyValues": {"trace": False}}) == "INTEGRATEDPARAMS (trace FALSE)"
+    assert extract_config._build_tranlog_options_clause(None) is None
+    assert extract_config._build_tranlog_options_clause(" archivedlogonly ") == "TRANLOGOPTIONS archivedlogonly"
+    assert extract_config._build_tranlog_options_clause([" alt ", " "]) == "TRANLOGOPTIONS alt"
+    assert extract_config._build_report_count_clause({"every": " 5 MINUTES "}) == "REPORTCOUNT EVERY 5 MINUTES"
+    assert extract_config._build_report_count_clause({}) is None
+    assert extract_config._build_bounded_recovery_clause({}) is None
+    assert extract_config._build_db_options_clause(" integratedparams ") == "DBOPTIONS integratedparams"
+    assert extract_config._build_db_options_clause([" a ", " "]) == "DBOPTIONS a"
+    assert extract_config._build_db_options_clause({}) is None
+
     lines = extract_config.build_advanced_extract_parameters(
         {
             "disableHeartbeatTable": True,
@@ -174,9 +241,21 @@ def test_extract_config_builders() -> None:
     assert "DYNAMICRESOLUTION" in lines
 
     assert extract_config.build_advanced_extract_parameters(None) == []
+    assert extract_config.build_advanced_extract_parameters({"ddl": "INCLUDE ALL"}) == ["DDL INCLUDE ALL"]
 
 
 def test_replicat_config_builders_and_errors() -> None:
+    assert replicat_config._build_db_options(None) is None
+    assert replicat_config._build_db_options(" allowduptargetmap ") == "DBOPTIONS allowduptargetmap"
+    assert replicat_config._build_db_options([" a ", " "]) == "DBOPTIONS a"
+    assert replicat_config._build_db_options({"entries": [" one "], "additional": [" two "]}) == "DBOPTIONS one, two"
+    assert replicat_config._build_batch_sql(None) == []
+    assert replicat_config._build_batch_sql(" mode ops ") == ["BATCHSQL mode ops"]
+    assert replicat_config.build_advanced_replicat_parameters(None) == {
+        "lines": [],
+        "mode": {"type": "nonintegrated", "parallel": True},
+    }
+
     payload = {
         "credential": ["USERIDALIAS C DOMAIN D"],
         "applyParallelism": 3,
@@ -266,6 +345,56 @@ def test_config_read_from_secret_ocid(monkeypatch: pytest.MonkeyPatch, tmp_path:
     assert cfg["password"] == "secretpass"
 
 
+def test_password_file_decoding_and_errors(tmp_path: Path) -> None:
+    utf16_file = tmp_path / "pwd-utf16.txt"
+    utf16_file.write_bytes(b"\xff\xfe" + " secret ".encode("utf-16-le"))
+    assert config._read_password_from_file(str(utf16_file)) == "secret"
+
+    invalid_file = tmp_path / "invalid.txt"
+    invalid_file.write_bytes(b"\xff")
+    with pytest.raises(ValueError, match="Unable to decode"):
+        config._read_password_from_file(str(invalid_file))
+
+    with pytest.raises(ValueError, match="Unable to read"):
+        config._read_password_from_file(str(tmp_path / "missing.txt"))
+
+
+def test_signed_get_success_and_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config, "sign_oci_request", lambda *_args, **_kwargs: {"authorization": "sig"})
+
+    class _Response:
+        def __init__(self, status: int, body: str):
+            self.status = status
+            self._body = body
+
+        def read(self):
+            return self._body.encode("utf-8")
+
+    class _Connection:
+        next_response = _Response(200, '{"ok": true}')
+        requests = []
+
+        def __init__(self, hostname: str):
+            self.hostname = hostname
+
+        def request(self, method: str, path: str, headers: dict):
+            self.requests.append((self.hostname, method, path, headers))
+
+        def getresponse(self):
+            return self.next_response
+
+    monkeypatch.setattr(http.client, "HTTPSConnection", _Connection)
+
+    assert config._signed_get({}, "secrets.example.com", "/secret") == {"ok": True}
+    assert _Connection.requests == [
+        ("secrets.example.com", "GET", "/secret", {"authorization": "sig"})
+    ]
+
+    _Connection.next_response = _Response(404, "missing")
+    with pytest.raises(RuntimeError, match="HTTP 404: missing"):
+        config._signed_get({}, "secrets.example.com", "/missing")
+
+
 def test_config_validation_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OGG_BASE_URL", raising=False)
     with pytest.raises(ValueError, match="OGG_BASE_URL"):
@@ -279,12 +408,40 @@ def test_config_validation_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(ValueError, match="Basic auth requires"):
         config.read_config()
 
+    monkeypatch.setenv("OGG_USERNAME", "user")
+    monkeypatch.setenv("OGG_PASSWORD_SECRET_OCID", "ocid1.secret.oc1..x")
+    with pytest.raises(ValueError, match="OCI_REGION"):
+        config.read_config()
+
+    monkeypatch.setenv("OCI_REGION", "us-phoenix-1")
+    with pytest.raises(ValueError, match="OCI signer credentials"):
+        config.read_config()
+
 
 def test_http_client_helpers_and_request_paths(monkeypatch: pytest.MonkeyPatch) -> None:
     assert http_client._classify_request_error(requests.exceptions.ConnectTimeout()) == "Connection timed out"
     assert http_client._classify_request_error(requests.exceptions.ReadTimeout()) == "Request timed out while waiting for response"
     assert http_client._classify_request_error(requests.exceptions.ConnectionError("connection refused")) == "Connection refused"
+    assert http_client._classify_request_error(requests.exceptions.ConnectionError("other")) == "Network connection error"
     assert http_client._classify_request_error(requests.exceptions.InvalidURL()) == "Invalid deployment URL"
+    assert http_client._classify_request_error(requests.exceptions.RequestException()) == "HTTP request failed"
+
+    with pytest.raises(ValueError, match="OCI signer is not fully configured"):
+        http_client.sign_oci_request({}, "GET", "/x", "example.com")
+
+    monkeypatch.setattr(http_client, "load_pem_private_key", lambda *args, **kwargs: object())
+    with pytest.raises(ValueError, match="RSA private key"):
+        http_client.sign_oci_request(
+            {
+                "tenancyOCID": "tenancy",
+                "userOCID": "user",
+                "keyFingerprint": "fp",
+                "privateKeyPEM": "pem",
+            },
+            "GET",
+            "/x",
+            "example.com",
+        )
 
     class _FakeKey:
         def sign(self, *_args, **_kwargs):
@@ -309,6 +466,20 @@ def test_http_client_helpers_and_request_paths(monkeypatch: pytest.MonkeyPatch) 
     assert headers["host"] == "example.com"
     assert "authorization" in headers
     assert headers["content-type"] == "application/json"
+
+    headers_without_body = http_client.sign_oci_request(
+        {
+            "tenancyOCID": "tenancy",
+            "userOCID": "user",
+            "keyFingerprint": "fp",
+            "privateKeyPEM": "pem",
+            "passphrase": "",
+        },
+        "GET",
+        "/x",
+        "example.com",
+    )
+    assert "content-length" not in headers_without_body
 
     class _Resp:
         def __init__(self, status_code: int, text: str, json_payload=None):
@@ -349,3 +520,28 @@ def test_http_client_helpers_and_request_paths(monkeypatch: pytest.MonkeyPatch) 
     fake.next = requests.exceptions.ConnectionError("name or service not known")
     with pytest.raises(RuntimeError, match="DNS resolution failed"):
         client.get("/conn")
+
+    captured = []
+
+    class _CapturingSession:
+        def request(self, **kwargs):
+            captured.append(kwargs)
+            return _Resp(200, "ok", {"ok": True})
+
+    client = http_client.HttpClient({"baseUrl": "https://example.com/", "authMode": "none"})
+    client.session = _CapturingSession()
+
+    assert client.get("https://override.example.com/ok", headers={"X-Test": "1"}) == {"ok": True}
+    assert captured[-1]["url"] == "https://override.example.com/ok"
+    assert captured[-1]["headers"]["X-Test"] == "1"
+    assert captured[-1]["auth"] is None
+
+    assert client.post("/post", {"x": 1}) == {"ok": True}
+    assert captured[-1]["method"] == "POST"
+    assert captured[-1]["data"] == '{"x": 1}'
+
+    assert client.patch("/patch", {"y": 2}) == {"ok": True}
+    assert captured[-1]["method"] == "PATCH"
+
+    assert client.delete("/delete") == {"ok": True}
+    assert captured[-1]["method"] == "DELETE"

--- a/src/oracle-goldengate-mcp-server/pyproject.toml
+++ b/src/oracle-goldengate-mcp-server/pyproject.toml
@@ -70,4 +70,4 @@ omit = [
 
 [tool.coverage.report]
 precision = 2
-fail_under = 80
+fail_under = 90


### PR DESCRIPTION
# Description

No functional change, only updates test coverage.

* Adds tests to the two MCP servers that had specified thresholds under 90%
* Bumps the `pyproject.toml` for each to fail under 90%, from the current 53.84 and 80 thresholds
* Updates the `BEST_PRACTICES.md` to recommend 90% unit test coverage for new MCP servers

Several MCP servers do not have any `fail_under` specified, this only updates the two that had a `fail_under` below 90.

Fixes # (issue)

## Type of change

Adds new tests, no other change.

# How Has This Been Tested?

Added new tests to increase coverage; tests pass. Tests were created by codex to improve coverage, and verified locally that tests pass and pytest now reports over 90% coverage

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
