### PR TITLE
Support GoldenGate Replicat checkpoint table payload

### DIFF
--- a/src/oracle-goldengate-mcp-server/.gitignore
+++ b/src/oracle-goldengate-mcp-server/.gitignore
@@ -9,11 +9,11 @@ __pycache__/
 
 logs/
 oracle-goldengate-mcp-server.env
+oracle-goldengate-mcp-server-bigdata.env
+oracle-goldengate-mcp-server-oracle.env
 
 # Local launcher scripts
-run_goldengate_mcp_server_linux.sh
-run_goldengate_mcp_server_macos.sh
-run_goldengate_mcp_server_windows.bat
+run_goldengate_mcp_server_*
 
 # Keep dependency lockfile for reproducible installs
 !uv.lock

--- a/src/oracle-goldengate-mcp-server/README.md
+++ b/src/oracle-goldengate-mcp-server/README.md
@@ -36,12 +36,7 @@ See [Environment configuration](#environment-configuration) below for all suppor
 
 ### 1) Obtain the code
 
-1. Download ZIP
-2. Extract ZIP and open `oracle-goldengate-mcp-server`.
-
-If you are using Git (recommended to get updates and pull additional required files), you can clone/pull instead of relying only on ZIP downloads.
-
-Clone:
+Git Clone:
 
 ```sh
 git clone https://github.com/oracle/mcp.git

--- a/src/oracle-goldengate-mcp-server/docs/createReplicat.md
+++ b/src/oracle-goldengate-mcp-server/docs/createReplicat.md
@@ -22,6 +22,11 @@ Input shape (abridged)
       }
     - options?: CreateReplicatOptions (see src/mapStatement.ts for full set)
 - Optional:
+  - checkpointTable?: string
+    - Checkpoint table name for the REST `checkpoint.table` payload, for example
+      `SRCMIRROR_OCIGGLL.CHECKTABLE` or `"SRCMIRROR_OCIGGLL"."CHECKTABLE"`.
+    - Prefer this top-level field. `advanced.checkpointTable` is still accepted
+      for backward compatibility.
   - advanced?: {
       dbOptions?: string | string[] | {
         entries?: string[]
@@ -31,6 +36,7 @@ Input shape (abridged)
       additionalParameters?: string[]
       modeType?: "nonintegrated" | "integrated" | "parallel" | "coordinated"
       modeParallel?: boolean
+       checkpointTable?: string
     }
 
 Advanced parameter emission order
@@ -85,6 +91,28 @@ BATCHSQL BATCHERRORMODE
 BATCHSQL BATCHESPERQUEUE 100
 BATCHSQL OPSPERBATCH 2000
 MAP SCHEMA.* , TARGET SCHEMA.*;
+
+2b) Replicat with checkpoint table
+Request:
+{
+  "replicatName": "RFLIGHT",
+  "trailName": "LT",
+  "domainName": "OracleGoldenGate",
+  "connectionName": "TARGET_CONN",
+  "mapStatement": "MAP SRC.FLIGHT, TARGET SRCMIRROR.FLIGHT;",
+  "checkpointTable": "\"SRCMIRROR_OCIGGLL\".\"CHECKTABLE\""
+}
+Sends the checkpoint table in the REST payload:
+{
+  "checkpoint": {
+    "table": "\"SRCMIRROR_OCIGGLL\".\"CHECKTABLE\""
+  }
+}
+
+Do not put the checkpoint table in `options`; `options` is only for MAP
+statement options. Passing `options: "CHECKPOINTTABLE ..."` or
+`options.checkpointTable` will fail schema validation. `advanced` must be an
+object if used, for example `{ "checkpointTable": "SRCMIRROR_OCIGGLL.CHECKTABLE" }`.
 
 3) Alternative credentials and advanced parallelism
 Request:
@@ -155,5 +183,6 @@ Notes
 - The `source` object must include `targetTable` when using structured MAP; otherwise provide a raw `mapStatement`.
 - `advanced.applyParallelism` cannot be combined with `advanced.minApplyParallelism` or `advanced.maxApplyParallelism`. Supplying both will result in an error prior to issuing the request.
 - `advanced.modeType` / `advanced.modeParallel` allow controlling the Replicat `mode` object for REST calls. When omitted, the server defaults to classic (`nonintegrated`) mode with `parallel: false`.
+- Use top-level `checkpointTable` when GoldenGate returns `OGG-08100: No checkpoint table specified for ADD REPLICAT command`. The server serializes it as REST `checkpoint.table` and does not emit `CHECKPOINTTABLE` into the parameter file.
 - Replicat parameter files do not support `EXTTRAIL`, so the server no longer emits this line when creating or updating replicats. For parallel replicat (`modeType: 'parallel'`) the server also suppresses `MAP_PARALLELISM` since it is unsupported.
 - See createExtract documentation for additional structured option handling patterns.

--- a/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/server.py
+++ b/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/server.py
@@ -107,6 +107,31 @@ def _resolve_begin_value(begin: Any, default: Any = "now") -> Any:
     return begin
 
 
+def _resolve_replicat_checkpoint(
+    checkpoint_table: Any,
+    advanced_checkpoint_table: Any,
+) -> str | None:
+    """Resolve a Replicat checkpoint table from top-level or advanced input.
+
+    The GoldenGate REST endpoint requires the checkpoint table in the Replicat
+    creation payload, not in MAP options.  Exposing it as a top-level tool
+    argument makes the MCP schema easier for LLM clients to discover, while the
+    advanced.checkpointTable location is kept for backward compatibility.
+    """
+    checkpoint_table = _none_if_fieldinfo(checkpoint_table)
+    advanced_checkpoint_table = _none_if_fieldinfo(advanced_checkpoint_table)
+
+    top_level = str(checkpoint_table).strip() if checkpoint_table and str(checkpoint_table).strip() else None
+    advanced = (
+        str(advanced_checkpoint_table).strip()
+        if advanced_checkpoint_table and str(advanced_checkpoint_table).strip()
+        else None
+    )
+    if top_level and advanced and top_level != advanced:
+        raise ValueError("Conflicting checkpoint table values supplied in 'checkpointTable' and 'advanced.checkpointTable'.")
+    return top_level or advanced
+
+
 @mcp.tool(description="Return the list of GoldenGate domains available in OCI GoldenGate deployment. Domains group connections in GoldenGate.")
 def list_domains() -> str:
     """Return the list of GoldenGate domains available in OCI GoldenGate deployment. Domains group connections in GoldenGate."""
@@ -343,7 +368,7 @@ def update_extract(
     return _ok(client.patch(api.update_extract(extractName), payload))
 
 
-@mcp.tool(description="Creates a new Replicat in OCI GoldenGate deployment to replicate data into a target. Supports raw mapStatement or structured source/options. Optionally accepts a checkpointTable, otherwise use list_checkpoint_tables to find a checkpoint table.")
+@mcp.tool(description="Creates a new Replicat in OCI GoldenGate deployment to replicate data into a target. Supports raw mapStatement or structured source/options. Requires checkpointTable for deployments that use database checkpoints; use list_checkpoint_tables to find a valid table.")
 def create_replicat(
     replicatName: str = Field(..., description="Replicat process name", min_length=1, max_length=8),
     trailName: str = Field(..., description="Two-character trail name", min_length=2, max_length=2),
@@ -356,13 +381,18 @@ def create_replicat(
         None,
         description="Optional start position for Replicat. Defaults to 'now'. Accepts an ISO-8601 timestamp string or structured trail position like {sequence: 145, offset: 5}.",
     ),
+    checkpointTable: str | None = Field(
+        None,
+        description='Checkpoint table name for ADD REPLICAT, for example SRCMIRROR_OCIGGLL.CHECKTABLE or "SRCMIRROR_OCIGGLL"."CHECKTABLE". Prefer this top-level field over options or advanced parameters.',
+    ),
     advanced: ReplicatAdvancedParameters | None = Field(None, description="Advanced GoldenGate Replicat parameters"),
 ) -> str:
-    """Creates a new Replicat in OCI GoldenGate deployment to replicate data into a target. Supports raw mapStatement or structured source/options. Optionally accepts a checkpointTable, otherwise use list_checkpoint_tables to find a checkpoint table."""
+    """Creates a new Replicat in OCI GoldenGate deployment to replicate data into a target. Supports raw mapStatement or structured source/options. Requires checkpointTable for deployments that use database checkpoints; use list_checkpoint_tables to find a valid table."""
     mapStatement = _none_if_fieldinfo(mapStatement)
     source = _none_if_fieldinfo(source)
     options = _none_if_fieldinfo(options)
     begin = _none_if_fieldinfo(begin)
+    checkpointTable = _none_if_fieldinfo(checkpointTable)
     advanced = _none_if_fieldinfo(advanced)
 
     if mapStatement and mapStatement.strip():
@@ -376,6 +406,7 @@ def create_replicat(
 
     advanced_payload = _serialize_model(advanced) or {}
     adv = build_advanced_replicat_parameters(advanced_payload)
+    checkpoint = _resolve_replicat_checkpoint(checkpointTable, adv.get("checkpointTable"))
     config_lines = [f"REPLICAT {replicatName}"]
     if adv.get("credentialLines"):
         config_lines.extend(adv["credentialLines"])
@@ -383,7 +414,6 @@ def create_replicat(
         config_lines.append(f"USERIDALIAS {connectionName} DOMAIN {domainName}")
 
     lines = adv.get("lines") or []
-    checkpoint = adv.get("checkpointTable")
     if checkpoint:
         lines = [ln for ln in lines if not ln.startswith("CHECKPOINTTABLE")]
     config_lines.extend(lines)
@@ -415,6 +445,10 @@ def update_replicat(
     mapStatement: str | None = Field(None, description="Raw MAP statement(s) for Replicat"),
     source: CreateReplicatSource | None = Field(None, description="Structured source mapping used to build MAP statements"),
     options: CreateReplicatOptions | None = Field(None, description="Optional structured MAP statement options"),
+    checkpointTable: str | None = Field(
+        None,
+        description='Checkpoint table name for the Replicat checkpoint payload, for example SRCMIRROR_OCIGGLL.CHECKTABLE or "SRCMIRROR_OCIGGLL"."CHECKTABLE".',
+    ),
     advanced: ReplicatAdvancedParameters | None = Field(None, description="Advanced GoldenGate Replicat parameters"),
 ) -> str:
     """Updates an existing Replicat in OCI GoldenGate deployment. Accepts the same structured payload as create_replicat but performs a PATCH instead."""
@@ -424,6 +458,7 @@ def update_replicat(
     mapStatement = _none_if_fieldinfo(mapStatement)
     source = _none_if_fieldinfo(source)
     options = _none_if_fieldinfo(options)
+    checkpointTable = _none_if_fieldinfo(checkpointTable)
     advanced = _none_if_fieldinfo(advanced)
 
     if mapStatement and mapStatement.strip():
@@ -440,12 +475,16 @@ def update_replicat(
 
     advanced_payload = _serialize_model(advanced) or {}
     adv = build_advanced_replicat_parameters(advanced_payload)
+    checkpoint = _resolve_replicat_checkpoint(checkpointTable, adv.get("checkpointTable"))
     config_lines = [f"REPLICAT {replicatName}"]
     if adv.get("credentialLines"):
         config_lines.extend(adv["credentialLines"])
     elif domainName and connectionName:
         config_lines.append(f"USERIDALIAS {connectionName} DOMAIN {domainName}")
-    config_lines.extend(adv.get("lines") or [])
+    lines = adv.get("lines") or []
+    if checkpoint:
+        lines = [ln for ln in lines if not ln.startswith("CHECKPOINTTABLE")]
+    config_lines.extend(lines)
     config_lines.append(final_map_statement)
 
     payload: dict[str, Any] = {
@@ -467,6 +506,8 @@ def update_replicat(
     payload["mode"] = resolved_mode
     if resolved_mode.get("type") != "parallel" and trailName:
         payload["source"] = {"name": trailName}
+    if checkpoint:
+        payload["checkpoint"] = {"table": checkpoint}
     if not adv.get("credentialLines") and domainName and connectionName:
         payload["credentials"] = {"domain": domainName, "alias": connectionName}
     return _ok(client.patch(api.update_replicat(replicatName), payload))

--- a/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/tests/test_goldengate_tools.py
+++ b/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/tests/test_goldengate_tools.py
@@ -318,6 +318,47 @@ class TestGoldenGateTools(unittest.TestCase):
             )
             self.assertEqual(m.call_args.args[1]["begin"], {"sequence": 145, "offset": 5})
 
+    def test_create_replicat_accepts_top_level_checkpoint_table(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            server.create_replicat(
+                "R1",
+                "AA",
+                "D",
+                "C",
+                mapStatement="MAP S.T, TARGET S2.T2;",
+                checkpointTable='"SRCMIRROR_OCIGGLL"."CHECKTABLE"',
+                advanced=None,
+            )
+            payload = m.call_args.args[1]
+            self.assertEqual(payload["checkpoint"], {"table": '"SRCMIRROR_OCIGGLL"."CHECKTABLE"'})
+            self.assertNotIn('CHECKPOINTTABLE "SRCMIRROR_OCIGGLL"."CHECKTABLE"', payload["config"])
+
+    def test_create_replicat_accepts_advanced_checkpoint_table_for_backward_compatibility(self):
+        with patch.object(server.client, "post", return_value={"ok": True}) as m:
+            server.create_replicat(
+                "R1",
+                "AA",
+                "D",
+                "C",
+                mapStatement="MAP S.T, TARGET S2.T2;",
+                advanced=ReplicatAdvancedParameters(checkpointTable="SRCMIRROR_OCIGGLL.CHECKTABLE"),
+            )
+            payload = m.call_args.args[1]
+            self.assertEqual(payload["checkpoint"], {"table": "SRCMIRROR_OCIGGLL.CHECKTABLE"})
+            self.assertNotIn("CHECKPOINTTABLE SRCMIRROR_OCIGGLL.CHECKTABLE", payload["config"])
+
+    def test_create_replicat_rejects_conflicting_checkpoint_tables(self):
+        with self.assertRaises(ValueError):
+            server.create_replicat(
+                "R1",
+                "AA",
+                "D",
+                "C",
+                mapStatement="MAP S.T, TARGET S2.T2;",
+                checkpointTable="A.CHK",
+                advanced=ReplicatAdvancedParameters(checkpointTable="B.CHK"),
+            )
+
     def test_update_replicat(self):
         with patch.object(server.client, "patch", return_value={"ok": True}) as m:
             out = server.update_replicat("R1", trailName="AA", domainName="D", connectionName="C", mapStatement="MAP S.T, TARGET S2.T2;", advanced=None)
@@ -355,6 +396,20 @@ class TestGoldenGateTools(unittest.TestCase):
         self.assertEqual(payload["mode"], {"type": "parallel", "parallel": False})
         self.assertNotIn("source", payload)
         self.assertNotIn("credentials", payload)
+
+    def test_update_replicat_accepts_top_level_checkpoint_table(self):
+        with patch.object(server.client, "patch", return_value={"ok": True}) as m:
+            server.update_replicat(
+                "R1",
+                trailName="AA",
+                domainName="D",
+                connectionName="C",
+                mapStatement="MAP S.T, TARGET S2.T2;",
+                checkpointTable="SRCMIRROR_OCIGGLL.CHECKTABLE",
+                advanced=None,
+            )
+            payload = m.call_args.args[1]
+            self.assertEqual(payload["checkpoint"], {"table": "SRCMIRROR_OCIGGLL.CHECKTABLE"})
 
     def test_create_distribution_path(self):
         with patch.object(server.client, "post", return_value={"ok": True}) as m:


### PR DESCRIPTION
# Description

Adds explicit Oracle GoldenGate Replicat checkpoint table support.

This PR allows `checkpointTable` to be supplied as a top-level `create_replicat` / `update_replicat` tool argument and serializes it into the GoldenGate REST payload as `checkpoint.table`.

It also keeps `advanced.checkpointTable` for backward compatibility and rejects conflicting values when both the top-level and advanced checkpoint table fields are supplied.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

- Add top-level `checkpointTable` support for Replicat create/update tools.
- Send checkpoint tables through the REST `checkpoint.table` payload.
- Avoid emitting `CHECKPOINTTABLE ...` into Replicat config lines when using the REST checkpoint payload.
- Update Replicat documentation and tests.

# How Has This Been Tested?

- `uv run python -m pytest oracle/oracle_goldengate_mcp_server/tests/test_goldengate_tools.py`
- 62 tests passed locally

Tested with OCI GoldenGate deployments (GoldenGate for Oracle 23.10)

**Test Configuration**:
* Firmware version: N/A
* Hardware: N/A
* Toolchain: Python 3.x, pytest
* SDK: N/A

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
