### PR TITLE
fix: rename ambiguous listener step in load balancer e2e tests

### DIFF
--- a/tests/e2e/features/oci-load-balancer-mcp-server.feature
+++ b/tests/e2e/features/oci-load-balancer-mcp-server.feature
@@ -30,7 +30,7 @@
 #
 #   Scenario: List listeners for a load balancer
 #     When I send a request with the prompt "list listeners for load balancer mock-lb"
-#     Then the response should contain a list of listeners
+#     Then the response should contain a list of load balancer listeners
 #
 #   Scenario: List backend sets and backends for a load balancer
 #     When I send a request with the prompt "show backend sets and backends for load balancer mock-lb"

--- a/tests/e2e/features/steps/oci-load-balancer-mcp-server-steps.py
+++ b/tests/e2e/features/steps/oci-load-balancer-mcp-server-steps.py
@@ -135,7 +135,7 @@ def step_impl_delete_lb(context):
     ), "Load balancer deletion not confirmed in response."
 
 
-@then("the response should contain a list of listeners")
+@then("the response should contain a list of load balancer listeners")
 def step_impl_list_listeners(context):
     result = context.response.json()
     assert "content" in result["message"], "Response does not contain a content key."


### PR DESCRIPTION
## Summary

Fixes #169

The step definition `the response should contain a list of listeners` in the load balancer step file was too generic. When Behave loads all step files globally before running any scenario, a step with the same or similarly matched text in another server test file would cause an `AmbiguousStep` error and block the entire test suite from starting.

Renamed the step to `the response should contain a list of load balancer listeners` to make it specific to the load balancer service. The matching line in the feature file was updated as well to keep things consistent.

The network load balancer step file already uses `the response should contain a list of network load balancer listeners` so both are now clearly scoped to their respective services.

## Changes

Updated `tests/e2e/features/steps/oci-load-balancer-mcp-server-steps.py` to use the service specific step name.

Updated the commented scenario line in `tests/e2e/features/oci-load-balancer-mcp-server.feature` to match.

## Test plan

- Confirm Behave step registry loads without raising `AmbiguousStep`
- Confirm no other feature files or step files reference the old generic step text