### PR TITLE
Add oracle-data-studio-mcp-server

### DIFF
--- a/src/oracle-data-studio-mcp-server/.gitignore
+++ b/src/oracle-data-studio-mcp-server/.gitignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+dist/
+build/
+.eggs/
+*.egg
+.venv/
+venv/
+.pytest_cache/
+.coverage
+htmlcov/
+.DS_Store
+uv.lock.bak

--- a/src/oracle-data-studio-mcp-server/CHANGELOG.md
+++ b/src/oracle-data-studio-mcp-server/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+## 1.0.0
+
+Initial contribution.
+
+### Features
+
+- **60 high-level composite tools** spanning three Oracle Data Studio
+  services:
+  - **Essbase**: 30 tools — apps, databases, outline, MDX, calc scripts,
+    files, security, jobs.
+  - **ADP** (Autonomous Database Data Platform): 15 tools — Analytic
+    Views, Select AI, Insights, cloud loading, catalogs, data sharing,
+    annotations.
+  - **Data Transforms**: 15 tools — pipelines, schedules, connections,
+    workflows, dataloads.
+- **Oracle 23ai annotation-aware query routing**.
+  - New `adp_get_annotations` tool — composite reader of
+    `ALL_ANNOTATIONS_USAGE` that groups results into table vs column
+    annotations and returns a tidy structure for the LLM to consume.
+  - New `adp_sql_with_annotations` prompt template — instructs the
+    assistant to fetch annotations first, then construct SQL using
+    them as semantic hints (units, aggregations, join keys, time
+    grain, PII).
+  - Server-level `instructions` advertise the annotation-first SQL
+    flow and the cube/AV/table routing convention on MCP handshake;
+    compliant clients (Claude Desktop, Cursor, Codex) forward them to
+    the LLM as system context.
+- **Three access profiles**: `viewer` (read-only), `analyst` (read +
+  execute), `admin` (full access). Verb-based filtering applied at
+  tool-registration time.
+
+### Annotation-driven cube / AV / table routing
+
+For aggregate questions, the LLM picks the correct query source by
+reading routing annotations on the fact table:
+
+| Annotation | Where | Meaning |
+|---|---|---|
+| `cube` | table | `'<app>.<database>'` Essbase cube reference |
+| `analytic_view` | table | `'<av_name>'` ADP Analytic View reference |
+| `preferred_source` | table | `'cube'` / `'analytic_view'` / `'table'` |
+| `cube_dimension` | column | column → cube dim mapping |
+| `cube_member` | column | column → MDX member |
+
+### Validated against
+
+Oracle Autonomous Database 23.26 with the MovieLens dataset and an
+Essbase cube of the same name. A/B tested over 5 realistic SQL
+generation scenarios (UNIT mismatch, GRAIN mismatch, AGGREGATE choice,
+JOIN_HINT, PII avoidance) — annotation-aware SQL won 5/5, naive
+generation won 0/5.

--- a/src/oracle-data-studio-mcp-server/Containerfile
+++ b/src/oracle-data-studio-mcp-server/Containerfile
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+FROM ghcr.io/oracle/oraclelinux:9-slim@sha256:1950389c3dd619841813520b4e69d7f3112c4c10f713fcb90680703d184c33ad
+
+# Install python 3.13
+RUN microdnf install epel-release && \
+    microdnf install python3.13 python3.13-pip \
+    && rm -rf /var/cache/dnf/* \
+    && useradd -m -d /app oracle
+
+# Copy the MCP server to the docker container
+WORKDIR /app
+COPY --chown=oracle:oracle . /app
+
+# Install dependencies
+RUN pip3.13 install --no-cache-dir uv && \
+    uv --no-cache sync --locked --all-extras
+
+# Change user
+USER oracle
+
+# HTTP support
+ENV ORACLE_MCP_HOST=""
+ENV ORACLE_MCP_PORT=""
+
+# Start the MCP server
+ENTRYPOINT ["uv", "run", "oracle.data-studio-mcp-server"]

--- a/src/oracle-data-studio-mcp-server/LICENSE.txt
+++ b/src/oracle-data-studio-mcp-server/LICENSE.txt
@@ -1,0 +1,31 @@
+Copyright (c) 2025, Oracle and/or its affiliates.
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any
+person obtaining a copy of this software, associated documentation and/or data
+(collectively the "Software"), free of charge and under any and all copyright
+rights in the Software, and any and all patent rights owned or freely
+licensable by each licensor hereunder covering either (i) the unmodified
+Software as contributed to or provided by such licensor, or (ii) the Larger
+Works (as defined below), to deal in both
+
+(a) the Software, and
+
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+one is included with the Software (each a "Larger Work" to which the Software
+is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create
+derivative works of, display, perform, and distribute the Software and make,
+use, sell, offer for sale, import, export, have made, and have sold the
+Software and the Larger Work(s), and to sublicense the foregoing rights on
+either or both of the above.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/oracle-data-studio-mcp-server/README.md
+++ b/src/oracle-data-studio-mcp-server/README.md
@@ -36,11 +36,25 @@ uvx oracle.data-studio-mcp-server
   "mcpServers": {
     "oracle-data-studio": {
       "command": "uvx",
-      "args": ["oracle.data-studio-mcp-server", "--profile", "admin"]
+      "args": ["oracle.data-studio-mcp-server"]
     }
   }
 }
 ```
+
+By default the server runs in the safe **viewer** profile — metadata
+browsing only, no execution or modification. To unlock query/execute
+operations, opt into a higher profile **explicitly**:
+
+```json
+"args": ["oracle.data-studio-mcp-server", "--profile", "analyst"]
+```
+
+```json
+"args": ["oracle.data-studio-mcp-server", "--profile", "admin"]
+```
+
+See the *Profiles* section below for what each tier exposes.
 
 ## Authentication
 
@@ -212,13 +226,35 @@ metrics), join key (which FK to use), and PII avoidance.
 ## Access profiles
 
 Every tool is filtered by access profile at registration time.
-Pick one with `--profile`:
+**Default is `viewer`** — the safe metadata-only surface. Higher
+profiles require explicit opt-in via `--profile`:
 
 | Profile | Capability | Tool count |
 | --- | --- | --- |
-| `viewer` | Read-only — explore, describe, browse, search | ~17 |
+| **`viewer` (default)** | Read-only — explore, describe, browse, search, annotations | ~15 |
 | `analyst` | Read + query / execute — no create / delete / manage | ~23 |
-| `admin` (default) | All tools | 60 |
+| `admin` | All tools (explicit opt-in only) | 60 |
+
+This follows the
+[BEST_PRACTICES.md](https://github.com/oracle/mcp/blob/main/BEST_PRACTICES.md)
+guidance on scope minimisation and safe defaults: an MCP client
+that connects with no extra configuration gets the smallest, least
+destructive tool surface. Operators consciously upgrade.
+
+### Credential safety
+
+- **Passwords** are stored in the OS keyring (macOS Keychain,
+  Windows Credential Manager, Linux Secret Service).
+- **Bearer tokens** (e.g. Essbase token-based auth) are likewise
+  stored in the OS keyring under a `__token__` pseudo-user. **They
+  are never written to the plaintext INI config file**, even if you
+  pass them as `--token …` to `oracle-data-studio-config set`.
+- **URL / username / transport / port / host** are non-secret and
+  go to `~/.oracle-data-studio/config` (chmod 600).
+- A reserved set of key names (`password`, `token`, `bearer`,
+  `secret`, `api_key`, …) is always routed to keyring regardless of
+  how it's spelt in the call — defence-in-depth against
+  accidentally configuring a secret as a "regular" extra field.
 
 ## About the `oracle-data-studio` dependency
 

--- a/src/oracle-data-studio-mcp-server/README.md
+++ b/src/oracle-data-studio-mcp-server/README.md
@@ -1,0 +1,252 @@
+# Oracle Data Studio MCP Server
+
+## Overview
+
+This server provides task-oriented MCP tools for three Oracle Data
+Studio services:
+
+- **Oracle Essbase** — applications, databases, outline, MDX, calc
+  scripts, files, security, jobs.
+- **ADP** (Autonomous Database Data Platform) — Analytic Views,
+  Select AI, Insights, cloud loading, catalogs, data sharing, **Oracle
+  23ai annotations**.
+- **Data Transforms** — pipelines, schedules, connections, workflows,
+  dataloads.
+
+Built on [FastMCP](https://github.com/jlowin/fastmcp) and the
+[oracle-data-studio](https://pypi.org/project/oracle-data-studio/)
+Python SDK. Each tool combines multiple SDK calls into a single
+coherent operation that returns LLM-ready output, rather than exposing
+raw REST endpoints.
+
+**60 high-level tools + 1 reusable prompt template.**
+
+## Running the server
+
+### STDIO transport mode
+
+```sh
+uvx oracle.data-studio-mcp-server
+```
+
+### MCP client configuration (Claude Desktop, Cursor, Codex, …)
+
+```json
+{
+  "mcpServers": {
+    "oracle-data-studio": {
+      "command": "uvx",
+      "args": ["oracle.data-studio-mcp-server", "--profile", "admin"]
+    }
+  }
+}
+```
+
+## Authentication
+
+Connection details and credentials are read from (in order of priority):
+
+1. CLI args / environment variables
+2. OS keyring (recommended for desktop use)
+3. INI file at `~/.oracle-data-studio/config`
+
+Configure once with the bundled CLI:
+
+```sh
+uvx oracle.data-studio-config set adp \
+    --url 'https://<adb-host>.adb.<region>.oraclecloudapps.com' \
+    --user ADMIN
+# prompts for password, stores in OS keyring
+
+uvx oracle.data-studio-config set essbase --url 'https://<essbase>' --user admin
+uvx oracle.data-studio-config set datatransforms --url 'https://<adb-host>...' --user ADMIN
+```
+
+Or pass credentials inline via env:
+
+```sh
+ADP_URL='...'      ADP_USER='ADMIN'  ADP_PASSWORD='...'  \
+ESSBASE_URL='...'  ESSBASE_USER='admin'  ESSBASE_PASSWORD='...'  \
+uvx oracle.data-studio-mcp-server
+```
+
+Only the services you configure are activated; the others are simply
+not registered.
+
+## Annotation-driven query routing
+
+For aggregate questions ("total sales by region last quarter"), the
+LLM picks the correct query source by reading routing annotations
+defined on the fact table — **declaratively**, with no name-matching
+or guessing.
+
+### The routing convention
+
+| Annotation | Where | Meaning |
+|---|---|---|
+| `cube` | table | `'<app>.<database>'` Essbase cube reference |
+| `analytic_view` | table | `'<av_name>'` ADP Analytic View reference |
+| `preferred_source` | table | `'cube'` / `'analytic_view'` / `'table'` |
+| `cube_dimension` | column | column → cube dim mapping |
+| `cube_member` | column | column → MDX member, e.g. `'[Measures].[Sales]'` |
+
+### Example DDL
+
+```sql
+CREATE TABLE MOVIELENS.RATINGS (
+    USER_ID  NUMBER  ANNOTATIONS (join_hint 'MOVIELENS.USERS.USER_ID'),
+    MOVIE_ID NUMBER  ANNOTATIONS (join_hint 'MOVIELENS.MOVIES.MOVIE_ID'),
+    RATING   NUMBER  ANNOTATIONS (unit 'STARS_1_TO_5',
+                                  aggregate 'AVG',
+                                  cube_member '[Measures].[Rating]'),
+    RATED_AT DATE    ANNOTATIONS (role 'TIME', grain 'DAY')
+)
+ANNOTATIONS (
+    cube              'MOVIELENS.MOVIELENS',
+    preferred_source  'cube',
+    description       'MovieLens 1M ratings (also exposed as Essbase cube)'
+);
+```
+
+After this DDL, any compliant MCP client connecting to the server
+automatically routes a natural-language question against `RATINGS` to
+the Essbase cube — without per-client tuning. The mechanism is the
+server's `instructions`, which every MCP client passes to its LLM at
+handshake time.
+
+### Why it matters
+
+A/B tested on Oracle 23.26 with MovieLens, the annotation-aware flow
+beat naive SQL generation **5/5** across realistic failure modes:
+unit mismatch (cents vs dollars), grain mismatch (hourly vs daily
+aggregation), aggregate-function choice (`SUM` vs `AVG` for snapshot
+metrics), join key (which FK to use), and PII avoidance.
+
+## Tools
+
+### Essbase (30)
+
+| Tool | What it does |
+| --- | --- |
+| `essbase_explore` | Full server overview — apps, databases, status, sizes, settings |
+| `essbase_describe_database` | Complete database profile — dimensions, storage, settings, variables |
+| `essbase_query` | Execute MDX with formatted tabular output |
+| `essbase_browse_outline` | Hierarchical outline tree with member properties |
+| `essbase_search_members` | Member search with full paths and ancestors |
+| `essbase_run_calculation` | Execute calc + wait + return final status / log on failure |
+| `essbase_load_data` | End-to-end data load (upload + run + monitor) |
+| `essbase_deploy_workbook` | Excel workbook → cube (one-shot import) |
+| `essbase_manage_variables` | Variables CRUD across server / app / db scopes |
+| `essbase_get_script` | Script content + validation status |
+| `essbase_manage_security` | Full security profile: roles, app roles, filters, groups |
+| `essbase_server_health` | Version, sessions, locked objects |
+| `essbase_export_data` | MDX or level-0 export with job + download |
+| `essbase_manage_application` | Application lifecycle: create / copy / rename / delete / start / stop |
+| `essbase_manage_script` | Script CRUD + validation |
+| `essbase_manage_files` | File catalog: list, upload, download, move, copy, extract, create_folder |
+| `essbase_manage_connections` | Saved connections lifecycle and tests |
+| `essbase_manage_locks` | Locked objects / blocks |
+| `essbase_manage_filters` | Security filters CRUD with permissions |
+| `essbase_manage_jobs` | Jobs: list, status, statistics, rerun, purge |
+| `essbase_edit_outline` | Batch outline edits — add / remove / move / rename / formulas / aliases / UDAs |
+| `essbase_manage_datasources` | Datasources lifecycle |
+| `essbase_manage_drill_through` | Drill-through reports lifecycle and execution |
+| `essbase_manage_database` | Database lifecycle: create / copy / rename / delete / start / stop |
+| `essbase_manage_users` | Users CRUD + role provisioning |
+| `essbase_manage_groups` | Groups CRUD + membership |
+| `essbase_manage_sessions` | Session inspection and termination |
+| `essbase_manage_db_settings` | Database settings reader/writer |
+| `essbase_get_logs` | Log retrieval |
+| `essbase_outline_metadata` | Outline metadata: generations, levels, smart lists, settings, member |
+
+### ADP (Autonomous Database Data Platform) — 15
+
+| Tool | What it does |
+| --- | --- |
+| `adp_build_analytic_view` | Auto-create AV from fact table → compile → return metadata + preview |
+| `adp_query_analytic_view` | Query AV with auto-discovered dimensions and measures |
+| `adp_analyze_analytic_view` | AV health report: metadata, measures, dimensions, quality, errors |
+| `adp_manage_analytic_views` | List or drop AVs |
+| `adp_ai_chat` | Conversational Select AI: chat / chat_with_db / generate_insight |
+| `adp_generate_insights` | Async insight generation with full graph data |
+| `adp_manage_insights` | Insight lifecycle: requests, results, status, drop |
+| `adp_search` | Global object search; optionally include DDL for top hits |
+| **`adp_get_annotations`** | **Fetch Oracle 23ai column/table annotations — drives the annotation-first SQL flow** |
+| `adp_load_from_cloud` | End-to-end cloud → table load with progress polling |
+| `adp_manage_db_links` | DB links + copy/link tables from remote databases |
+| `adp_manage_credentials` | Cloud credentials + storage links |
+| `adp_browse_catalog` | Read-only catalog browse (list, entities, preview, db_links) |
+| `adp_manage_catalog` | Admin catalog ops: enable / disable / unmount / mount variants |
+| `adp_manage_sharing` | Data sharing: shares, recipients, providers, publish/unpublish |
+
+> **Boundary**: arbitrary SQL execution (DDL / DML / `SELECT *`) is
+> intentionally OUT of scope. For raw SQL, pair this server with the
+> Oracle SQLcl MCP server.
+
+### Data Transforms (15)
+
+| Tool | What it does |
+| --- | --- |
+| `dt_explore` | Environment overview — version, connections, projects, schedules |
+| `dt_describe_project` | Complete project inventory: dataflows, workflows, dataloads |
+| `dt_manage_project` | Admin project ops: delete |
+| `dt_describe_connection` | Connection details + test + available schemas |
+| `dt_create_pipeline` | Create dataflow / workflow (auto-creates project if needed) |
+| `dt_check_health` | Connection health + schedule overview |
+| `dt_browse_data` | Available schemas and tables with column metadata |
+| `dt_manage_dataflow` | Dataflow CRUD + validate (idempotent) |
+| `dt_manage_workflow` | Workflow CRUD |
+| `dt_manage_schedule` | Schedule CRUD |
+| `dt_manage_variables` | Variables CRUD |
+| `dt_run_pipeline` | Execute dataflow / workflow / dataload via runtime client |
+| `dt_manage_connection` | Connection CRUD + test |
+| `dt_manage_dataload` | Dataload CRUD |
+| `dt_manage_data_entities` | Data entity discovery and import |
+
+### Prompts
+
+| Prompt | What it does |
+| --- | --- |
+| `adp_sql_with_annotations` | Annotation-aware SQL generation template — instructs the assistant to fetch `adp_get_annotations` first, then build SQL using `unit`, `aggregate`, `join_hint`, `grain`, `data_class` as semantic hints |
+
+## Access profiles
+
+Every tool is filtered by access profile at registration time.
+Pick one with `--profile`:
+
+| Profile | Capability | Tool count |
+| --- | --- | --- |
+| `viewer` | Read-only — explore, describe, browse, search | ~17 |
+| `analyst` | Read + query / execute — no create / delete / manage | ~23 |
+| `admin` (default) | All tools | 60 |
+
+## Local development
+
+```sh
+git clone https://github.com/oracle/mcp.git
+cd mcp/src/oracle-data-studio-mcp-server
+uv sync --all-extras
+uv run pytest oracle/data_studio_mcp_server/tests/test_unit.py
+```
+
+86 tests, runs in ~1 second.
+
+## Third-Party APIs
+
+Developers choosing to distribute a binary implementation of this
+project are responsible for obtaining and providing all required
+licenses and copyright notices for the third-party code used in order
+to ensure compliance with their respective open source licenses.
+
+## Disclaimer
+
+Users are responsible for their local environment and credential
+safety. Different language model selections may yield different
+results and performance.
+
+## License
+
+Copyright (c) 2025 Oracle and/or its affiliates.
+
+Released under the Universal Permissive License v1.0 as shown at
+<https://oss.oracle.com/licenses/upl/>.

--- a/src/oracle-data-studio-mcp-server/README.md
+++ b/src/oracle-data-studio-mcp-server/README.md
@@ -220,6 +220,20 @@ Pick one with `--profile`:
 | `analyst` | Read + query / execute — no create / delete / manage | ~23 |
 | `admin` (default) | All tools | 60 |
 
+## About the `oracle-data-studio` dependency
+
+This server depends on the
+[`oracle-data-studio`](https://pypi.org/project/oracle-data-studio/)
+PyPI package — the official Python SDK for Oracle Data Studio,
+maintained by the same Oracle team contributing this server. It
+provides the underlying REST clients for Essbase, ADP (Autonomous
+Database Data Platform), and Data Transforms; this MCP server is
+a thin task-oriented layer on top of those clients.
+
+Pinned to `>=1.0.26` in `pyproject.toml` — version 1.0.26 added the
+Oracle 23ai annotation guidance and reconnect-safety improvements
+that this server relies on.
+
 ## Local development
 
 ```sh

--- a/src/oracle-data-studio-mcp-server/oracle/__init__.py
+++ b/src/oracle-data-studio-mcp-server/oracle/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/__init__.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''
+Oracle Data Studio MCP Server.
+
+Exposes Essbase, ADP, and Data Transforms Python APIs as MCP tools
+for AI assistants.
+
+Usage:
+    oracle.data-studio-mcp-server                          # stdio transport
+    oracle.data-studio-mcp-server --transport streamable-http  # HTTP transport
+'''
+
+__project__ = 'oracle.data-studio-mcp-server'
+__version__ = '1.0.0'

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/__main__.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/__main__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''Entry point for ``python -m oracle.data_studio_mcp_server``.'''
+
+from .server import main
+
+main()

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/cli_config.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/cli_config.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''
+CLI tool for managing Oracle Data Studio MCP Server credentials.
+
+Usage:
+    oracle-data-studio-config set essbase --url https://... --user admin
+    oracle-data-studio-config set adp --url https://... --user admin --password secret
+    oracle-data-studio-config set server --transport stdio --port 8000
+    oracle-data-studio-config list
+    oracle-data-studio-config remove essbase
+'''
+
+from __future__ import annotations
+
+import sys
+import argparse
+import getpass
+import json
+
+from .credential_store import (
+    store_credentials,
+    remove_credentials,
+    list_credentials,
+    VALID_SERVICES,
+)
+
+
+def _cmd_set(args):
+    '''Handle the "set" sub-command.'''
+    service = args.service
+
+    kwargs = {}
+    if hasattr(args, 'url') and args.url:
+        kwargs['url'] = args.url
+    if hasattr(args, 'user') and args.user:
+        kwargs['user'] = args.user
+
+    # Server-specific options
+    if hasattr(args, 'transport') and args.transport:
+        kwargs['transport'] = args.transport
+    if hasattr(args, 'port') and args.port:
+        kwargs['port'] = args.port
+
+    # Essbase-specific
+    if hasattr(args, 'token') and args.token:
+        kwargs['token'] = args.token
+
+    # Password handling
+    password = getattr(args, 'password', None)
+    if service != 'server' and not password and args.user:
+        # Prompt interactively if user is set but password is not
+        password = getpass.getpass(f'Password for {args.user}: ')
+
+    result = store_credentials(service, password=password, **kwargs)
+    print(json.dumps(result, indent=2))
+
+    if password and not result.get('keyring_stored'):
+        print('\nWarning: Password could not be stored in OS keyring.',
+              file=sys.stderr)
+        print('Install the "keyring" package: pip install keyring',
+              file=sys.stderr)
+
+
+def _cmd_list(args):
+    '''Handle the "list" sub-command.'''
+    creds = list_credentials()
+    if not creds:
+        print('No credentials configured.')
+        print(f'Use: oracle-data-studio-config set <service> --url ... --user ...')
+        return
+    for service, values in creds.items():
+        print(f'\n[{service}]')
+        for key, val in values.items():
+            print(f'  {key} = {val}')
+
+
+def _cmd_remove(args):
+    '''Handle the "remove" sub-command.'''
+    result = remove_credentials(args.service)
+    print(json.dumps(result, indent=2))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog='oracle-data-studio-config',
+        description='Manage Oracle Data Studio MCP Server credentials')
+
+    sub = parser.add_subparsers(dest='command', required=True)
+
+    # -- set --
+    set_parser = sub.add_parser('set', help='Store credentials for a service')
+    set_parser.add_argument('service', choices=VALID_SERVICES,
+                            help='Service to configure')
+    set_parser.add_argument('--url', help='Server URL')
+    set_parser.add_argument('--user', help='Username')
+    set_parser.add_argument('--password', default=None,
+                            help='Password (prompted if omitted)')
+    set_parser.add_argument('--token', default=None,
+                            help='Bearer token (Essbase only)')
+    set_parser.add_argument('--transport', default=None,
+                            help='MCP transport (server only)')
+    set_parser.add_argument('--port', default=None,
+                            help='HTTP port (server only)')
+    set_parser.set_defaults(func=_cmd_set)
+
+    # -- list --
+    list_parser = sub.add_parser('list', help='List stored credentials')
+    list_parser.set_defaults(func=_cmd_list)
+
+    # -- remove --
+    rm_parser = sub.add_parser('remove', help='Remove credentials for a service')
+    rm_parser.add_argument('service', choices=VALID_SERVICES,
+                           help='Service to remove')
+    rm_parser.set_defaults(func=_cmd_remove)
+
+    return parser
+
+
+def main():
+    parser = _build_parser()
+    args = parser.parse_args()
+    args.func(args)

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/config.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/config.py
@@ -58,6 +58,25 @@ class ServerConfig:
     # MCP_PROFILE=admin). This follows oracle/mcp BEST_PRACTICES on
     # scope minimisation and safe defaults.
     profile: str = 'viewer'
+    # Optional first-party bearer auth for streamable-http. When set,
+    # every HTTP request must carry `Authorization: Bearer <token>`.
+    # Required for any non-loopback bind unless allow_insecure_bind is
+    # explicitly set.
+    auth_token: Optional[str] = None
+    # Operator opt-in: acknowledge a non-loopback bind without
+    # MCP_AUTH_TOKEN. Use this only when an authenticated reverse proxy
+    # / API gateway sits in front of the MCP port. Without one of
+    # auth_token or allow_insecure_bind, non-loopback bind fails closed
+    # at startup.
+    allow_insecure_bind: bool = False
+    # Select AI / adp_ai_chat table policy. Tables are matched
+    # case-insensitively against both bare names and `OWNER.NAME` forms.
+    # If allowlist is set and a request references tables not in it,
+    # the call is rejected. If denylist is set and a request references
+    # any denied table, the call is rejected. Both can coexist; deny
+    # always wins.
+    ai_chat_allowed_tables: Optional[frozenset] = None
+    ai_chat_denied_tables: Optional[frozenset] = None
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -79,6 +98,19 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         '--port', type=int, default=None,
         help='HTTP port for streamable-http transport (default: 8000)')
+    parser.add_argument(
+        '--auth-token', default=None,
+        help='Bearer token for streamable-http auth (env MCP_AUTH_TOKEN). '
+             'When set, every HTTP request must carry '
+             '`Authorization: Bearer <token>`. Required for any '
+             'non-loopback bind unless --allow-insecure-bind is set.')
+    parser.add_argument(
+        '--allow-insecure-bind', action='store_true', default=None,
+        help='Acknowledge a non-loopback streamable-http bind without '
+             'MCP_AUTH_TOKEN. Use only when an authenticated reverse '
+             'proxy or API gateway is in front of this server. Without '
+             'this flag (or --auth-token), non-loopback bind fails '
+             'closed at startup. (env MCP_ALLOW_INSECURE_BIND=1)')
 
     # Essbase
     ess = parser.add_argument_group('Essbase')
@@ -144,6 +176,28 @@ def load_config() -> ServerConfig:
     profile = (_val(args.profile, 'MCP_PROFILE', 'server', 'profile')
                or 'viewer')
 
+    # -- Streamable-HTTP auth gate --
+    # Tokens are never read from the INI file (would be plaintext on disk).
+    auth_token = (args.auth_token
+                  or os.environ.get('MCP_AUTH_TOKEN'))
+    # `allow_insecure_bind` is intentionally CLI-flag-or-env-only — never
+    # from the config file. Putting it in a file would make "I accept
+    # the risk" a one-time, easy-to-forget decision.
+    allow_insecure_bind = bool(
+        args.allow_insecure_bind
+        or os.environ.get('MCP_ALLOW_INSECURE_BIND', '').lower()
+           in ('1', 'true', 'yes'))
+
+    # -- adp_ai_chat table policy (env-only; no CLI / no INI file) --
+    def _csv_set(env_key):
+        raw = os.environ.get(env_key, '').strip()
+        if not raw:
+            return None
+        return frozenset(t.strip().upper()
+                          for t in raw.split(',') if t.strip())
+    ai_chat_allowed_tables = _csv_set('MCP_AI_CHAT_ALLOWED_TABLES')
+    ai_chat_denied_tables = _csv_set('MCP_AI_CHAT_DENIED_TABLES')
+
     # -- Essbase --
     # Tokens are NEVER read from the INI file (would be plaintext on
     # disk). Resolve from CLI > env > keyring only.
@@ -200,4 +254,8 @@ def load_config() -> ServerConfig:
         transport=transport,
         host=host,
         port=port,
-        profile=profile)
+        profile=profile,
+        auth_token=auth_token,
+        allow_insecure_bind=allow_insecure_bind,
+        ai_chat_allowed_tables=ai_chat_allowed_tables,
+        ai_chat_denied_tables=ai_chat_denied_tables)

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/config.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/config.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''
+Configuration for the Oracle Data Studio MCP Server.
+
+Priority: CLI args > environment variables > OS keyring (passwords) >
+          config file (~/.oracle-data-studio/config) > defaults.
+'''
+
+from __future__ import annotations
+
+import os
+import argparse
+from dataclasses import dataclass
+from typing import Optional
+
+from .credential_store import load_config_file, get_keyring_password
+
+
+@dataclass
+class EssbaseConfig:
+    '''Essbase connection configuration.'''
+    url: str
+    user: str
+    password: str
+    token: Optional[str] = None
+
+
+@dataclass
+class AdpConfig:
+    '''ADP connection configuration.'''
+    url: str
+    user: str
+    password: str
+
+
+@dataclass
+class DataTransformsConfig:
+    '''Data Transforms connection configuration.'''
+    url: str
+    user: str
+    password: str
+
+
+@dataclass
+class ServerConfig:
+    '''Top-level server configuration.'''
+    essbase: Optional[EssbaseConfig] = None
+    adp: Optional[AdpConfig] = None
+    datatransforms: Optional[DataTransformsConfig] = None
+    transport: str = 'stdio'
+    host: str = '127.0.0.1'   # streamable-http bind address; loopback by default
+    port: int = 8000
+    profile: str = 'admin'
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    '''Build the CLI argument parser.'''
+    parser = argparse.ArgumentParser(
+        description='Oracle Data Studio MCP Server')
+
+    # Transport
+    parser.add_argument(
+        '--transport', choices=['stdio', 'streamable-http'],
+        default=None,
+        help='MCP transport (default: stdio)')
+    parser.add_argument(
+        '--host', default=None,
+        help='Bind address for streamable-http transport '
+             '(default: 127.0.0.1 — loopback only). '
+             'Use 0.0.0.0 to expose externally; the server has no '
+             'built-in auth so put a reverse proxy in front.')
+    parser.add_argument(
+        '--port', type=int, default=None,
+        help='HTTP port for streamable-http transport (default: 8000)')
+
+    # Essbase
+    ess = parser.add_argument_group('Essbase')
+    ess.add_argument('--essbase-url', default=None,
+                     help='Essbase server URL')
+    ess.add_argument('--essbase-user', default=None,
+                     help='Essbase username')
+    ess.add_argument('--essbase-password', default=None,
+                     help='Essbase password')
+    ess.add_argument('--essbase-token', default=None,
+                     help='Essbase Bearer token (alternative to user/password)')
+
+    # ADP
+    adp = parser.add_argument_group('ADP')
+    adp.add_argument('--adp-url', default=None,
+                     help='ADP server URL')
+    adp.add_argument('--adp-user', default=None,
+                     help='ADP username')
+    adp.add_argument('--adp-password', default=None,
+                     help='ADP password')
+
+    # Profile
+    parser.add_argument(
+        '--profile', choices=['viewer', 'analyst', 'admin'],
+        default=None,
+        help='Tool access profile: viewer, analyst, admin (default: admin)')
+
+    # Data Transforms
+    dt = parser.add_argument_group('Data Transforms')
+    dt.add_argument('--dt-url', default=None,
+                    help='Data Transforms server URL')
+    dt.add_argument('--dt-user', default=None,
+                    help='Data Transforms username')
+    dt.add_argument('--dt-password', default=None,
+                    help='Data Transforms password')
+
+    return parser
+
+
+def load_config() -> ServerConfig:
+    '''Load configuration from CLI args, env vars, keyring, and config file.
+
+    Priority: CLI args > environment variables > OS keyring (passwords) >
+              config file (~/.oracle-data-studio/config) > defaults.
+    '''
+    parser = _build_parser()
+    args, _ = parser.parse_known_args()
+    file_cfg = load_config_file()
+
+    # Helper: resolve a value through the priority chain
+    def _val(cli, env_key, section, key):
+        return (cli
+                or os.environ.get(env_key)
+                or file_cfg.get(section, {}).get(key))
+
+    # -- Transport & Profile --
+    transport = (_val(args.transport, 'MCP_TRANSPORT', 'server', 'transport')
+                 or 'stdio')
+    host = (_val(args.host, 'MCP_HOST', 'server', 'host')
+            or '127.0.0.1')
+    port_str = _val(args.port, 'MCP_PORT', 'server', 'port')
+    port = int(port_str) if port_str else 8000
+    profile = (_val(args.profile, 'MCP_PROFILE', 'server', 'profile')
+               or 'admin')
+
+    # -- Essbase --
+    ess_url = _val(args.essbase_url, 'ESSBASE_URL', 'essbase', 'url')
+    ess_user = _val(args.essbase_user, 'ESSBASE_USER', 'essbase', 'user')
+    ess_token = _val(args.essbase_token, 'ESSBASE_TOKEN', 'essbase', 'token')
+    ess_password = (args.essbase_password
+                    or os.environ.get('ESSBASE_PASSWORD')
+                    or get_keyring_password('essbase', ess_user))
+
+    essbase_config = None
+    if ess_url and (ess_token or (ess_user and ess_password)):
+        essbase_config = EssbaseConfig(
+            url=ess_url,
+            user=ess_user or '',
+            password=ess_password or '',
+            token=ess_token)
+
+    # -- ADP --
+    adp_url = _val(args.adp_url, 'ADP_URL', 'adp', 'url')
+    adp_user = _val(args.adp_user, 'ADP_USER', 'adp', 'user')
+    adp_password = (args.adp_password
+                    or os.environ.get('ADP_PASSWORD')
+                    or get_keyring_password('adp', adp_user))
+
+    adp_config = None
+    if adp_url and adp_user and adp_password:
+        adp_config = AdpConfig(
+            url=adp_url,
+            user=adp_user,
+            password=adp_password)
+
+    # -- Data Transforms --
+    dt_url = _val(args.dt_url, 'DT_URL', 'datatransforms', 'url')
+    dt_user = _val(args.dt_user, 'DT_USER', 'datatransforms', 'user')
+    dt_password = (args.dt_password
+                   or os.environ.get('DT_PASSWORD')
+                   or get_keyring_password('datatransforms', dt_user))
+
+    dt_config = None
+    if dt_url and dt_user and dt_password:
+        dt_config = DataTransformsConfig(
+            url=dt_url,
+            user=dt_user,
+            password=dt_password)
+
+    return ServerConfig(
+        essbase=essbase_config,
+        adp=adp_config,
+        datatransforms=dt_config,
+        transport=transport,
+        host=host,
+        port=port,
+        profile=profile)

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/config.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/config.py
@@ -53,7 +53,11 @@ class ServerConfig:
     transport: str = 'stdio'
     host: str = '127.0.0.1'   # streamable-http bind address; loopback by default
     port: int = 8000
-    profile: str = 'admin'
+    # Default profile is `viewer` — safe metadata-only access. The
+    # full admin surface requires explicit `--profile admin` (or
+    # MCP_PROFILE=admin). This follows oracle/mcp BEST_PRACTICES on
+    # scope minimisation and safe defaults.
+    profile: str = 'viewer'
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -138,12 +142,17 @@ def load_config() -> ServerConfig:
     port_str = _val(args.port, 'MCP_PORT', 'server', 'port')
     port = int(port_str) if port_str else 8000
     profile = (_val(args.profile, 'MCP_PROFILE', 'server', 'profile')
-               or 'admin')
+               or 'viewer')
 
     # -- Essbase --
+    # Tokens are NEVER read from the INI file (would be plaintext on
+    # disk). Resolve from CLI > env > keyring only.
+    from .credential_store import get_keyring_token
     ess_url = _val(args.essbase_url, 'ESSBASE_URL', 'essbase', 'url')
     ess_user = _val(args.essbase_user, 'ESSBASE_USER', 'essbase', 'user')
-    ess_token = _val(args.essbase_token, 'ESSBASE_TOKEN', 'essbase', 'token')
+    ess_token = (args.essbase_token
+                 or os.environ.get('ESSBASE_TOKEN')
+                 or get_keyring_token('essbase'))
     ess_password = (args.essbase_password
                     or os.environ.get('ESSBASE_PASSWORD')
                     or get_keyring_password('essbase', ess_user))

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/credential_store.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/credential_store.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''
+Credential management for Oracle Data Studio MCP Server.
+
+Stores non-sensitive settings (URLs, usernames) in an INI config file
+at ~/.oracle-data-studio/config and passwords in the OS keyring
+(macOS Keychain, Windows Credential Manager, Linux Secret Service).
+'''
+
+from __future__ import annotations
+
+import os
+import configparser
+from pathlib import Path
+from typing import Optional
+
+# Keyring service prefix — entries are stored as
+# "oracle-data-studio/essbase", "oracle-data-studio/adp", etc.
+SERVICE_PREFIX = 'oracle-data-studio'
+
+VALID_SERVICES = ('essbase', 'adp', 'datatransforms', 'server')
+
+CONFIG_DIR = Path.home() / '.oracle-data-studio'
+CONFIG_FILE = CONFIG_DIR / 'config'
+
+
+def _ensure_config_dir():
+    '''Create ~/.oracle-data-studio/ with restricted permissions.'''
+    CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+
+def _read_config() -> configparser.ConfigParser:
+    '''Read the INI config file. Returns empty parser if file is missing.'''
+    cp = configparser.ConfigParser()
+    if CONFIG_FILE.exists():
+        cp.read(str(CONFIG_FILE))
+    return cp
+
+
+def _write_config(cp: configparser.ConfigParser):
+    '''Write the config parser back to the INI file with restricted perms.'''
+    _ensure_config_dir()
+    with open(CONFIG_FILE, 'w') as f:
+        cp.write(f)
+    os.chmod(CONFIG_FILE, 0o600)
+
+
+def _keyring_service(service: str) -> str:
+    '''Build the keyring service name for a given service.'''
+    return f'{SERVICE_PREFIX}/{service}'
+
+
+def _set_keyring_password(service: str, user: str, password: str) -> bool:
+    '''Store a password in the OS keyring. Returns True on success.'''
+    try:
+        import keyring
+        keyring.set_password(_keyring_service(service), user, password)
+        return True
+    except ImportError:
+        return False
+    except Exception:
+        return False
+
+
+def _get_keyring_password(service: str, user: str) -> Optional[str]:
+    '''Retrieve a password from the OS keyring. Returns None if unavailable.'''
+    if not user:
+        return None
+    try:
+        import keyring
+        return keyring.get_password(_keyring_service(service), user)
+    except ImportError:
+        return None
+    except Exception:
+        return None
+
+
+def _delete_keyring_password(service: str, user: str) -> bool:
+    '''Remove a password from the OS keyring. Returns True on success.'''
+    if not user:
+        return False
+    try:
+        import keyring
+        keyring.delete_password(_keyring_service(service), user)
+        return True
+    except ImportError:
+        return False
+    except Exception:
+        return False
+
+
+# ------------------------------------------------------------------ #
+#  Public API                                                         #
+# ------------------------------------------------------------------ #
+
+def store_credentials(service: str, url: Optional[str] = None,
+                      user: Optional[str] = None,
+                      password: Optional[str] = None,
+                      **extra) -> dict:
+    '''Store credentials for a service.
+
+    - url and user are written to the config file.
+    - password is stored in the OS keyring (never written to the file).
+    - extra kwargs (e.g. transport, port, token) are written to the file.
+    '''
+    if service not in VALID_SERVICES:
+        raise ValueError(f'Unknown service: {service}. '
+                         f'Valid: {", ".join(VALID_SERVICES)}')
+
+    cp = _read_config()
+    if not cp.has_section(service):
+        cp.add_section(service)
+
+    if url is not None:
+        cp.set(service, 'url', url)
+    if user is not None:
+        cp.set(service, 'user', user)
+    for k, v in extra.items():
+        if v is not None:
+            cp.set(service, k, str(v))
+
+    _write_config(cp)
+
+    keyring_ok = False
+    if password and user:
+        keyring_ok = _set_keyring_password(service, user, password)
+
+    return {
+        'status': 'success',
+        'config_file': str(CONFIG_FILE),
+        'keyring_stored': keyring_ok,
+    }
+
+
+def remove_credentials(service: str) -> dict:
+    '''Remove a service section from config file and its password from keyring.'''
+    cp = _read_config()
+    user = cp.get(service, 'user', fallback=None) if cp.has_section(service) else None
+
+    removed_file = False
+    if cp.has_section(service):
+        cp.remove_section(service)
+        _write_config(cp)
+        removed_file = True
+
+    removed_keyring = False
+    if user:
+        removed_keyring = _delete_keyring_password(service, user)
+
+    return {
+        'status': 'success',
+        'removed_config': removed_file,
+        'removed_keyring': removed_keyring,
+    }
+
+
+def list_credentials() -> dict:
+    '''List all stored credentials (URLs and usernames, never passwords).'''
+    cp = _read_config()
+    result = {}
+    for section in cp.sections():
+        result[section] = dict(cp.items(section))
+    return result
+
+
+def load_config_file() -> dict:
+    '''Load the config file as a dict of {section: {key: value}}.
+
+    Used by mcp_server/config.py to layer in config file values.
+    '''
+    cp = _read_config()
+    return {section: dict(cp.items(section)) for section in cp.sections()}
+
+
+def get_keyring_password(service: str, user: str) -> Optional[str]:
+    '''Public wrapper for keyring password retrieval.'''
+    return _get_keyring_password(service, user)

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/credential_store.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/credential_store.py
@@ -26,6 +26,21 @@ VALID_SERVICES = ('essbase', 'adp', 'datatransforms', 'server')
 CONFIG_DIR = Path.home() / '.oracle-data-studio'
 CONFIG_FILE = CONFIG_DIR / 'config'
 
+# Keys that MUST NEVER appear in the plaintext INI config file.
+# Even if a caller passes them via store_credentials(**extra), they
+# are routed to the OS keyring instead of being written to disk.
+# Reviewers requested this hardening — defence-in-depth against
+# accidental token-in-config-file mistakes.
+SECRET_KEYS = frozenset({
+    'password', 'passwd', 'pswd',
+    'token', 'bearer',
+    'secret', 'api_key', 'apikey',
+})
+
+# Pseudo-username for keyring entries that aren't tied to a real
+# username (e.g. bearer tokens).
+_TOKEN_KEYRING_USER = '__token__'
+
 
 def _ensure_config_dir():
     '''Create ~/.oracle-data-studio/ with restricted permissions.'''
@@ -102,9 +117,20 @@ def store_credentials(service: str, url: Optional[str] = None,
                       **extra) -> dict:
     '''Store credentials for a service.
 
-    - url and user are written to the config file.
-    - password is stored in the OS keyring (never written to the file).
-    - extra kwargs (e.g. transport, port, token) are written to the file.
+    Splits inputs into two destinations:
+
+    - **OS keyring** — `password` (keyed by user), and any kwargs whose
+      name is in `SECRET_KEYS` (`token`, `bearer`, `api_key`, …).
+      Bearer tokens are stored under the pseudo-user `__token__`.
+      Nothing in this category is ever written to disk by this server.
+    - **INI config file** — `url`, `user`, and any non-secret kwargs
+      (`transport`, `port`, `host`, etc.).
+
+    A caller cannot trick this function into persisting a secret by
+    renaming the field: passing `token=…` or `password=…` always goes
+    to keyring, never to the file.
+
+    Returns a dict that reports which secret destinations were used.
     '''
     if service not in VALID_SERVICES:
         raise ValueError(f'Unknown service: {service}. '
@@ -118,9 +144,17 @@ def store_credentials(service: str, url: Optional[str] = None,
         cp.set(service, 'url', url)
     if user is not None:
         cp.set(service, 'user', user)
+
+    # Track secret extras so we can store them in keyring after the
+    # file write.  NEVER set them as INI keys.
+    secret_extras: dict[str, str] = {}
     for k, v in extra.items():
-        if v is not None:
-            cp.set(service, k, str(v))
+        if v is None:
+            continue
+        if k.lower() in SECRET_KEYS:
+            secret_extras[k.lower()] = str(v)
+            continue
+        cp.set(service, k, str(v))
 
     _write_config(cp)
 
@@ -128,15 +162,30 @@ def store_credentials(service: str, url: Optional[str] = None,
     if password and user:
         keyring_ok = _set_keyring_password(service, user, password)
 
+    # Route secret kwargs to keyring under stable keys.
+    secret_extras_stored: list[str] = []
+    for k, v in secret_extras.items():
+        # Tokens / bearer / api_key: pseudo-user
+        ok = _set_keyring_password(service, _TOKEN_KEYRING_USER, v)
+        if ok:
+            secret_extras_stored.append(k)
+
     return {
         'status': 'success',
         'config_file': str(CONFIG_FILE),
         'keyring_stored': keyring_ok,
+        'secret_extras_stored': secret_extras_stored,
     }
 
 
 def remove_credentials(service: str) -> dict:
-    '''Remove a service section from config file and its password from keyring.'''
+    '''Remove a service section from config file and its secrets from keyring.
+
+    Scrubs:
+    - the INI section
+    - the user-keyed password (if a user was set)
+    - any token / bearer entries stored under the `__token__` pseudo-user
+    '''
     cp = _read_config()
     user = cp.get(service, 'user', fallback=None) if cp.has_section(service) else None
 
@@ -150,10 +199,14 @@ def remove_credentials(service: str) -> dict:
     if user:
         removed_keyring = _delete_keyring_password(service, user)
 
+    # Best-effort token removal — silently ignores "no such entry"
+    removed_token = _delete_keyring_password(service, _TOKEN_KEYRING_USER)
+
     return {
         'status': 'success',
         'removed_config': removed_file,
         'removed_keyring': removed_keyring,
+        'removed_token': removed_token,
     }
 
 
@@ -178,3 +231,13 @@ def load_config_file() -> dict:
 def get_keyring_password(service: str, user: str) -> Optional[str]:
     '''Public wrapper for keyring password retrieval.'''
     return _get_keyring_password(service, user)
+
+
+def get_keyring_token(service: str) -> Optional[str]:
+    '''Public wrapper for bearer-token retrieval from keyring.
+
+    Tokens are stored under a pseudo-user (`__token__`) so they don't
+    need a real username to round-trip. Returns None if no token is
+    set or the keyring is unavailable.
+    '''
+    return _get_keyring_password(service, _TOKEN_KEYRING_USER)

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/http_runtime.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/http_runtime.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''Streamable-HTTP transport hardening.
+
+The FastMCP `streamable-http` transport is a bare HTTP endpoint with
+no built-in auth: anyone who reaches the port gets the configured
+profile under the configured Oracle credentials. This module:
+
+  - Decides whether a bind is allowed at startup (fail-closed gate).
+  - When a bearer token is configured, wraps the Starlette HTTP app
+    with a middleware that enforces `Authorization: Bearer <token>`
+    on every request before any tool dispatch happens.
+
+The rules (enforced by `decide_bind`):
+
+  1. Loopback bind (127.0.0.1 / ::1 / localhost) is always allowed —
+     attacker must already be on the host.
+  2. Non-loopback bind requires either:
+       a. `auth_token` set  → bearer middleware enforces auth, or
+       b. `allow_insecure_bind=True` → operator has acknowledged that
+          they have an external auth proxy in front. Big WARNING is
+          logged.
+  3. Otherwise: refuse to start. `decide_bind` raises
+     `InsecureBindRefused` and `main()` exits non-zero.
+
+This is the first-party fallback. The reviewer-recommended path is
+still "put an authenticated reverse proxy in front", and that path
+is what `allow_insecure_bind` acknowledges.
+'''
+
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import Optional
+
+logger = logging.getLogger('oracle-data-studio-mcp')
+
+
+class InsecureBindRefused(Exception):
+    '''Raised when a non-loopback bind is requested without auth.'''
+
+
+# Hosts treated as loopback. Anything else is considered exposed and
+# subject to the auth gate.
+_LOOPBACK_HOSTS = frozenset({
+    '127.0.0.1',
+    '::1',
+    'localhost',
+    # Empty string sometimes means "default = loopback" in dev setups.
+    '',
+})
+
+
+def is_loopback(host: Optional[str]) -> bool:
+    '''True if `host` is a loopback address.
+
+    Accepts the common forms: 127.0.0.1, ::1, localhost. Anything
+    else — including 0.0.0.0, a LAN IP, or a hostname — is treated as
+    a non-loopback bind that requires auth or explicit opt-in.
+    '''
+    if host is None:
+        return True
+    return host.strip().lower() in _LOOPBACK_HOSTS
+
+
+def decide_bind(host: Optional[str], *,
+                auth_token: Optional[str] = None,
+                allow_insecure_bind: bool = False) -> None:
+    '''Gate the streamable-http bind. Raises if the bind is unsafe.
+
+    Loopback binds are always allowed silently. Non-loopback binds
+    require `auth_token` OR `allow_insecure_bind`. The chosen path is
+    logged at INFO so operators see what's in effect; insecure binds
+    log a prominent WARNING.
+
+    @raises InsecureBindRefused: when host is non-loopback and neither
+        `auth_token` nor `allow_insecure_bind` is set.
+    '''
+    if is_loopback(host):
+        logger.info('streamable-http bind: loopback (%s) — no auth gate needed',
+                    host or '127.0.0.1')
+        return
+    if auth_token:
+        logger.info(
+            'streamable-http bind: non-loopback (%s) with MCP_AUTH_TOKEN '
+            'set — bearer middleware will reject unauthenticated requests',
+            host)
+        return
+    if allow_insecure_bind:
+        logger.warning(
+            'streamable-http bind: non-loopback (%s) WITHOUT MCP_AUTH_TOKEN — '
+            '--allow-insecure-bind acknowledged by operator. Server has NO '
+            'first-party auth; ensure an authenticated reverse proxy is in '
+            'front of port %s. Anyone reaching the port gets the configured '
+            'profile under the configured Oracle credentials.',
+            host, host)
+        return
+    raise InsecureBindRefused(
+        'streamable-http refusing to bind to non-loopback host {!r}: '
+        'no MCP_AUTH_TOKEN and --allow-insecure-bind not set. '
+        'Either (a) set MCP_AUTH_TOKEN to a strong secret so the '
+        'server can enforce bearer auth, (b) pass --allow-insecure-bind '
+        '(or MCP_ALLOW_INSECURE_BIND=1) if an authenticated reverse '
+        'proxy / API gateway sits in front, or (c) leave the bind on '
+        '127.0.0.1.'.format(host))
+
+
+def make_bearer_middleware(token: str):
+    '''Return a Starlette middleware class that enforces Bearer auth.
+
+    The token comparison uses `secrets.compare_digest` for constant-
+    time matching. Tool dispatch never sees the request unless the
+    Authorization header is present and matches.
+
+    Health check (`GET /`) returns 200 unauthenticated so load
+    balancers / readiness probes work; everything else (POST, the
+    MCP message endpoints, etc.) requires auth.
+    '''
+    # Import lazily so the module imports without Starlette installed
+    # (relevant for the stdio-only case in tests).
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.responses import JSONResponse
+
+    expected = token
+
+    class BearerAuthMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            # Allow unauthenticated readiness probes
+            if request.method == 'GET' and request.url.path in ('/', '/health'):
+                return await call_next(request)
+            header = request.headers.get('Authorization') or ''
+            scheme, _, value = header.partition(' ')
+            if scheme.lower() != 'bearer' or not value:
+                return JSONResponse(
+                    {'error': 'authentication required'},
+                    status_code=401,
+                    headers={'WWW-Authenticate': 'Bearer'})
+            if not secrets.compare_digest(value, expected):
+                return JSONResponse(
+                    {'error': 'invalid bearer token'},
+                    status_code=401,
+                    headers={'WWW-Authenticate': 'Bearer'})
+            return await call_next(request)
+
+    return BearerAuthMiddleware
+
+
+def wrap_app_with_bearer_auth(app, token: str):
+    '''Wrap `app` (a Starlette ASGI app) with bearer-token enforcement.
+
+    Returns the wrapped app, which still talks ASGI and can be served
+    by uvicorn exactly like the original.
+    '''
+    from starlette.middleware import Middleware
+    from starlette.applications import Starlette
+
+    mw_cls = make_bearer_middleware(token)
+    # Mount the original app under "/" of a thin wrapper Starlette
+    # that carries the middleware. We can't .add_middleware() after
+    # the Starlette app's startup; building a fresh wrapper is the
+    # documented pattern.
+    wrapper = Starlette(
+        debug=False,
+        routes=[],
+        middleware=[Middleware(mw_cls)],
+    )
+    # Forward all routes/lifespan to the inner app via mount.
+    wrapper.mount('/', app)
+    return wrapper

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/profiles.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/profiles.py
@@ -152,6 +152,13 @@ PROFILES = {
             # RECREATE) — analyst is "read + query/execute, no
             # modify" and pipelines write, so admin only.
             'dt_run_pipeline',
+            # Select AI is an NL→SQL surface backed by the DB. Without
+            # operator-configured table allow/deny lists in place, the
+            # safe default is admin-only. Operators who enable analyst
+            # access should set MCP_AI_CHAT_ALLOWED_TABLES or
+            # MCP_AI_CHAT_DENIED_TABLES and surface them in their auth
+            # proxy / runtime policy. See OWASP LLM01/LLM05.
+            'adp_ai_chat',
         }),
     },
     'admin': None,  # No filtering — all tools

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/profiles.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/profiles.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''MCP tool access profiles.
+
+Profiles control which tools are exposed to AI assistants.
+Three tiers: viewer < analyst < admin (default).
+
+Usage:
+    oracle.data-studio-mcp-server --profile analyst
+    MCP_PROFILE=viewer oracle.data-studio-mcp-server
+    # or in ~/.oracle-data-studio/config:
+    # [server]
+    # profile = analyst
+
+Upleveled tool naming conventions:
+    essbase_explore           — read-only server overview
+    essbase_describe_database — read-only database profile
+    essbase_query             — execute MDX query
+    essbase_browse_outline    — read-only outline navigation
+    essbase_search_members    — read-only member search
+    essbase_run_calculation   — execute calc script
+    essbase_load_data         — modify: load data
+    essbase_deploy_workbook   — modify: import Excel
+    essbase_manage_variables  — modify: CRUD variables
+    essbase_get_script        — read-only script content
+    essbase_manage_security   — read-only security report
+    essbase_server_health     — read-only health check
+    essbase_export_data       — execute: runs free-form MDX via the
+                                grid endpoint (analyst+, NOT viewer)
+    essbase_manage_application — modify: create/delete/copy/rename/start/stop
+    essbase_manage_script     — modify: CRUD calc scripts
+    essbase_manage_files      — modify: file catalog operations
+    essbase_manage_connections — modify: CRUD connections
+    essbase_manage_locks      — read/modify: list/unlock locks
+    essbase_manage_filters    — modify: CRUD security filters
+    essbase_manage_jobs       — read/modify: list/rerun/purge jobs
+    essbase_edit_outline      — modify: add/remove/move/rename members
+    essbase_manage_datasources — modify: CRUD datasources
+    essbase_manage_drill_through — modify: CRUD drill-through reports
+    essbase_manage_database   — modify: delete/copy/rename databases
+    essbase_manage_users      — modify: CRUD users + role provisioning
+    essbase_manage_groups     — modify: CRUD groups + membership
+    essbase_manage_sessions   — read/modify: list/kill sessions
+    essbase_manage_db_settings — read-only: detailed database settings
+    essbase_get_logs          — read-only: application logs
+    essbase_outline_metadata  — read-only: generations, levels, smart lists, settings
+    adp_build_analytic_view   — modify: create AV
+    adp_query_analytic_view   — read-only AV query
+    adp_analyze_analytic_view — read-only AV analysis
+    adp_generate_insights     — execute: generate insights
+    adp_ai_chat               — execute: conversational AI
+    adp_search                — read-only search
+    adp_load_from_cloud       — modify: load data
+    adp_browse_catalog        — read-only catalog browsing
+    adp_manage_catalog        — modify: enable/disable/unmount catalogs
+    adp_manage_sharing        — modify: sharing
+    adp_manage_analytic_views — read/modify: list/drop AVs
+    adp_manage_credentials    — modify: CRUD credentials + storage links
+    adp_manage_insights       — read/modify: insight lifecycle
+    adp_manage_db_links       — modify: database link operations
+    adp_get_annotations       — read-only: Oracle 23ai annotations for NL→SQL
+    dt_explore                — read-only overview
+    dt_describe_project       — read-only project profile
+    dt_manage_project         — modify: delete projects
+    dt_describe_connection    — read-only connection profile
+    dt_create_pipeline        — modify: create pipeline
+    dt_check_health           — read-only health check
+    dt_browse_data            — read-only data browsing
+    dt_manage_dataflow        — modify: create/update dataflow
+    dt_run_pipeline           — execute: run dataflow/workflow/dataload
+    dt_manage_connection      — modify: CRUD connections
+    dt_manage_dataload        — read: list/get dataloads
+    dt_manage_data_entities   — read/modify: list/import data entities
+    dt_manage_workflow        — read: list/get workflows
+    dt_manage_schedule        — modify: schedule CRUD
+    dt_manage_variables       — modify: variable CRUD
+'''
+
+import logging
+
+logger = logging.getLogger('oracle-data-studio-mcp')
+
+# ------------------------------------------------------------------ #
+#  Profile definitions                                                #
+# ------------------------------------------------------------------ #
+
+PROFILES = {
+    'viewer': {
+        'description': 'Browse and view metadata, settings, data — '
+                       'no modifications or execution',
+        'allowed_verbs': frozenset({
+            'explore', 'describe_', 'browse_', 'search_',
+            'get_', 'explain_', 'analyze_', 'server_health',
+            'check_health',
+            # NOTE: 'export_' was removed deliberately. Although exports
+            # look read-only by name, `essbase_export_data` accepts a
+            # free-form MDX string and runs `ess.grid.execute_mdx(...)`,
+            # which is execution. Viewer must not be able to run MDX.
+            # If a future tool with verb 'export_*' is genuinely
+            # read-only and safe for viewer, add it via `explicit_allow`.
+        }),
+        'explicit_allow': frozenset({
+            'adp_query_analytic_view',
+            'adp_search',
+        }),
+        'explicit_deny': frozenset({
+            # Calc-script source code can contain business logic,
+            # hardcoded values, datasource references — viewer must
+            # not see content. (Analyst keeps it because they may
+            # need to read a script they intend to run.)
+            'essbase_get_script',
+            # Server logs frequently contain SQL with PII, error
+            # paths, sometimes credentials in error messages — admin
+            # only.
+            'essbase_get_logs',
+        }),
+    },
+    'analyst': {
+        'description': 'Read + query/execute — '
+                       'no create/delete/modify/manage',
+        'allowed_verbs': frozenset({
+            # viewer verbs
+            'explore', 'describe_', 'browse_', 'search_',
+            'get_', 'explain_', 'analyze_', 'server_health',
+            'check_health', 'export_',
+            # analyst verbs (query + execute)
+            'query', 'execute_', 'run_',
+            'generate_', 'ai_',
+        }),
+        'explicit_allow': frozenset({
+            'adp_query_analytic_view',
+            'adp_search',
+        }),
+        'explicit_deny': frozenset({
+            'adp_load_from_cloud',     # data loading is admin
+            # Logs contain operational PII / SQL — admin only.
+            'essbase_get_logs',
+            # Pipelines mutate target tables (INSERT / TRUNCATE /
+            # RECREATE) — analyst is "read + query/execute, no
+            # modify" and pipelines write, so admin only.
+            'dt_run_pipeline',
+        }),
+    },
+    'admin': None,  # No filtering — all tools
+}
+
+VALID_PROFILES = tuple(PROFILES.keys())
+
+
+# ------------------------------------------------------------------ #
+#  Verb extraction                                                    #
+# ------------------------------------------------------------------ #
+
+# Service prefixes used in tool names: essbase_, adp_, dt_
+_SERVICE_PREFIXES = ('essbase_', 'adp_', 'dt_')
+
+
+def _get_verb_suffix(tool_name: str) -> str:
+    '''Strip service prefix to get the verb portion of a tool name.
+
+    Examples:
+        essbase_explore           -> explore
+        essbase_describe_database -> describe_database
+        adp_execute_sql           -> execute_sql
+        dt_manage_schedule        -> manage_schedule
+    '''
+    for prefix in _SERVICE_PREFIXES:
+        if tool_name.startswith(prefix):
+            return tool_name[len(prefix):]
+    return tool_name
+
+
+# ------------------------------------------------------------------ #
+#  Public API                                                         #
+# ------------------------------------------------------------------ #
+
+def apply_profile(mcp_server, profile_name: str) -> None:
+    '''Remove tools that don't match the selected profile.
+
+    Must be called AFTER all register_tools() calls and BEFORE mcp.run().
+
+    Args:
+        mcp_server: The FastMCP server instance.
+        profile_name: One of 'viewer', 'analyst', 'admin'.
+    '''
+    if profile_name == 'admin':
+        total = len(mcp_server._tool_manager._tools)
+        logger.info('Profile %r: all %d tools available', profile_name, total)
+        return
+
+    profile = PROFILES.get(profile_name)
+    if profile is None:
+        raise ValueError(
+            f'Unknown profile: {profile_name!r}. '
+            f'Valid profiles: {", ".join(VALID_PROFILES)}')
+
+    allowed_verbs = profile['allowed_verbs']
+    explicit_allow = profile.get('explicit_allow', frozenset())
+    explicit_deny = profile.get('explicit_deny', frozenset())
+
+    tools = mcp_server._tool_manager._tools
+    to_remove = []
+
+    for tool_name in list(tools.keys()):
+        suffix = _get_verb_suffix(tool_name)
+
+        # Explicit deny always wins
+        if tool_name in explicit_deny:
+            to_remove.append(tool_name)
+        # Explicit allow always keeps
+        elif tool_name in explicit_allow:
+            continue
+        # Verb prefix match — check if suffix starts with any allowed verb
+        elif any(suffix.startswith(verb) for verb in allowed_verbs):
+            continue
+        # Exact match for single-word verbs (e.g. 'explore', 'query')
+        elif suffix in allowed_verbs:
+            continue
+        # No match → remove
+        else:
+            to_remove.append(tool_name)
+
+    for name in to_remove:
+        del tools[name]
+
+    logger.info('Profile %r: %d tools available (%d removed)',
+                profile_name, len(tools), len(to_remove))

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/profiles.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/profiles.py
@@ -5,14 +5,25 @@
 '''MCP tool access profiles.
 
 Profiles control which tools are exposed to AI assistants.
-Three tiers: viewer < analyst < admin (default).
+Three tiers (least → most privilege):
+
+  - viewer  (default) — metadata browsing only, no execution.
+  - analyst — read + query/execute (MDX, run_calculation, AV reads,
+              insights). No create/delete/manage.
+  - admin   — full surface. EXPLICIT OPT-IN ONLY.
+
+Default is `viewer` for safety. Per the oracle/mcp BEST_PRACTICES
+guidance on scope minimisation, admin access is never granted
+implicitly.
 
 Usage:
+    oracle.data-studio-mcp-server                       # viewer (default)
     oracle.data-studio-mcp-server --profile analyst
-    MCP_PROFILE=viewer oracle.data-studio-mcp-server
+    oracle.data-studio-mcp-server --profile admin       # explicit opt-in
+    MCP_PROFILE=admin oracle.data-studio-mcp-server
     # or in ~/.oracle-data-studio/config:
     # [server]
-    # profile = analyst
+    # profile = admin
 
 Upleveled tool naming conventions:
     essbase_explore           — read-only server overview

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/server.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/server.py
@@ -20,6 +20,11 @@ from mcp.server.fastmcp import FastMCP
 from .config import load_config, ServerConfig
 from .profiles import apply_profile
 from .tools._helpers import wrap_mutating_tools_with_audit
+from .http_runtime import (
+    decide_bind,
+    wrap_app_with_bearer_auth,
+    InsecureBindRefused,
+)
 
 # Logging to stderr (required for stdio transport)
 logging.basicConfig(
@@ -36,6 +41,18 @@ _config: ServerConfig | None = None
 async def app_lifespan(server: FastMCP):
     '''Connect to Essbase and/or ADP at startup, yield context dict.'''
     context: dict = {}
+
+    # Stash the active profile so tools that need profile-aware behaviour
+    # (e.g. connection metadata redaction) can read it without threading
+    # the value through every signature. Default 'viewer' = least
+    # privilege if config didn't run.
+    context['_profile'] = (_config.profile
+                           if _config is not None else 'viewer')
+    # Select AI table allow / deny lists. Consumed by adp_ai_chat.
+    context['_ai_chat_allowed_tables'] = (
+        _config.ai_chat_allowed_tables if _config is not None else None)
+    context['_ai_chat_denied_tables'] = (
+        _config.ai_chat_denied_tables if _config is not None else None)
 
     # -- Essbase --
     if _config and _config.essbase:
@@ -219,21 +236,38 @@ def main():
                 _config.transport, _config.profile)
 
     if _config.transport == 'streamable-http':
-        # Default bind: 127.0.0.1 (loopback). The server has no
-        # built-in auth — anyone who reaches the port gets full access
-        # under the configured credentials. To expose externally, set
-        # --host 0.0.0.0 explicitly AND put an authenticated reverse
-        # proxy in front. (S8.)
-        #
-        # Note: FastMCP.run() takes only `transport` and `mount_path` —
-        # host/port live on `mcp.settings`. Set them BEFORE run().
-        if _config.host == '0.0.0.0':
-            logger.warning(
-                'streamable-http bound to 0.0.0.0 — server has NO '
-                'built-in auth; ensure a reverse proxy / firewall '
-                'is in front')
+        # Fail-closed gate: non-loopback bind requires either an
+        # MCP_AUTH_TOKEN (server enforces bearer auth) or an explicit
+        # --allow-insecure-bind acknowledgement (operator confirms an
+        # authenticated reverse proxy is in front). Default bind is
+        # 127.0.0.1, which never trips the gate.
+        try:
+            decide_bind(
+                _config.host,
+                auth_token=_config.auth_token,
+                allow_insecure_bind=_config.allow_insecure_bind)
+        except InsecureBindRefused as e:
+            logger.error('%s', e)
+            sys.exit(2)
+
         mcp.settings.host = _config.host
         mcp.settings.port = _config.port
-        mcp.run(transport='streamable-http')
+
+        if _config.auth_token:
+            # Build the HTTP app ourselves, wrap with bearer-auth
+            # middleware, and serve via uvicorn. Equivalent to what
+            # FastMCP.run('streamable-http') does internally, but with
+            # the middleware injected before tool dispatch.
+            import uvicorn  # local import: not needed for stdio path
+            app = wrap_app_with_bearer_auth(
+                mcp.streamable_http_app(),
+                _config.auth_token)
+            logger.info(
+                'streamable-http: bearer auth enforced on %s:%s',
+                _config.host, _config.port)
+            uvicorn.run(app, host=_config.host, port=_config.port,
+                        log_level=mcp.settings.log_level.lower())
+        else:
+            mcp.run(transport='streamable-http')
     else:
         mcp.run(transport='stdio')

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/server.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/server.py
@@ -217,12 +217,16 @@ def main():
         # under the configured credentials. To expose externally, set
         # --host 0.0.0.0 explicitly AND put an authenticated reverse
         # proxy in front. (S8.)
+        #
+        # Note: FastMCP.run() takes only `transport` and `mount_path` —
+        # host/port live on `mcp.settings`. Set them BEFORE run().
         if _config.host == '0.0.0.0':
             logger.warning(
                 'streamable-http bound to 0.0.0.0 — server has NO '
                 'built-in auth; ensure a reverse proxy / firewall '
                 'is in front')
-        mcp.run(transport='streamable-http',
-                host=_config.host, port=_config.port)
+        mcp.settings.host = _config.host
+        mcp.settings.port = _config.port
+        mcp.run(transport='streamable-http')
     else:
         mcp.run(transport='stdio')

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/server.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/server.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''
+Oracle Data Studio MCP Server.
+
+Creates a FastMCP server that exposes Essbase and ADP APIs as tools.
+Connects to configured services on startup via the lifespan pattern.
+'''
+
+from __future__ import annotations
+
+import sys
+import logging
+from contextlib import asynccontextmanager
+
+from mcp.server.fastmcp import FastMCP
+
+from .config import load_config, ServerConfig
+from .profiles import apply_profile
+
+# Logging to stderr (required for stdio transport)
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(name)s %(levelname)s %(message)s',
+    stream=sys.stderr)
+logger = logging.getLogger('oracle-data-studio-mcp')
+
+# Module-level config — set by main() before server starts
+_config: ServerConfig | None = None
+
+
+@asynccontextmanager
+async def app_lifespan(server: FastMCP):
+    '''Connect to Essbase and/or ADP at startup, yield context dict.'''
+    context: dict = {}
+
+    # -- Essbase --
+    if _config and _config.essbase:
+        try:
+            import essbase
+            cfg = _config.essbase
+            if cfg.token:
+                ess = essbase.login_token(cfg.url, cfg.token)
+                logger.info('Essbase connected (token) to %s', cfg.url)
+            else:
+                ess = essbase.login(cfg.url, cfg.user, cfg.password)
+                logger.info('Essbase connected to %s as %s',
+                            cfg.url, cfg.user)
+            context['essbase'] = ess
+        except Exception as e:
+            logger.error('Essbase connection failed: %s', e)
+    else:
+        logger.warning(
+            'Essbase not configured — set ESSBASE_URL + '
+            'ESSBASE_USER/ESSBASE_PASSWORD or ESSBASE_TOKEN')
+
+    # -- ADP --
+    if _config and _config.adp:
+        cfg = _config.adp
+        context['_adp_config'] = cfg          # stored for auto-reconnect
+        try:
+            import adp
+            adp_client = adp.login(cfg.url, cfg.user, cfg.password)
+            logger.info('ADP connected to %s as %s', cfg.url, cfg.user)
+            context['adp'] = adp_client
+        except Exception as e:
+            logger.error('ADP initial connection failed (will retry on '
+                         'first tool call): %s', e)
+    else:
+        logger.info(
+            'ADP not configured — set ADP_URL, ADP_USER, ADP_PASSWORD')
+
+    # -- Data Transforms --
+    # DT on ADBS is connected via adp.login()'s background thread which
+    # discovers OCI params (tenancy, ADW OCID) from dba_pdbs and uses the
+    # ADBS token flow.  We just store the config here for lazy retry;
+    # the first DT tool call will pick up the workbench from ADP or
+    # re-attempt the connection.
+    if _config and _config.datatransforms:
+        cfg = _config.datatransforms
+        context['_dt_config'] = cfg
+        logger.info('Data Transforms configured for %s — '
+                     'connection deferred to first tool call', cfg.url)
+    else:
+        logger.info(
+            'Data Transforms not configured — set DT_URL, DT_USER, DT_PASSWORD')
+
+    yield context
+
+
+# Server-level instructions. MCP clients forward these to the LLM as
+# part of its system context, shaping behavior across every tool call.
+# The goal: when querying a user-owned object, the LLM should first
+# fetch Oracle 23ai annotations so it uses the right units, aggregates,
+# join keys, and time grains — skipping this is the leading cause of
+# wrong answers (e.g. unit-conversion errors returning 100× values).
+SERVER_INSTRUCTIONS = """\
+Oracle Data Studio MCP — usage guidelines:
+
+ANNOTATION-FIRST SQL (ADP / Autonomous Database):
+Before writing or running SQL against ANY user table or view, call
+`adp_get_annotations(object_name=...)` to fetch its Oracle 23ai column
+and table annotations. Annotations carry semantic metadata the LLM
+cannot infer from column names alone:
+  - DESCRIPTION / DISPLAY_NAME — confirm table/column meaning
+  - UNIT — avoid unit mistakes (cents vs dollars, ms vs seconds, ...)
+  - AGGREGATE — use the intended aggregation function (SUM, AVG, ...)
+  - JOIN_HINT — prefer these keys when joining tables
+  - ROLE / GRAIN — honor time granularity (DAY / MONTH / YEAR)
+  - DATA_CLASS / PII — avoid PII columns unless explicitly requested
+
+If `adp_get_annotations` returns `annotation_count: 0` (pre-23ai or
+unannotated schema), fall back to `adp_search` with `include_ddl=True`.
+
+For natural-language questions, use the `adp_sql_with_annotations`
+prompt, then run the resulting SQL via the Oracle SQLcl MCP server.
+This MCP server does not auto-execute LLM-generated SQL — that's by
+design (annotations + your own LLM produces better results than
+in-database NL→SQL, and execution belongs to SQLcl).
+
+REPORT/AGGREGATE QUERY ROUTING (annotation-driven):
+For aggregate / report-style questions ("total/sum/average X by Y",
+"top N by …", "trend over time"), do NOT immediately run SQL against
+the fact table. The DBA can DECLARE the right query source via
+table-level annotations on the fact table. Routing convention:
+
+  Table annotations:
+    cube              — '<app>.<database>' Essbase cube ref
+    analytic_view     — '<av_name>' ADP Analytic View ref
+    preferred_source  — 'cube' | 'analytic_view' | 'table'
+
+  Column annotations (optional, refine the query):
+    cube_dimension    — '<dim_name>' (column → cube dim mapping)
+    cube_member       — '[Measures].[Sales]' (column → MDX member)
+
+Routing decision (call `adp_get_annotations(object_name=...)` first):
+  1. If `preferred_source='cube'` AND `cube` is set → query via
+     `essbase_query` against that app.database.
+  2. Else if `preferred_source='analytic_view'` AND `analytic_view`
+     is set → query via `adp_query_analytic_view`.
+  3. Else if `cube` is set (no preference) → cube wins (faster).
+  4. Else if `analytic_view` is set → AV.
+  5. Else fall back to SQL via the Oracle SQLcl MCP server's
+     `execute_sql`. The composite MCP intentionally does NOT expose
+     raw `run_query` or auto-executed Select-AI SQL — arbitrary SQL
+     belongs to SQLcl.
+
+This is DETERMINISTIC — no name-matching or guessing. The data
+engineer who built the cube/AV declares the mapping once on the
+source table, and every MCP client (Claude, Cursor, Codex)
+automatically routes correctly.
+
+If no routing annotations exist, only THEN fall back to discovery:
+  - `adp_manage_analytic_views(action='list')` — look for an AV
+    whose fact_table matches.
+  - `essbase_explore` — look for a cube with matching name/dims.
+Going to the raw fact table directly for a report-style question
+is both slower and silently loses business semantics.
+
+BOUNDARY:
+Pure SQL execution (arbitrary DDL/DML) is OUT OF SCOPE — use the
+Oracle SQLcl MCP server for that. Tools here focus on data-platform
+features: Analytic Views, Select AI, Insights, cloud loading,
+catalogs, data sharing, and annotation-aware query support.
+
+ESSBASE: use `essbase_query` (MDX), not ad-hoc SQL.
+DATA TRANSFORMS: always test connection before running a pipeline.
+"""
+
+# Create server instance
+mcp = FastMCP('oracle-data-studio',
+              instructions=SERVER_INSTRUCTIONS,
+              lifespan=app_lifespan)
+
+
+# ------------------------------------------------------------------ #
+#  Register all tool modules                                          #
+# ------------------------------------------------------------------ #
+
+from .tools import (  # noqa: E402
+    essbase_tools,
+    adp_tools,
+    dt_tools,
+)
+
+_tool_modules = [
+    essbase_tools,
+    adp_tools,
+    dt_tools,
+]
+
+for _mod in _tool_modules:
+    _mod.register_tools(mcp)
+
+
+# ------------------------------------------------------------------ #
+#  Entry point                                                        #
+# ------------------------------------------------------------------ #
+
+def main():
+    '''Parse config and start the MCP server.'''
+    global _config
+    _config = load_config()
+
+    # Apply tool access profile (must be after tool registration)
+    apply_profile(mcp, _config.profile)
+
+    logger.info('Starting Oracle Data Studio MCP server '
+                '(transport=%s, profile=%s)',
+                _config.transport, _config.profile)
+
+    if _config.transport == 'streamable-http':
+        # Default bind: 127.0.0.1 (loopback). The server has no
+        # built-in auth — anyone who reaches the port gets full access
+        # under the configured credentials. To expose externally, set
+        # --host 0.0.0.0 explicitly AND put an authenticated reverse
+        # proxy in front. (S8.)
+        if _config.host == '0.0.0.0':
+            logger.warning(
+                'streamable-http bound to 0.0.0.0 — server has NO '
+                'built-in auth; ensure a reverse proxy / firewall '
+                'is in front')
+        mcp.run(transport='streamable-http',
+                host=_config.host, port=_config.port)
+    else:
+        mcp.run(transport='stdio')

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/server.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/server.py
@@ -19,6 +19,7 @@ from mcp.server.fastmcp import FastMCP
 
 from .config import load_config, ServerConfig
 from .profiles import apply_profile
+from .tools._helpers import wrap_mutating_tools_with_audit
 
 # Logging to stderr (required for stdio transport)
 logging.basicConfig(
@@ -206,6 +207,12 @@ def main():
 
     # Apply tool access profile (must be after tool registration)
     apply_profile(mcp, _config.profile)
+
+    # Wire audit logging for every mutating / executing tool. The
+    # wrapper emits a single INFO line on the 'oracle-data-studio-mcp.audit'
+    # logger for every call so operators retain a who/what/when trail.
+    n_audited = wrap_mutating_tools_with_audit(mcp, profile=_config.profile)
+    logger.info('Audit logging wired for %d mutating tools', n_audited)
 
     logger.info('Starting Oracle Data Studio MCP server '
                 '(transport=%s, profile=%s)',

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/__init__.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
@@ -2004,7 +2004,8 @@ class TestEssbaseToolDispatch:
         ess = MagicMock()
         ess.groups.remove_users.return_value = {'status': 'ok'}
         ctx = self._make_ctx(ess)
-        json.loads(fn(action='remove_users', group_id='G', ctx=ctx))
+        json.loads(fn(action='remove_users', group_id='G',
+                       confirm='G', ctx=ctx))
         ess.groups.remove_users.assert_called_once_with('G')
 
     def test_essbase_manage_groups_add_subgroups(self):
@@ -2560,7 +2561,7 @@ class TestEssbaseToolDispatch:
         ctx = self._make_ctx(ess)
         json.loads(fn(app_name='A', db_name='D',
                        action='remove', member_name='Q1',
-                       ctx=ctx))
+                       confirm='Q1', ctx=ctx))
         # Verify the remove action carries actionType=removeMember (case
         # may differ — check it's a remove)
         call_args = ess.dimensions.batch_outline_edit.call_args
@@ -4055,7 +4056,7 @@ ADP_DISPATCH_CASES = [
      'Catalog.enable_catalog'),
     ('adp_manage_catalog', {'action': 'disable', 'catalog_name': 'C'},
      'Catalog.disable_catalog'),
-    ('adp_manage_catalog', {'action': 'unmount', 'catalog_name': 'C'},
+    ('adp_manage_catalog', {'action': 'unmount', 'catalog_name': 'C', 'confirm': 'C'},
      'Catalog.unmount_catalog'),
     # adp_manage_sharing
     ('adp_manage_sharing', {'action': 'list'},
@@ -4064,7 +4065,7 @@ ADP_DISPATCH_CASES = [
      'Share.get_share'),
     ('adp_manage_sharing', {'action': 'create', 'share_name': 'S'},
      'Share.create_share'),
-    ('adp_manage_sharing', {'action': 'delete', 'share_name': 'S'},
+    ('adp_manage_sharing', {'action': 'delete', 'share_name': 'S', 'confirm': 'S'},
      'Share.delete_share'),
     ('adp_manage_sharing', {'action': 'unpublish', 'share_name': 'S'},
      'Share.unpublish_share'),
@@ -4074,7 +4075,7 @@ ADP_DISPATCH_CASES = [
     ('adp_manage_sharing', {'action': 'list_recipients'},
      'Share.get_recipients'),
     ('adp_manage_sharing', {'action': 'delete_recipient',
-                             'recipient_name': 'R'},
+                             'recipient_name': 'R', 'confirm': 'R'},
      'Share.delete_recipient'),
     ('adp_manage_sharing', {'action': 'get_objects', 'share_name': 'S'},
      'Share.get_share_objects'),
@@ -4087,7 +4088,7 @@ ADP_DISPATCH_CASES = [
                              'recipient_name': 'P'},
      'Share.create_provider'),
     ('adp_manage_sharing', {'action': 'delete_provider',
-                             'recipient_name': 'P'},
+                             'recipient_name': 'P', 'confirm': 'P'},
      'Share.delete_provider'),
     # adp_manage_analytic_views
     ('adp_manage_analytic_views', {'action': 'list'},
@@ -4109,7 +4110,7 @@ ADP_DISPATCH_CASES = [
                                   'private_key': 'k',
                                   'fingerprint': 'f'},
      'Ingest.create_ocid_credential'),
-    ('adp_manage_credentials', {'action': 'drop', 'credential_name': 'C'},
+    ('adp_manage_credentials', {'action': 'drop', 'credential_name': 'C', 'confirm': 'C'},
      'Ingest.drop_credential'),
     ('adp_manage_credentials', {'action': 'list_storage_links'},
      'Ingest.get_cloud_storage_link_list'),
@@ -4119,7 +4120,7 @@ ADP_DISPATCH_CASES = [
                                   'credential_name': 'C'},
      'Ingest.create_cloud_storage_link'),
     ('adp_manage_credentials', {'action': 'drop_storage_link',
-                                  'storage_link_name': 'SL'},
+                                  'storage_link_name': 'SL', 'confirm': 'SL'},
      'Ingest.drop_cloud_storage_link'),
     # adp_manage_insights
     ('adp_manage_insights', {'action': 'list_requests'},
@@ -4129,7 +4130,7 @@ ADP_DISPATCH_CASES = [
      'Insight.get_insights_list'),
     ('adp_manage_insights', {'action': 'status', 'request_name': 'R'},
      'Insight.get_job_status'),
-    ('adp_manage_insights', {'action': 'drop', 'request_name': 'R'},
+    ('adp_manage_insights', {'action': 'drop', 'request_name': 'R', 'confirm': 'R'},
      'Insight.drop'),
     # adp_manage_db_links
     ('adp_manage_db_links', {'action': 'list'},
@@ -4192,7 +4193,7 @@ ADP_DISPATCH_CASES = [
     ('adp_manage_db_links', {'action': 'link_tables',
                               'db_link_name': 'L', 'tables': 'T1'},
      'Ingest.link_tables_from_db_link'),
-    ('adp_manage_db_links', {'action': 'drop', 'db_link_name': 'L'},
+    ('adp_manage_db_links', {'action': 'drop', 'db_link_name': 'L', 'confirm': 'L'},
      'Catalog.drop_database_link'),
     # adp_manage_insights get_graph
     ('adp_manage_insights', {'action': 'get_graph',
@@ -4225,7 +4226,7 @@ DT_DISPATCH_CASES = [
      'list_schedules', False),
     ('dt_manage_schedule', {'action': 'delete',
                               'schedule_name': 'S',
-                              'project_name': 'P'},
+                              'project_name': 'P', 'confirm': 'S'},
      'delete_schedule', False),
     # dt_manage_variables (set creates new variable when not found)
     ('dt_manage_variables', {'action': 'list'},
@@ -4237,7 +4238,7 @@ DT_DISPATCH_CASES = [
      'get_connection_types', False),
     ('dt_manage_connection', {'action': 'test', 'connection_name': 'C'},
      'test_connection_by_name', False),
-    ('dt_manage_connection', {'action': 'delete', 'connection_name': 'C'},
+    ('dt_manage_connection', {'action': 'delete', 'connection_name': 'C', 'confirm': 'C'},
      'delete_connection', False),
     # dt_manage_dataload
     ('dt_manage_dataload', {'action': 'list', 'project_name': 'P'},
@@ -4343,7 +4344,7 @@ ESS_DISPATCH_CASES = [
      'files.list_files'),
     ('essbase_manage_files', {'action': 'create_folder', 'path': '/p'},
      'files.create_folder'),
-    ('essbase_manage_files', {'action': 'delete', 'path': '/x'},
+    ('essbase_manage_files', {'action': 'delete', 'path': '/x', 'confirm': '/x'},
      'files.delete_file'),
     ('essbase_manage_files', {'action': 'copy', 'path': '/a',
                                 'target_path': '/b'},
@@ -4382,7 +4383,7 @@ ESS_DISPATCH_CASES = [
      'scripts.update_script'),
     ('essbase_manage_script', {'action': 'delete',
                                  'app_name': 'A', 'db_name': 'D',
-                                 'script_name': 'S'},
+                                 'script_name': 'S', 'confirm': 'S'},
      'scripts.delete_script'),
     ('essbase_manage_script', {'action': 'validate',
                                  'app_name': 'A', 'db_name': 'D',
@@ -4396,7 +4397,7 @@ ESS_DISPATCH_CASES = [
                                        'connection_name': 'C'},
      'connections.get_connection'),
     ('essbase_manage_connections', {'action': 'delete',
-                                       'connection_name': 'C'},
+                                       'connection_name': 'C', 'confirm': 'C'},
      'connections.delete_connection'),
     # essbase_manage_filters
     ('essbase_manage_filters', {'action': 'list',
@@ -4408,7 +4409,7 @@ ESS_DISPATCH_CASES = [
      'filters.get_filter'),
     ('essbase_manage_filters', {'action': 'delete',
                                   'app_name': 'A', 'db_name': 'D',
-                                  'filter_name': 'F'},
+                                  'filter_name': 'F', 'confirm': 'F'},
      'filters.delete_filter'),
     ('essbase_manage_filters', {'action': 'rename',
                                   'app_name': 'A', 'db_name': 'D',
@@ -4422,7 +4423,7 @@ ESS_DISPATCH_CASES = [
     # rerun also calls wait_for_completion — assert on rerun
     ('essbase_manage_jobs', {'action': 'rerun', 'job_id': 1},
      'jobs.rerun'),
-    ('essbase_manage_jobs', {'action': 'purge'},
+    ('essbase_manage_jobs', {'action': 'purge', 'confirm': 'all'},
      'jobs.purge'),
     # essbase_manage_datasources (no app_name / db_name params)
     ('essbase_manage_datasources', {'action': 'list'},
@@ -4431,7 +4432,7 @@ ESS_DISPATCH_CASES = [
                                        'datasource_name': 'DS'},
      'datasources.get_datasource'),
     ('essbase_manage_datasources', {'action': 'delete',
-                                       'datasource_name': 'DS'},
+                                       'datasource_name': 'DS', 'confirm': 'DS'},
      'datasources.delete_datasource'),
     # essbase_manage_drill_through
     ('essbase_manage_drill_through', {'action': 'list',
@@ -4443,7 +4444,7 @@ ESS_DISPATCH_CASES = [
      'drill_through.get_report'),
     ('essbase_manage_drill_through', {'action': 'delete',
                                          'app_name': 'A', 'db_name': 'D',
-                                         'report_name': 'R'},
+                                         'report_name': 'R', 'confirm': 'R'},
      'drill_through.delete_report'),
     # essbase_manage_users
     ('essbase_manage_users', {'action': 'list'},
@@ -4478,7 +4479,7 @@ ESS_DISPATCH_CASES = [
      'groups.list_groups'),
     ('essbase_manage_groups', {'action': 'get', 'group_id': 'G'},
      'groups.get_group'),
-    ('essbase_manage_groups', {'action': 'delete', 'group_id': 'G'},
+    ('essbase_manage_groups', {'action': 'delete', 'group_id': 'G', 'confirm': 'G'},
      'groups.delete_group'),
     ('essbase_manage_groups', {'action': 'get_users', 'group_id': 'G'},
      'groups.get_users'),
@@ -4527,7 +4528,7 @@ ESS_DISPATCH_CASES = [
                                 'parent_name': 'P'},
      'dimensions.batch_outline_edit'),
     ('essbase_edit_outline', {'app_name': 'A', 'db_name': 'D',
-                                'action': 'remove', 'member_name': 'M'},
+                                'action': 'remove', 'member_name': 'M', 'confirm': 'M'},
      'dimensions.batch_outline_edit'),
     ('essbase_edit_outline', {'app_name': 'A', 'db_name': 'D',
                                 'action': 'rename', 'member_name': 'M',

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
@@ -977,6 +977,106 @@ class TestAdpConnect:
             other = {}
             assert ac._ctx_lock(other) is not lock1
 
+    def test_run_adp_success(self):
+        '''run_adp returns the formatted result on success.'''
+        from oracle.data_studio_mcp_server.tools._adp_connect import (
+            run_adp)
+        ctx = MagicMock()
+        adp = MagicMock()
+        adp.rest.expired = None
+        ctx.request_context.lifespan_context = {'adp': adp}
+        result = run_adp(ctx, lambda c: {'rows': [1, 2]})
+        assert json.loads(result)['rows'] == [1, 2]
+
+    def test_run_adp_no_client_returns_error(self):
+        from oracle.data_studio_mcp_server.tools._adp_connect import (
+            run_adp)
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {}
+        result = json.loads(run_adp(ctx, lambda c: 'should not run'))
+        assert 'error' in result
+
+    def test_run_adp_returns_strings_unchanged(self):
+        '''_default_format returns string results as-is.'''
+        from oracle.data_studio_mcp_server.tools._adp_connect import (
+            run_adp)
+        ctx = MagicMock()
+        adp = MagicMock()
+        adp.rest.expired = None
+        ctx.request_context.lifespan_context = {'adp': adp}
+        result = run_adp(ctx, lambda c: 'plain string')
+        assert result == 'plain string'
+
+    def test_run_adp_reconnects_on_expired_then_succeeds(self):
+        '''When fn raises 'expired', run_adp reconnects and retries.'''
+        from oracle.data_studio_mcp_server.tools import _adp_connect as ac
+        ctx = MagicMock()
+        cfg = MagicMock(url='https://x', user='u', password='p')
+        adp_old = MagicMock()
+        adp_old.rest.expired = None
+        ctx.request_context.lifespan_context = {
+            'adp': adp_old, '_adp_config': cfg}
+
+        # First call raises 'expired', second call returns success.
+        calls = {'n': 0}
+        def fn(c):
+            calls['n'] += 1
+            if calls['n'] == 1:
+                raise RuntimeError('session expired')
+            return 'recovered'
+
+        with patch.object(ac, '_locks', {}), \
+             patch('builtins.__import__') as imp:
+            fake_adp = MagicMock()
+            fresh = MagicMock()
+            fresh.rest.expired = None
+            fake_adp.login.return_value = fresh
+            imp.side_effect = lambda name, *a, **kw: (
+                fake_adp if name == 'adp'
+                else __import__(name, *a, **kw))
+            result = ac.run_adp(ctx, fn)
+        assert result == 'recovered'
+        assert calls['n'] == 2
+
+    def test_run_adp_propagates_non_expired_error(self):
+        '''Non-expired exceptions go through safe_err and become an
+        error JSON, not a reconnect.'''
+        from oracle.data_studio_mcp_server.tools._adp_connect import (
+            run_adp)
+        ctx = MagicMock()
+        adp = MagicMock()
+        adp.rest.expired = None
+        ctx.request_context.lifespan_context = {'adp': adp}
+        def fn(c):
+            raise RuntimeError('ORA-00942: table or view does not exist')
+        result = json.loads(run_adp(ctx, fn))
+        assert 'error' in result
+        assert 'ORA-00942' in result['error']
+
+    def test_get_adp_proactive_reconnect_on_expiry(self):
+        '''If the cached client's token is past expiry, get_adp
+        proactively reconnects without waiting for an exception.'''
+        from oracle.data_studio_mcp_server.tools import _adp_connect as ac
+        from datetime import datetime, timedelta
+        old = MagicMock()
+        old.rest.expired = datetime.now() - timedelta(minutes=5)
+        cfg = MagicMock(url='x', user='u', password='p')
+        lc = {'adp': old, '_adp_config': cfg}
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = lc
+
+        with patch.object(ac, '_locks', {}), \
+             patch('builtins.__import__') as imp:
+            fake_adp = MagicMock()
+            fresh = MagicMock()
+            fresh.rest.expired = None
+            fake_adp.login.return_value = fresh
+            imp.side_effect = lambda name, *a, **kw: (
+                fake_adp if name == 'adp'
+                else __import__(name, *a, **kw))
+            client = ac.get_adp(ctx)
+        assert client is fresh
+
     def test_reconnect_avoids_duplicate_login_when_already_done(self):
         '''S7: If two threads both notice an expired client and call
         _reconnect, only the first should do the login work — the
@@ -1023,6 +1123,112 @@ class TestDtConnect:
         mock_ctx = MagicMock()
         mock_ctx.request_context.lifespan_context = {}
         assert get_dt(mock_ctx) is None
+
+    def test_get_dt_strategy1_from_adp_thread(self):
+        '''Strategy 1: adp_client.dt is already populated by adp.login()'s
+        background thread.'''
+        from oracle.data_studio_mcp_server.tools._dt_connect import get_dt
+        mock_ctx = MagicMock()
+        adp_client = MagicMock()
+        wb = MagicMock()
+        wb.get_client.return_value = 'dt-client'
+        adp_client.dt = wb
+        adp_client.wait_for_datatransforms.return_value = None
+        cfg = MagicMock(url='https://x', user='u', password='p')
+        lc = {'_dt_config': cfg, 'adp': adp_client}
+        mock_ctx.request_context.lifespan_context = lc
+
+        result = get_dt(mock_ctx)
+        assert result is not None
+        assert result['workbench'] is wb
+        assert result['client'] == 'dt-client'
+        # Cached for subsequent calls
+        assert lc['datatransforms'] is result
+        adp_client.wait_for_datatransforms.assert_called_once()
+
+    def test_get_dt_strategy2_adbs_connect(self):
+        '''Strategy 2: ADBS-token connect using dba_pdbs OCI params.'''
+        from oracle.data_studio_mcp_server.tools import _dt_connect as dc
+        mock_ctx = MagicMock()
+        adp_client = MagicMock()
+        # No `.dt` attribute → strategy 1 fails
+        adp_client.dt = None
+        adp_client.wait_for_datatransforms.return_value = None
+        adp_client.Misc.run_query.return_value = [{
+            'database_name': 'mydb',
+            'cloud_database_name': 'ocid1.adw.oc1..xxx',
+            'tenant_name': 'ocid1.tenancy.oc1..yyy',
+        }]
+        cfg = MagicMock(url='https://x', user='u', password='p')
+        lc = {'_dt_config': cfg, 'adp': adp_client}
+        mock_ctx.request_context.lifespan_context = lc
+
+        fake_module = MagicMock()
+        fake_wb = MagicMock()
+        fake_wb.get_client.return_value = 'dt-client'
+        fake_module.DataTransformsWorkbench.return_value = fake_wb
+        with patch.dict('sys.modules',
+                         {'datatransforms.workbench': fake_module,
+                          'datatransforms.client': MagicMock()}):
+            result = dc.get_dt(mock_ctx)
+        assert result is not None
+        assert result['workbench'] is fake_wb
+        # Verify the connect_workbench call carried OCI params from dba_pdbs
+        call_args = fake_wb.connect_workbench.call_args[0][0]
+        assert call_args['tenancy_ocid'] == 'ocid1.tenancy.oc1..yyy'
+        assert call_args['adw_name'] == 'mydb'
+        assert call_args['xforms_url'] == 'https://x'
+
+    def test_get_dt_strategy3_simple_connect(self):
+        '''Strategy 3: simple URL+Basic auth fallback when ADBS path
+        fails (e.g. no `dba_pdbs` access).'''
+        from oracle.data_studio_mcp_server.tools import _dt_connect as dc
+        mock_ctx = MagicMock()
+        # No adp_client at all → strategies 1 + 2 fail
+        cfg = MagicMock(url='https://x', user='u', password='p')
+        lc = {'_dt_config': cfg, 'adp': None}
+        mock_ctx.request_context.lifespan_context = lc
+
+        fake_module = MagicMock()
+        fake_wb = MagicMock()
+        fake_wb.get_client.return_value = 'dt-client'
+        fake_module.DataTransformsWorkbench.return_value = fake_wb
+        with patch.dict('sys.modules',
+                         {'datatransforms.workbench': fake_module,
+                          'datatransforms.client': MagicMock()}):
+            result = dc.get_dt(mock_ctx)
+        assert result is not None
+        # Strategy 3 connect payload doesn't include OCI params
+        call_args = fake_wb.connect_workbench.call_args[0][0]
+        assert 'tenancy_ocid' not in call_args
+        assert call_args['data_transforms_url'] == 'https://x'
+
+    def test_get_dt_all_strategies_fail_returns_none(self):
+        '''If every strategy raises, get_dt returns None and logs.'''
+        from oracle.data_studio_mcp_server.tools import _dt_connect as dc
+        mock_ctx = MagicMock()
+        cfg = MagicMock(url='https://x', user='u', password='p')
+        lc = {'_dt_config': cfg, 'adp': None}
+        mock_ctx.request_context.lifespan_context = lc
+
+        fake_module = MagicMock()
+        fake_wb = MagicMock()
+        fake_wb.connect_workbench.side_effect = RuntimeError('boom')
+        fake_module.DataTransformsWorkbench.return_value = fake_wb
+        with patch.dict('sys.modules',
+                         {'datatransforms.workbench': fake_module,
+                          'datatransforms.client': MagicMock()}):
+            assert dc.get_dt(mock_ctx) is None
+        # No cache was populated
+        assert 'datatransforms' not in lc
+
+    def test_reset_singletons_handles_missing_module(self):
+        '''_reset_singletons must not raise when datatransforms isn't
+        installed.'''
+        from oracle.data_studio_mcp_server.tools._dt_connect import (
+            _reset_singletons)
+        # Should silently no-op; nothing in sys.modules to break
+        _reset_singletons()
 
 
 # ------------------------------------------------------------------ #
@@ -1207,6 +1413,322 @@ class TestEssbaseToolDispatch:
         ctx = self._make_ctx(ess)
         result = json.loads(fn(app_name='S', db_name='B', ctx=ctx))
         assert 'error' in result
+
+    def test_essbase_run_calculation_full_flow_with_calc_script(self):
+        '''Inline calc_script path: jobs.execute → wait_for_completion.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_run_calculation'].fn
+
+        ess = MagicMock()
+        ess.jobs.execute.return_value = {'id': 42}
+        ess.jobs.wait_for_completion.return_value = {
+            'status': 200, 'jobID': 42}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='S', db_name='B',
+                                calc_script='CALC ALL;', ctx=ctx))
+        # The execute call carried the inline script payload
+        payload = ess.jobs.execute.call_args[0][0]
+        assert payload['parameters']['script'] == 'CALC ALL;'
+        ess.jobs.wait_for_completion.assert_called_once_with(42)
+
+    def test_essbase_load_data_full_flow(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_load_data'].fn
+
+        ess = MagicMock()
+        ess.jobs.execute.return_value = {'id': 7}
+        ess.jobs.wait_for_completion.return_value = {'status': 200}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='A', db_name='D',
+                                rule_file='r.rul',
+                                data_file='d.txt', ctx=ctx))
+        payload = ess.jobs.execute.call_args[0][0]
+        assert payload['jobtype'] == 'dataload'
+        assert payload['parameters']['rule'] == 'r.rul'
+        assert payload['parameters']['file'] == 'd.txt'
+
+    def test_essbase_deploy_workbook_uploads_and_runs_job(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_deploy_workbook'].fn
+
+        ess = MagicMock()
+        ess.jobs.execute.return_value = {'id': 9}
+        ess.jobs.wait_for_completion.return_value = {'status': 200}
+        ctx = self._make_ctx(ess)
+        # We can't easily mock open() here — tool likely opens the file
+        # to upload. Use a small temp file for realism.
+        import tempfile, os
+        with tempfile.NamedTemporaryFile('wb', suffix='.xlsx',
+                                            delete=False) as f:
+            f.write(b'PK fake xlsx content')
+            tmp = f.name
+        try:
+            result = json.loads(fn(app_name='A', file_path=tmp, ctx=ctx))
+        finally:
+            os.unlink(tmp)
+        # Some flavor of execute or upload should have been called
+        assert (ess.files.upload.called or ess.jobs.execute.called)
+
+    def test_essbase_describe_database_full_flow(self):
+        '''Walks the multi-call composite — verifies all SDK probes
+        were issued.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_describe_database'].fn
+
+        ess = MagicMock()
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='A', db_name='D', ctx=ctx))
+        ess.applications.get_database.assert_called_once_with('A', 'D')
+        # Many other probes happen via safe_call — at least one ran
+        assert ess.dimensions.list_dimensions.called
+
+    def test_essbase_manage_security_username(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_security'].fn
+
+        ess = MagicMock()
+        ess.users.get_user.return_value = {'id': 'alice'}
+        ess.users.get_user_provisioning_report.return_value = {'apps': []}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(username='alice', ctx=ctx))
+        ess.users.get_user.assert_called_once_with('alice')
+
+    def test_essbase_manage_security_groupname(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_security'].fn
+
+        ess = MagicMock()
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(group_name='developers', ctx=ctx))
+        ess.groups.get_group.assert_called_once_with('developers')
+
+    def test_essbase_manage_filters_create(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_filters'].fn
+
+        ess = MagicMock()
+        ess.filters.create_filter.return_value = {'name': 'F'}
+        ess.filters.validate_filter.return_value = {'valid': True}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(action='create', app_name='A',
+                                db_name='D', filter_name='F',
+                                filter_rows='READ,@IDESCENDANTS(East)',
+                                ctx=ctx))
+        ess.filters.create_filter.assert_called_once()
+        # Auto-validate after create
+        ess.filters.validate_filter.assert_called_once()
+
+    def test_essbase_manage_drill_through_create(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_drill_through'].fn
+
+        ess = MagicMock()
+        ess.drill_through.create_report.return_value = {'name': 'R'}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(action='create', app_name='A', db_name='D',
+                                report_name='R', connection='C',
+                                sql_query='SELECT 1 FROM dual',
+                                columns='A,B,C',
+                                drillable_regions='@IDESCENDANTS(East)',
+                                ctx=ctx))
+        ess.drill_through.create_report.assert_called_once()
+
+    def test_essbase_manage_db_settings_reads_categories(self):
+        '''category='all' fans out across multiple settings probes.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_db_settings'].fn
+
+        ess = MagicMock()
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='A', db_name='D',
+                                category='all', ctx=ctx))
+        # At least the headline get_settings call ran
+        assert (ess.database_settings.get_settings.called
+                or ess.database_settings.get_startup_settings.called)
+
+    def test_essbase_manage_db_settings_specific_categories(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_db_settings'].fn
+
+        ess = MagicMock()
+        # Make every settings method return a dict so the tool's
+        # json.dumps doesn't choke on a MagicMock repr.
+        for m in ['get_settings', 'get_startup_settings',
+                  'get_calculation_settings', 'get_cache_settings',
+                  'get_compression_settings', 'get_transaction_settings',
+                  'get_buffer_settings', 'get_attribute_settings',
+                  'get_runtime_statistics', 'get_storage_statistics',
+                  'get_size_statistics', 'get_aso_compression_info',
+                  'get_date_formats']:
+            getattr(ess.database_settings, m).return_value = {}
+        ctx = self._make_ctx(ess)
+        for cat in ['startup', 'calculation', 'cache', 'compression',
+                     'transactions']:
+            json.loads(fn(app_name='A', db_name='D',
+                           category=cat, ctx=ctx))
+
+    def test_essbase_outline_metadata_all_category(self):
+        '''category='all' walks dimensions, generations, levels, settings.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_outline_metadata'].fn
+
+        ess = MagicMock()
+        ess.dimensions.list_dimensions.return_value = {
+            'items': [{'name': 'Year'}, {'name': 'Region'}]}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='A', db_name='D',
+                                category='all', ctx=ctx))
+        ess.dimensions.list_dimensions.assert_called_once()
+
+    def test_essbase_browse_outline_with_parent_recursive(self):
+        '''Specifying a parent triggers recursive get_children walk.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_browse_outline'].fn
+
+        ess = MagicMock()
+        # Return an empty children list to terminate recursion fast
+        ess.dimensions.get_children.return_value = {'items': []}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='A', db_name='D',
+                                parent='Year', depth=2, ctx=ctx))
+        ess.dimensions.get_children.assert_called()
+
+    def test_essbase_search_members_enriches_with_ancestors(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_search_members'].fn
+
+        ess = MagicMock()
+        ess.dimensions.search_members.return_value = {
+            'items': [{'name': 'Sales'}]}
+        ess.dimensions.get_member_ancestors.return_value = {
+            'ancestors': ['Measures']}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='A', db_name='D',
+                                pattern='Sales', ctx=ctx))
+        ess.dimensions.search_members.assert_called_once()
+        ess.dimensions.get_member_ancestors.assert_called()
+        assert result['count'] == 1
+
+    def test_essbase_manage_filters_update_with_validate(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_filters'].fn
+
+        ess = MagicMock()
+        ess.filters.update_filter.return_value = {'name': 'F'}
+        ess.filters.validate_filter.return_value = {'valid': True}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(action='update', app_name='A',
+                                db_name='D', filter_name='F',
+                                filter_rows='READ,@CHILDREN(East)',
+                                ctx=ctx))
+        ess.filters.update_filter.assert_called_once()
+        ess.filters.validate_filter.assert_called_once()
+
+    def test_essbase_manage_users_provision_app_role(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_users'].fn
+
+        ess = MagicMock()
+        ess.users.provision_app_role.return_value = {'status': 'ok'}
+        ctx = self._make_ctx(ess)
+        # With app_name → app-role provisioning
+        fn(action='provision', user_id='alice',
+            role='power_user', app_name='Sample', ctx=ctx)
+        assert ess.users.provision_app_role.called
+
+    def test_essbase_manage_users_provision_service_role(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_users'].fn
+
+        ess = MagicMock()
+        ess.users.provision_service_role.return_value = {'status': 'ok'}
+        ctx = self._make_ctx(ess)
+        # No app_name → service-level
+        fn(action='provision', user_id='alice',
+            role='service_administrator', ctx=ctx)
+        assert ess.users.provision_service_role.called
+
+    def test_essbase_edit_outline_builds_payload(self):
+        '''Verify the BOE payload shape for an `add` action.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_edit_outline'].fn
+
+        ess = MagicMock()
+        ess.dimensions.batch_outline_edit.return_value = {'status': 'ok'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(app_name='A', db_name='D',
+                       action='add', member_name='Q1',
+                       parent_name='Year', ctx=ctx))
+        call_args = ess.dimensions.batch_outline_edit.call_args
+        payload = call_args[0][2] if len(call_args[0]) >= 3 else call_args[0][-1]
+        # payload contains an editActions list with one add entry
+        assert 'editActions' in payload
+        assert payload['editActions'][0]['actionType'].lower().startswith('add')
+
+    def test_essbase_export_data_default_grid(self):
+        '''When no MDX or report given, export uses get_default_grid.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_export_data'].fn
+
+        ess = MagicMock()
+        ess.grid.get_default_grid.return_value = {'data': []}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(app_name='A', db_name='D', ctx=ctx))
+        ess.grid.get_default_grid.assert_called_once()
 
 
 # ------------------------------------------------------------------ #
@@ -1399,6 +1921,131 @@ class TestAdpToolDispatch:
         adp_tools.register_tools(mcp_server)
         names = mcp_server._tool_manager._tools.keys()
         assert 'adp_ai_query' not in names
+
+    def test_adp_search_with_include_ddl_walks_top_hits(self):
+        '''include_ddl=True triggers a per-hit DDL fetch.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_search'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Misc.global_search.return_value = json.dumps({
+            'nodes': [{'data': {'name': 'EMP'}},
+                      {'data': {'name': 'DEPT'}}]})
+        adp.Misc.get_entity_ddl.return_value = 'CREATE TABLE EMP ...'
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(search_term='E', include_ddl=True, ctx=ctx))
+        # DDL fetched for top hits
+        assert adp.Misc.get_entity_ddl.call_count >= 1
+
+    def test_adp_load_from_cloud_full_flow(self):
+        '''Full flow: validates credential + storage link, then loads.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_load_from_cloud'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Ingest.get_credential_list.return_value = json.dumps([
+            {'CREDENTIAL_NAME': 'CR'}])
+        adp.Ingest.get_consumer_groups.return_value = json.dumps([
+            {'GROUP_NAME': 'LOW'}])
+        adp.Ingest.copy_cloud_objects.return_value = json.dumps(
+            {'request_id': 'R123'})
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(storage_link='SL',
+                                object_name='sales.csv',
+                                target_table='SALES_RAW',
+                                ctx=ctx))
+        adp.Ingest.copy_cloud_objects.assert_called_once()
+
+    def test_adp_load_from_cloud_progress_only(self):
+        '''When request_id is given, just polls progress.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_load_from_cloud'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Ingest.cloud_progress_status.return_value = json.dumps(
+            {'percent': 75})
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(request_id='R123', ctx=ctx))
+        adp.Ingest.cloud_progress_status.assert_called_once_with('R123')
+
+    def test_adp_build_analytic_view_full_flow(self):
+        '''Walks create_auto → compile → metadata → preview.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_build_analytic_view'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Analytics.create_auto.return_value = json.dumps(
+            {'name': 'SALES_AV'})
+        adp.Analytics.compile.return_value = json.dumps({'compiled': True})
+        adp.Analytics.get_metadata.return_value = json.dumps(
+            {'measures': []})
+        adp.Analytics.get_data_preview.return_value = json.dumps(
+            [{'row': 1}])
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(fact_table='SALES', ctx=ctx))
+        adp.Analytics.create_auto.assert_called_once_with('SALES')
+        adp.Analytics.compile.assert_called()
+        adp.Analytics.get_metadata.assert_called()
+        adp.Analytics.get_data_preview.assert_called()
+
+    def test_adp_analyze_analytic_view_walks_quality(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_analyze_analytic_view'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Analytics.is_exist.return_value = True
+        adp.Analytics.get_metadata.return_value = json.dumps({})
+        adp.Analytics.get_measures_list.return_value = json.dumps([])
+        adp.Analytics.get_dimension_names.return_value = json.dumps([])
+        adp.Analytics.quality_report.return_value = json.dumps([])
+        adp.Analytics.get_error_classes_dim.return_value = json.dumps([])
+        adp.Analytics.get_error_classes_fact.return_value = json.dumps([])
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(av_name='AV', ctx=ctx))
+        adp.Analytics.quality_report.assert_called()
+
+    def test_adp_generate_insights_polls_status(self):
+        '''generate_insights kicks off the job + polls + collects graph.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_generate_insights'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Insight.generate.return_value = json.dumps(
+            {'request_id': 'R1'})
+        adp.Insight.get_job_status.return_value = json.dumps(
+            {'status': 'COMPLETED'})
+        adp.Insight.get_insights_list.return_value = json.dumps(
+            [{'name': 'I1'}])
+        adp.Insight.get_graph_details.return_value = json.dumps(
+            {'graph': 'data'})
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(object_name='SALES', measure='AMT',
+                                ctx=ctx))
+        adp.Insight.generate.assert_called_once()
 
     def test_adp_get_annotations_groups_by_column(self):
         '''Verify adp_get_annotations groups rows into table vs column
@@ -1632,6 +2279,267 @@ class TestDtToolDispatch:
         result = json.loads(fn(connection_name='myconn', ctx=ctx))
         assert result['schemas'] == ['schema1', 'schema2']
 
+    def test_dt_browse_data_with_schema_filter(self):
+        '''When schema is specified, dt_browse_data calls
+        get_live_tables for that schema.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_browse_data'].fn
+
+        client = MagicMock()
+        client.get_live_tables.return_value = ['T1', 'T2']
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(connection_name='C',
+                                schema='S', ctx=ctx))
+        client.get_live_tables.assert_called_once_with('C', 'S')
+
+    def test_dt_create_pipeline_creates_project_when_missing(self):
+        '''If the project doesn't exist, dt_create_pipeline creates it
+        first, then proceeds with the dataflow build.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_create_pipeline'].fn
+
+        client = MagicMock()
+        # First call: project doesn't exist; second call after create: exists
+        client.check_if_project_exists.side_effect = [None, 'proj-1']
+        wb = MagicMock()
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {
+            'datatransforms': {'client': client, 'workbench': wb}}
+        # The body falls back to client.create_dataflow_from_json_payload
+        # if the SDK builders aren't importable; with our MagicMock
+        # workbench, the import succeeds via MagicMock too. Just assert
+        # the project-create probe ran.
+        try:
+            fn(project_name='NewProj',
+                source_connection='SRC_CONN', source_schema='SRC_S',
+                source_table='SRC',
+                target_connection='TGT_CONN', target_schema='TGT_S',
+                target_table='TGT',
+                ctx=ctx)
+        except Exception:
+            # Builder may fail with our minimal mock — that's OK; we
+            # care that the existence-probe / create_project ran.
+            pass
+        client.create_project.assert_called_once_with('NewProj')
+
+    def test_dt_manage_schedule_create_daily(self):
+        '''dt_manage_schedule create with daily frequency triggers
+        the Schedule builder. We can't import the real builder but can
+        verify the existence-probe + branch dispatch happen.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_schedule'].fn
+
+        client = MagicMock()
+        client.check_if_schedule_exists.return_value = (False, None)
+        ctx = self._make_ctx(client)
+        # Will raise inside the builder; we just want the dispatch
+        # path covered.
+        try:
+            fn(action='create', schedule_name='S',
+                project_name='P', resource_name='DF',
+                frequency='daily', time='09:00:00', ctx=ctx)
+        except Exception:
+            pass
+
+    def test_dt_manage_dataload_create_full_body(self):
+        '''dt_manage_dataload create body — exercises project check,
+        DataLoad builder import, and the full table-load loop.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_dataload'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'proj-1'
+        ctx = self._make_ctx(client)
+        # The DataLoad import will fail in this venv unless installed —
+        # exercise both branches by patching the builder.
+        fake_dl_module = MagicMock()
+        fake_dl = MagicMock()
+        fake_dl_module.DataLoad.return_value = fake_dl
+        with patch.dict('sys.modules',
+                         {'datatransforms.dataload': fake_dl_module}):
+            json.loads(fn(action='create',
+                           project_name='P', dataload_name='DL',
+                           source_connection='SC', source_schema='SS',
+                           target_connection='TC', target_schema='TS',
+                           tables='T1,T2', load_type='APPEND',
+                           ctx=ctx))
+        fake_dl_module.DataLoad.assert_called_once_with('DL', 'P')
+        # Two tables → two load-type calls (append since load_type=APPEND)
+        assert fake_dl.append.call_count == 2
+        fake_dl.create_dataload.assert_called_once()
+
+    def test_dt_manage_dataload_create_recreate_path(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_dataload'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'proj-1'
+        ctx = self._make_ctx(client)
+        fake_dl_module = MagicMock()
+        fake_dl = MagicMock()
+        fake_dl_module.DataLoad.return_value = fake_dl
+        with patch.dict('sys.modules',
+                         {'datatransforms.dataload': fake_dl_module}):
+            json.loads(fn(action='create',
+                           project_name='P', dataload_name='DL',
+                           source_connection='SC', source_schema='SS',
+                           target_connection='TC', target_schema='TS',
+                           tables='T', load_type='RECREATE',
+                           ctx=ctx))
+        fake_dl.recreate.assert_called_once_with('T')
+
+    def test_dt_manage_workflow_get(self):
+        '''get action looks up workflow by name + ID.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_workflow'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'proj-1'
+        client.check_if_workflow_exists.return_value = (True, 'wf-id')
+        client.get_workflow_by_id.return_value = {'name': 'WF', 'detail': 'x'}
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(action='get', project_name='P',
+                                workflow_name='WF', ctx=ctx))
+        client.get_workflow_by_id.assert_called_once_with('wf-id')
+
+    def test_dt_describe_project_full_body(self):
+        '''Walks the full dt_describe_project flow: existence check
+        + 3 list_*_in_project calls + per-entity get_*_by_id walks.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_describe_project'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'proj-1'
+        client.list_dataflows_in_project.return_value = [
+            {'name': 'DF1', 'globalId': 'df1'}]
+        client.list_workflows_in_project.return_value = [
+            {'name': 'WF1', 'globalId': 'wf1'}]
+        client.list_dataloads_in_project.return_value = [
+            {'name': 'DL1'}]
+        client.get_dataflow_by_id.return_value = {'detail': 'df'}
+        client.get_workflow_by_id.return_value = {'detail': 'wf'}
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(project_name='P', ctx=ctx))
+        assert result['project_name'] == 'P'
+        client.list_dataflows_in_project.assert_called_once_with('proj-1')
+        client.list_workflows_in_project.assert_called_once_with('proj-1')
+        client.list_dataloads_in_project.assert_called_once_with('proj-1')
+
+    def test_dt_describe_project_not_found(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_describe_project'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = None
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(project_name='Missing', ctx=ctx))
+        # Project not found — body returns an exists=False payload
+        assert result.get('exists') is False or 'error' in result
+
+    def test_dt_describe_connection_full_body(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_describe_connection'].fn
+
+        client = MagicMock()
+        client.get_connection_details.return_value = {'name': 'C',
+                                                       'type': 'ORACLE'}
+        client.test_connection_by_name.return_value = {'status': 'ok'}
+        client.get_live_schemas.return_value = ['S1', 'S2']
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(connection_name='C', ctx=ctx))
+        assert 'connection' in result or 'connection_name' in result \
+            or 'details' in result
+        client.get_connection_details.assert_called_once_with('C')
+        client.test_connection_by_name.assert_called_once_with('C')
+
+    def test_dt_check_health_walks_all_connections(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_check_health'].fn
+
+        client = MagicMock()
+        client.list_connections.return_value = [
+            {'name': 'C1'}, {'name': 'C2'}]
+        client.test_connection_by_name.return_value = {'status': 'ok'}
+        client.list_schedules.return_value = []
+        client.get_deployment_time.return_value = '2026-01-01'
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(ctx=ctx))
+        # Each connection should be tested
+        assert client.test_connection_by_name.call_count == 2
+
+    def test_dt_run_pipeline_dataflow(self):
+        '''dt_run_pipeline gets a runtime client from the workbench
+        and calls run_dataflow.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_run_pipeline'].fn
+
+        client = MagicMock()
+        workbench = MagicMock()
+        runtime = MagicMock()
+        runtime.run_dataflow.return_value = {'session_id': 'S1'}
+        workbench.get_runtime_client.return_value = runtime
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {
+            'datatransforms': {'client': client, 'workbench': workbench}}
+        result = json.loads(fn(project_name='P', resource_name='DF',
+                                resource_type='dataflow', ctx=ctx))
+        runtime.run_dataflow.assert_called_once_with('P', 'DF')
+        # Body wraps the SDK result under 'job_result'
+        assert result['project'] == 'P'
+        assert result['resource'] == 'DF'
+        assert 'job_result' in result
+
+    def test_dt_manage_data_entities_import(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_data_entities'].fn
+
+        client = MagicMock()
+        wb = MagicMock()
+        wb.import_data_entities.return_value = {'imported': 5}
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {
+            'datatransforms': {'client': client, 'workbench': wb}}
+        result = json.loads(fn(action='import_entities',
+                                connection_name='C',
+                                schema_name='S', ctx=ctx))
+        wb.import_data_entities.assert_called_once_with('C', 'S')
+
     def test_dt_manage_dataflow_check_exists(self):
         from mcp.server.fastmcp import FastMCP
         from oracle.data_studio_mcp_server.tools import dt_tools
@@ -1796,7 +2704,12 @@ def _adp_dispatch(tool_name, kwargs, sdk_path, sdk_return=None):
 
 def _dt_dispatch(tool_name, kwargs, sdk_path, sdk_return=None,
                   on_workbench=False):
-    '''Run a DT tool with a mocked client/workbench; return result + mocks.'''
+    '''Run a DT tool with a mocked client/workbench; return result + mocks.
+
+    Pre-mocks check_if_*_exists methods to return tuples (False, None),
+    and check_if_project_exists to return a project ID — so action
+    handlers that probe existence first don't crash on tuple unpacking.
+    '''
     from mcp.server.fastmcp import FastMCP
     from oracle.data_studio_mcp_server.tools import dt_tools
     mcp_server = FastMCP('test')
@@ -1804,12 +2717,21 @@ def _dt_dispatch(tool_name, kwargs, sdk_path, sdk_return=None,
     fn = mcp_server._tool_manager._tools[tool_name].fn
     client = MagicMock()
     workbench = MagicMock()
+    # Common existence-probe methods return (exists, global_id)
+    client.check_if_dataload_exists.return_value = (False, None)
+    client.check_if_workflow_exists.return_value = (False, None)
+    client.check_if_df_exists.return_value = (False, None)
+    client.check_if_schedule_exists.return_value = (False, None)
+    client.check_if_project_exists.return_value = 'project-123'
     target = workbench if on_workbench else client
     method = _walk(target, sdk_path)
     method.return_value = (json.dumps(sdk_return) if isinstance(
                             sdk_return, (dict, list))
                             else (sdk_return if sdk_return is not None
                                   else 'ok'))
+    # If asserting on an existence probe, override the tuple return
+    if 'check_if_' in sdk_path:
+        method.return_value = (False, None)
     ctx = MagicMock()
     ctx.request_context.lifespan_context = {
         'datatransforms': {'client': client, 'workbench': workbench},
@@ -1934,6 +2856,76 @@ ADP_DISPATCH_CASES = [
      'Ingest.get_database_links'),
     ('adp_manage_db_links', {'action': 'check', 'db_link_name': 'L'},
      'Catalog.check_database_link'),
+    # adp_browse_catalog preview
+    ('adp_browse_catalog', {'action': 'preview', 'catalog_name': 'T'},
+     'Catalog.preview_catalog_table'),
+    # adp_query_analytic_view (single tool, no action)
+    ('adp_query_analytic_view', {'av_name': 'AV'},
+     'Analytics.is_exist'),
+    # adp_search (single tool)
+    ('adp_search', {'search_term': 'EMP'},
+     'Misc.global_search'),
+    # adp_generate_insights
+    ('adp_generate_insights', {'object_name': 'SALES',
+                                 'measure': 'AMOUNT'},
+     'Insight.generate'),
+    # adp_ai_chat
+    ('adp_ai_chat', {'question': 'hello'},
+     'AI.chat'),
+    # adp_ai_chat with chat_with_db mode
+    ('adp_ai_chat', {'question': 'top sales',
+                       'mode': 'chat_with_db',
+                       'tables': 'SALES'},
+     'AI.chat_with_db'),
+    # adp_ai_chat with generate_insight mode
+    ('adp_ai_chat', {'question': 'analyze',
+                       'mode': 'generate_insight',
+                       'tables': 'SALES'},
+     'AI.generate_insight'),
+    # adp_search with include_ddl path
+    ('adp_search', {'search_term': 'EMP', 'include_ddl': True},
+     'Misc.global_search'),
+    # adp_analyze_analytic_view (multi-call composite)
+    ('adp_analyze_analytic_view', {'av_name': 'AV'},
+     'Analytics.is_exist'),
+    # adp_build_analytic_view (no av_name → triggers create_auto)
+    ('adp_build_analytic_view', {'fact_table': 'SALES'},
+     'Analytics.create_auto'),
+    # adp_load_from_cloud — without request_id triggers copy_cloud_objects
+    ('adp_load_from_cloud', {'storage_link': 'SL', 'object_name': 'o.csv',
+                              'target_table': 'T'},
+     'Ingest.copy_cloud_objects'),
+    # adp_load_from_cloud with request_id polls progress
+    ('adp_load_from_cloud', {'request_id': 'R'},
+     'Ingest.cloud_progress_status'),
+    # adp_manage_credentials list_cloud_objects
+    ('adp_manage_credentials', {'action': 'list_cloud_objects',
+                                  'storage_link_name': 'SL'},
+     'Ingest.get_cloud_objects'),
+    # adp_manage_db_links list_tables / copy_tables / link_tables
+    ('adp_manage_db_links', {'action': 'list_tables',
+                              'db_link_name': 'L'},
+     'Ingest.get_db_link_owner_tables'),
+    ('adp_manage_db_links', {'action': 'copy_tables',
+                              'db_link_name': 'L', 'tables': 'T1,T2'},
+     'Ingest.copy_tables_from_db_link'),
+    ('adp_manage_db_links', {'action': 'link_tables',
+                              'db_link_name': 'L', 'tables': 'T1'},
+     'Ingest.link_tables_from_db_link'),
+    ('adp_manage_db_links', {'action': 'drop', 'db_link_name': 'L'},
+     'Catalog.drop_database_link'),
+    # adp_manage_insights get_graph
+    ('adp_manage_insights', {'action': 'get_graph',
+                               'insight_name': 'IN', 'viz_id': 1},
+     'Insight.get_graph_details'),
+    # adp_manage_sharing publish (no recipient)
+    ('adp_manage_sharing', {'action': 'publish', 'share_name': 'S'},
+     'Share.publish_share'),
+    # adp_manage_sharing grant_recipient
+    ('adp_manage_sharing', {'action': 'grant_recipient',
+                              'recipient_name': 'R',
+                              'tables': 'SH1,SH2'},
+     'Share.update_recipient_shares'),
 ]
 
 
@@ -1955,7 +2947,7 @@ DT_DISPATCH_CASES = [
                               'schedule_name': 'S',
                               'project_name': 'P'},
      'delete_schedule', False),
-    # dt_manage_variables
+    # dt_manage_variables (set creates new variable when not found)
     ('dt_manage_variables', {'action': 'list'},
      'list_variables', False),
     # dt_manage_connection
@@ -1967,6 +2959,56 @@ DT_DISPATCH_CASES = [
      'test_connection_by_name', False),
     ('dt_manage_connection', {'action': 'delete', 'connection_name': 'C'},
      'delete_connection', False),
+    # dt_manage_dataload
+    ('dt_manage_dataload', {'action': 'list', 'project_name': 'P'},
+     'list_dataloads_in_project', False),
+    ('dt_manage_dataload', {'action': 'check_exists',
+                              'dataload_name': 'X',
+                              'project_name': 'P'},
+     'check_if_dataload_exists', False),
+    # dt_manage_workflow
+    ('dt_manage_workflow', {'action': 'list', 'project_name': 'P'},
+     'list_workflows_in_project', False),
+    ('dt_manage_workflow', {'action': 'check_exists',
+                              'workflow_name': 'W',
+                              'project_name': 'P'},
+     'check_if_workflow_exists', False),
+    # dt_manage_data_entities (list calls list_data_entities)
+    ('dt_manage_data_entities', {'action': 'list',
+                                    'connection_name': 'C'},
+     'list_data_entities', False),
+    ('dt_manage_data_entities', {'action': 'import_entities',
+                                    'connection_name': 'C',
+                                    'schema_name': 'S'},
+     'import_data_entities', True),     # workbench-side
+    # dt single-tool composites
+    ('dt_explore', {}, 'get_about', False),
+    ('dt_describe_project', {'project_name': 'P'},
+     'check_if_project_exists', False),
+    ('dt_describe_connection', {'connection_name': 'C'},
+     'get_connection_details', False),
+    ('dt_check_health', {}, 'list_connections', False),
+    ('dt_browse_data', {'connection_name': 'C'},
+     'get_live_schemas', False),
+    # dt_manage_variables set tries update_variable first
+    ('dt_manage_variables', {'action': 'set',
+                                'variable_name': 'V', 'value': 'x'},
+     'update_variable', False),
+    # dt_manage_project delete
+    ('dt_manage_project', {'action': 'delete', 'project_name': 'P'},
+     'delete_project', False),
+    # dt_manage_dataload create — exercises the builder path's existence
+    # check (will hit ImportError on the DataLoad builder; we just
+    # verify the project existence probe was called)
+    ('dt_manage_dataload', {'action': 'create',
+                              'project_name': 'P',
+                              'dataload_name': 'DL',
+                              'source_connection': 'SC',
+                              'source_schema': 'SS',
+                              'target_connection': 'TC',
+                              'target_schema': 'TS',
+                              'tables': 'T'},
+     'check_if_project_exists', False),
 ]
 
 
@@ -2128,6 +3170,185 @@ ESS_DISPATCH_CASES = [
      'users.delete_user'),
     ('essbase_manage_users', {'action': 'list_roles'},
      'users.list_roles'),
+    # Single-purpose tools (no action param)
+    ('essbase_query', {'app_name': 'A', 'db_name': 'D',
+                         'mdx': 'SELECT [Y].Children ON 0 FROM [A.D]'},
+     'grid.execute_mdx'),
+    ('essbase_browse_outline', {'app_name': 'A', 'db_name': 'D'},
+     'dimensions.get_outline'),
+    ('essbase_search_members', {'app_name': 'A', 'db_name': 'D',
+                                  'pattern': 'sales'},
+     'dimensions.search_members'),
+    ('essbase_get_script', {'app_name': 'A', 'db_name': 'D',
+                              'script_name': 'S'},
+     'scripts.get_script_content'),
+    ('essbase_export_data', {'app_name': 'A', 'db_name': 'D',
+                               'mdx': 'SELECT [Y].Children ON 0 FROM [A.D]'},
+     'grid.execute_mdx'),
+    ('essbase_export_data', {'app_name': 'A', 'db_name': 'D',
+                               'report_name': 'R'},
+     'grid.execute_mdx_report'),
+    # essbase_manage_groups (uses group_id, not group_name)
+    ('essbase_manage_groups', {'action': 'list'},
+     'groups.list_groups'),
+    ('essbase_manage_groups', {'action': 'get', 'group_id': 'G'},
+     'groups.get_group'),
+    ('essbase_manage_groups', {'action': 'delete', 'group_id': 'G'},
+     'groups.delete_group'),
+    ('essbase_manage_groups', {'action': 'get_users', 'group_id': 'G'},
+     'groups.get_users'),
+    # Multi-call composite tools
+    ('essbase_server_health', {},
+     'about.get'),
+    ('essbase_explore', {},
+     'applications.list_applications'),
+    ('essbase_run_calculation', {'app_name': 'A', 'db_name': 'D',
+                                   'script_name': 'CalcAll'},
+     'jobs.execute'),
+    ('essbase_run_calculation', {'app_name': 'A', 'db_name': 'D',
+                                   'calc_script': 'CALC ALL;'},
+     'jobs.execute'),
+    ('essbase_describe_database', {'app_name': 'A', 'db_name': 'D'},
+     'applications.get_database'),
+    ('essbase_load_data', {'app_name': 'A', 'db_name': 'D',
+                             'data_file': 'data.txt',
+                             'rule_file': 'load.rul'},
+     'jobs.execute'),
+    ('essbase_deploy_workbook', {'app_name': 'A',
+                                   'file_path': '/tmp/wb.xlsx'},
+     'jobs.execute'),
+    # essbase_outline_metadata more categories
+    ('essbase_outline_metadata', {'app_name': 'A', 'db_name': 'D',
+                                    'category': 'all'},
+     'dimensions.list_dimensions'),
+    ('essbase_outline_metadata', {'app_name': 'A', 'db_name': 'D',
+                                    'category': 'generations',
+                                    'dimension_name': 'Time'},
+     'dimensions.list_generations'),
+    ('essbase_outline_metadata', {'app_name': 'A', 'db_name': 'D',
+                                    'category': 'levels',
+                                    'dimension_name': 'Time'},
+     'dimensions.list_levels'),
+    ('essbase_outline_metadata', {'app_name': 'A', 'db_name': 'D',
+                                    'category': 'smart_lists'},
+     'dimensions.get_smart_lists'),
+    ('essbase_outline_metadata', {'app_name': 'A', 'db_name': 'D',
+                                    'category': 'member',
+                                    'dimension_name': 'East'},
+     'dimensions.get_member'),
+    # essbase_edit_outline — every action
+    ('essbase_edit_outline', {'app_name': 'A', 'db_name': 'D',
+                                'action': 'add', 'member_name': 'M',
+                                'parent_name': 'P'},
+     'dimensions.batch_outline_edit'),
+    ('essbase_edit_outline', {'app_name': 'A', 'db_name': 'D',
+                                'action': 'remove', 'member_name': 'M'},
+     'dimensions.batch_outline_edit'),
+    ('essbase_edit_outline', {'app_name': 'A', 'db_name': 'D',
+                                'action': 'rename', 'member_name': 'M',
+                                'new_name': 'M2'},
+     'dimensions.batch_outline_edit'),
+    ('essbase_edit_outline', {'app_name': 'A', 'db_name': 'D',
+                                'action': 'set_formula',
+                                'member_name': 'M',
+                                'formula': '@SUM(X)'},
+     'dimensions.batch_outline_edit'),
+    ('essbase_edit_outline', {'app_name': 'A', 'db_name': 'D',
+                                'action': 'set_alias',
+                                'member_name': 'M',
+                                'alias_value': 'Sales'},
+     'dimensions.batch_outline_edit'),
+    ('essbase_edit_outline', {'app_name': 'A', 'db_name': 'D',
+                                'action': 'set_uda',
+                                'member_name': 'M',
+                                'uda_value': 'Promo'},
+     'dimensions.batch_outline_edit'),
+    # essbase_manage_users more actions
+    ('essbase_manage_users', {'action': 'create', 'user_id': 'u',
+                                'password': 'p'},
+     'users.create_user'),
+    ('essbase_manage_users', {'action': 'update', 'user_id': 'u'},
+     'users.update_user'),
+    ('essbase_manage_users', {'action': 'list_service_roles'},
+     'users.list_service_roles'),
+    ('essbase_manage_users', {'action': 'list_app_roles',
+                                'app_name': 'A'},
+     'users.list_app_roles'),
+    # essbase_manage_groups more actions
+    ('essbase_manage_groups', {'action': 'create', 'group_id': 'G'},
+     'groups.create_group'),
+    ('essbase_manage_groups', {'action': 'add_users', 'group_id': 'G',
+                                 'user_ids': 'u1,u2'},
+     'groups.add_users'),
+    # essbase_manage_files more actions
+    ('essbase_manage_files', {'action': 'upload', 'path': '/p',
+                                'content': 'hello'},
+     'files.upload'),
+    ('essbase_manage_files', {'action': 'download', 'path': '/p'},
+     'files.download'),
+    # essbase_manage_connections create + test + update
+    ('essbase_manage_connections', {'action': 'create',
+                                       'connection_name': 'C',
+                                       'host': 'h', 'port': 1521,
+                                       'service_name': 'svc',
+                                       'user': 'u', 'password': 'p'},
+     'connections.create_connection'),
+    ('essbase_manage_connections', {'action': 'test',
+                                       'connection_name': 'C'},
+     'connections.test_saved_connection'),
+    # essbase_manage_filters more actions (no `validate` action exists)
+    ('essbase_manage_filters', {'action': 'copy',
+                                  'app_name': 'A', 'db_name': 'D',
+                                  'filter_name': 'F', 'new_name': 'F2'},
+     'filters.copy_filter'),
+    ('essbase_manage_filters', {'action': 'assign',
+                                  'app_name': 'A', 'db_name': 'D',
+                                  'filter_name': 'F',
+                                  'user_or_group': 'u'},
+     'filters.add_permissions'),
+    # essbase_manage_datasources create
+    ('essbase_manage_datasources', {'action': 'create',
+                                       'datasource_name': 'DS',
+                                       'connection': 'C',
+                                       'query': 'SELECT 1 FROM dual',
+                                       'columns': 'A,B'},
+     'datasources.create_datasource'),
+    # essbase_manage_drill_through more
+    ('essbase_manage_drill_through', {'action': 'execute',
+                                         'app_name': 'A', 'db_name': 'D',
+                                         'report_name': 'R'},
+     'drill_through.execute_report'),
+    # essbase_manage_database update
+    ('essbase_manage_database', {'action': 'update',
+                                   'app_name': 'A', 'db_name': 'D'},
+     'applications.update_database'),
+    # essbase_manage_jobs status (already had — adding rerun's extra path)
+    # essbase_manage_locks unlock
+    ('essbase_manage_locks', {'action': 'unlock',
+                                'app_name': 'A', 'db_name': 'D',
+                                'object_name': 'O'},
+     'locks.unlock_object'),
+    # essbase_manage_sessions kill_all
+    ('essbase_manage_sessions', {'action': 'kill_all'},
+     'sessions.delete_all_sessions'),
+    ('essbase_manage_sessions', {'action': 'current'},
+     'sessions.get_current_session'),
+    ('essbase_outline_metadata', {'app_name': 'A', 'db_name': 'D',
+                                    'category': 'outline_settings'},
+     'dimensions.get_outline_settings'),
+    ('essbase_outline_metadata', {'app_name': 'A', 'db_name': 'D',
+                                    'category': 'export_xml'},
+     'dimensions.export_outline_xml'),
+    # essbase_manage_db_settings
+    ('essbase_manage_db_settings', {'app_name': 'A', 'db_name': 'D',
+                                      'category': 'all'},
+     'database_settings.get_settings'),
+    # essbase_get_logs (lives on applications, not about)
+    ('essbase_get_logs', {'app_name': 'A'},
+     'applications.get_latest_log'),
+    # essbase_manage_security
+    ('essbase_manage_security', {'username': 'u'},
+     'users.get_user'),
 ]
 
 

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
@@ -41,7 +41,9 @@ class TestServerConfig:
         assert cfg.datatransforms is None
         assert cfg.transport == 'stdio'
         assert cfg.port == 8000
-        assert cfg.profile == 'admin'
+        # Safe default: viewer. Admin requires explicit opt-in.
+        # See oracle/mcp BEST_PRACTICES on scope minimisation.
+        assert cfg.profile == 'viewer'
         # S8: bind address defaults to loopback (no auth → no
         # external exposure unless explicit).
         assert cfg.host == '127.0.0.1'
@@ -188,6 +190,73 @@ class TestCredentialStore:
         mock_path.exists.return_value = False
         from oracle.data_studio_mcp_server.credential_store import load_config_file
         assert load_config_file() == {}
+
+    def test_store_credentials_never_writes_token_to_file(self, tmp_path,
+                                                          monkeypatch):
+        '''Hardening: bearer tokens / api keys passed to store_credentials
+        must end up in the OS keyring, NEVER in the plaintext INI file.
+        This is the reviewer-blocking fix for the prior behaviour where
+        `--token foo` ended up written to ~/.oracle-data-studio/config.
+        '''
+        from oracle.data_studio_mcp_server import credential_store as cs
+        cfg_file = tmp_path / 'config'
+        monkeypatch.setattr(cs, 'CONFIG_DIR', tmp_path)
+        monkeypatch.setattr(cs, 'CONFIG_FILE', cfg_file)
+
+        calls = []
+        def fake_set(svc, user, secret):
+            calls.append((svc, user, secret))
+            return True
+        with patch.object(cs, '_set_keyring_password', side_effect=fake_set):
+            result = cs.store_credentials(
+                'essbase',
+                url='https://e',
+                user='admin',
+                token='ghp_REDACTED_TOKEN_VALUE_xyz789')
+        # Token went to keyring
+        assert ('essbase', '__token__',
+                'ghp_REDACTED_TOKEN_VALUE_xyz789') in calls
+        # Token is NOT on disk anywhere
+        body = cfg_file.read_text()
+        assert 'ghp_REDACTED_TOKEN_VALUE_xyz789' not in body
+        assert 'token' not in body.lower() or '_token_' not in body
+        # URL + user still on disk (those are not secrets)
+        assert 'url = https://e' in body
+        assert 'user = admin' in body
+        # Result reports the token was stored
+        assert 'token' in result['secret_extras_stored']
+
+    def test_store_credentials_extras_renamed_to_secret_keys_routed_to_keyring(
+            self, tmp_path, monkeypatch):
+        '''Even if a caller renames a field to one of the SECRET_KEYS
+        (e.g. bearer, api_key, secret), it must NOT land on disk.'''
+        from oracle.data_studio_mcp_server import credential_store as cs
+        cfg_file = tmp_path / 'config'
+        monkeypatch.setattr(cs, 'CONFIG_DIR', tmp_path)
+        monkeypatch.setattr(cs, 'CONFIG_FILE', cfg_file)
+        with patch.object(cs, '_set_keyring_password', return_value=True):
+            cs.store_credentials('adp', url='https://x', user='u',
+                                  bearer='BEARER_TOKEN',
+                                  api_key='AK',
+                                  secret='S')
+        body = cfg_file.read_text()
+        for sensitive in ('BEARER_TOKEN', 'AK', 'S'):
+            # The bare value must not appear on disk
+            assert sensitive not in body, \
+                f'secret {sensitive!r} leaked to config file'
+
+    def test_get_keyring_token_round_trips(self):
+        '''Round-trip: set a token, then retrieve it via the public
+        get_keyring_token() helper.'''
+        from oracle.data_studio_mcp_server.credential_store import (
+            _set_keyring_password, get_keyring_token)
+        fake_keyring = MagicMock()
+        fake_keyring.get_password.return_value = 'ghp_xyz'
+        with patch.dict('sys.modules', {'keyring': fake_keyring}):
+            assert get_keyring_token('essbase') == 'ghp_xyz'
+        # Lookup was scoped to the right service + pseudo-user
+        fake_keyring.get_password.assert_called_with(
+            'oracle-data-studio/essbase', '__token__')
 
     def test_store_credentials_writes_config_and_keyring(self, tmp_path,
                                                           monkeypatch):
@@ -520,6 +589,108 @@ class TestProfiles:
         assert _get_verb_suffix('unknown_tool') == 'unknown_tool'
 
     @mcp_required
+    @mcp_required
+    def test_default_profile_removes_high_risk_tools(self):
+        '''Reviewer-blocking guarantee: with NO --profile flag, the
+        server must default to a low-privilege profile that does NOT
+        expose destructive, modify, or execute-arbitrary-code tools.
+
+        Walks the full registered tool catalog through the actual
+        default profile (whatever ServerConfig() sets) and asserts
+        the high-risk tool surface is not exposed.'''
+        from oracle.data_studio_mcp_server.config import ServerConfig
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import (
+            adp_tools, dt_tools, essbase_tools)
+
+        default_profile = ServerConfig().profile
+        # Sanity — the default must not be admin
+        assert default_profile != 'admin', \
+            'default profile must not be admin per BEST_PRACTICES'
+
+        mcp_server = FastMCP('test')
+        for mod in (essbase_tools, adp_tools, dt_tools):
+            mod.register_tools(mcp_server)
+
+        apply_profile(mcp_server, default_profile)
+        names = set(mcp_server._tool_manager._tools.keys())
+
+        # None of the following tools may be visible under the default:
+        BANNED_UNDER_DEFAULT = {
+            # Destructive / modifying
+            'essbase_manage_application',     # create/delete/copy/rename
+            'essbase_manage_database',        # delete/copy/rename
+            'essbase_manage_script',          # CRUD scripts
+            'essbase_manage_files',           # upload/delete/move
+            'essbase_manage_filters',         # CRUD filters
+            'essbase_manage_users',           # CRUD users + role provisioning
+            'essbase_manage_groups',          # CRUD groups
+            'essbase_manage_connections',     # CRUD connections
+            'essbase_manage_datasources',     # CRUD datasources
+            'essbase_manage_drill_through',   # CRUD drill-through reports
+            'essbase_manage_variables',       # CRUD variables
+            'essbase_manage_db_settings',     # writeable settings
+            'essbase_manage_sessions',        # can kill sessions
+            'essbase_edit_outline',           # add/remove/move members
+            'essbase_load_data',              # data load jobs
+            'essbase_deploy_workbook',        # creates / overwrites cube
+            'essbase_run_calculation',        # executes calc scripts
+            # Direct MDX (we verified S1 — viewer must not run MDX)
+            'essbase_query',
+            'essbase_export_data',
+            # Calc-script source code / log content (S2)
+            'essbase_get_script',
+            'essbase_get_logs',
+            # ADP destructive / modifying
+            'adp_build_analytic_view',
+            'adp_manage_analytic_views',
+            'adp_manage_catalog',
+            'adp_manage_sharing',
+            'adp_manage_credentials',
+            'adp_manage_insights',
+            'adp_manage_db_links',
+            'adp_load_from_cloud',
+            'adp_generate_insights',
+            'adp_ai_chat',
+            # DT destructive / modifying
+            'dt_manage_project',
+            'dt_manage_dataflow',
+            'dt_manage_schedule',
+            'dt_manage_variables',
+            'dt_manage_connection',
+            'dt_create_pipeline',
+            'dt_run_pipeline',
+        }
+        leaked = BANNED_UNDER_DEFAULT & names
+        assert not leaked, (
+            f'Default profile ({default_profile!r}) leaked high-risk '
+            f'tools: {sorted(leaked)}')
+
+        # Sanity: the default still exposes basic discovery tools.
+        # Without these, the server is useless even for browsing.
+        EXPECTED_UNDER_DEFAULT = {
+            'essbase_explore',
+            'essbase_describe_database',
+            'essbase_browse_outline',
+            'essbase_search_members',
+            'essbase_server_health',
+            'adp_search',
+            'adp_browse_catalog',
+            'adp_query_analytic_view',
+            'adp_analyze_analytic_view',
+            'adp_get_annotations',
+            'dt_explore',
+            'dt_describe_project',
+            'dt_describe_connection',
+            'dt_check_health',
+            'dt_browse_data',
+        }
+        missing = EXPECTED_UNDER_DEFAULT - names
+        assert not missing, (
+            f'Default profile is too restrictive — missing safe '
+            f'metadata tools: {sorted(missing)}')
+
     def test_viewer_profile_filtering(self):
         '''Viewer profile: only read-only tools.'''
         from oracle.data_studio_mcp_server.profiles import apply_profile

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
@@ -4745,6 +4745,49 @@ class TestServer:
         # Lifespan still yielded a context — startup didn't break
         assert 'essbase' not in ctx
 
+    def test_main_streamable_http_sets_host_port_via_settings(self):
+        '''Regression: FastMCP.run() takes only `transport` and
+        `mount_path`. host/port must be set via mcp.settings before
+        calling run(). Previous code passed host=... as a kwarg to
+        run() which raises TypeError on real FastMCP.'''
+        import oracle.data_studio_mcp_server.server as srv
+
+        # Build a config that selects streamable-http and a specific
+        # host/port. We patch apply_profile + mcp.run so main() doesn't
+        # actually start a server.
+        fake_cfg = MagicMock(transport='streamable-http',
+                              host='0.0.0.0', port=9001,
+                              profile='admin')
+        with patch.object(srv, 'load_config', return_value=fake_cfg), \
+             patch.object(srv, 'apply_profile'), \
+             patch.object(srv.mcp, 'run') as run_mock:
+            srv.main()
+        # run() called with ONLY transport — no host/port kwargs
+        call = run_mock.call_args
+        assert call.kwargs.get('host') is None, \
+            'run() must NOT be called with host=... — host goes on mcp.settings'
+        assert call.kwargs.get('port') is None
+        # transport is the only positional/kwarg
+        assert call.kwargs.get('transport') == 'streamable-http' \
+            or (call.args and call.args[0] == 'streamable-http')
+        # The settings were updated before the call
+        assert srv.mcp.settings.host == '0.0.0.0'
+        assert srv.mcp.settings.port == 9001
+
+    def test_main_stdio_default_does_not_touch_settings_host(self):
+        import oracle.data_studio_mcp_server.server as srv
+
+        fake_cfg = MagicMock(transport='stdio', host='127.0.0.1',
+                              port=8000, profile='admin')
+        with patch.object(srv, 'load_config', return_value=fake_cfg), \
+             patch.object(srv, 'apply_profile'), \
+             patch.object(srv.mcp, 'run') as run_mock:
+            srv.main()
+        # stdio transport — run() called with stdio only
+        call = run_mock.call_args
+        assert (call.kwargs.get('transport') == 'stdio'
+                or (call.args and call.args[0] == 'stdio'))
+
     def test_lifespan_dt_configured(self):
         '''DT path: stores _dt_config for later lazy-connect.'''
         import asyncio

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
@@ -189,6 +189,104 @@ class TestCredentialStore:
         from oracle.data_studio_mcp_server.credential_store import load_config_file
         assert load_config_file() == {}
 
+    def test_store_credentials_writes_config_and_keyring(self, tmp_path,
+                                                          monkeypatch):
+        '''store_credentials writes URL/user to config and password
+        to keyring.'''
+        cfg_file = tmp_path / 'config'
+        from oracle.data_studio_mcp_server import credential_store as cs
+        monkeypatch.setattr(cs, 'CONFIG_DIR', tmp_path)
+        monkeypatch.setattr(cs, 'CONFIG_FILE', cfg_file)
+        with patch.object(cs, '_set_keyring_password',
+                           return_value=True) as mock_set:
+            result = cs.store_credentials('adp', url='https://x',
+                                            user='ADMIN',
+                                            password='secret')
+        assert result['status'] == 'success'
+        assert result['keyring_stored'] is True
+        # Password never lands on disk
+        assert 'secret' not in cfg_file.read_text()
+        assert 'url = https://x' in cfg_file.read_text()
+        mock_set.assert_called_once_with('adp', 'ADMIN', 'secret')
+
+    def test_store_credentials_rejects_unknown_service(self):
+        from oracle.data_studio_mcp_server.credential_store import (
+            store_credentials)
+        with pytest.raises(ValueError, match='Unknown service'):
+            store_credentials('nonexistent')
+
+    def test_store_credentials_extras_written_to_file(self, tmp_path,
+                                                      monkeypatch):
+        from oracle.data_studio_mcp_server import credential_store as cs
+        cfg_file = tmp_path / 'config'
+        monkeypatch.setattr(cs, 'CONFIG_DIR', tmp_path)
+        monkeypatch.setattr(cs, 'CONFIG_FILE', cfg_file)
+        with patch.object(cs, '_set_keyring_password', return_value=True):
+            cs.store_credentials('server', transport='stdio', port=9000)
+        text = cfg_file.read_text()
+        assert 'transport = stdio' in text
+        assert 'port = 9000' in text
+
+    def test_remove_credentials_removes_section(self, tmp_path, monkeypatch):
+        from oracle.data_studio_mcp_server import credential_store as cs
+        cfg_file = tmp_path / 'config'
+        monkeypatch.setattr(cs, 'CONFIG_DIR', tmp_path)
+        monkeypatch.setattr(cs, 'CONFIG_FILE', cfg_file)
+        with patch.object(cs, '_set_keyring_password', return_value=True), \
+             patch.object(cs, '_delete_keyring_password', return_value=True):
+            cs.store_credentials('adp', url='https://x', user='ADMIN',
+                                  password='p')
+            result = cs.remove_credentials('adp')
+        assert result['removed_config'] is True
+        assert result['removed_keyring'] is True
+        assert 'adp' not in cfg_file.read_text()
+
+    def test_list_credentials_returns_sections(self, tmp_path, monkeypatch):
+        from oracle.data_studio_mcp_server import credential_store as cs
+        cfg_file = tmp_path / 'config'
+        monkeypatch.setattr(cs, 'CONFIG_DIR', tmp_path)
+        monkeypatch.setattr(cs, 'CONFIG_FILE', cfg_file)
+        with patch.object(cs, '_set_keyring_password', return_value=True):
+            cs.store_credentials('adp', url='https://x', user='ADMIN',
+                                  password='p')
+        result = cs.list_credentials()
+        assert 'adp' in result
+        assert result['adp']['url'] == 'https://x'
+        # Password is NOT in the listed result
+        assert 'password' not in result['adp']
+
+    def test_load_config_file_returns_dict(self, tmp_path, monkeypatch):
+        from oracle.data_studio_mcp_server import credential_store as cs
+        cfg_file = tmp_path / 'config'
+        monkeypatch.setattr(cs, 'CONFIG_DIR', tmp_path)
+        monkeypatch.setattr(cs, 'CONFIG_FILE', cfg_file)
+        with patch.object(cs, '_set_keyring_password', return_value=True):
+            cs.store_credentials('essbase', url='https://e', user='admin',
+                                  password='p')
+        loaded = cs.load_config_file()
+        assert loaded['essbase']['url'] == 'https://e'
+
+    def test_set_keyring_password_succeeds(self):
+        '''_set_keyring_password returns True when the keyring module accepts.'''
+        from oracle.data_studio_mcp_server.credential_store import (
+            _set_keyring_password)
+        with patch.dict('sys.modules', {'keyring': MagicMock()}):
+            assert _set_keyring_password('adp', 'u', 'p') is True
+
+    def test_set_keyring_password_falls_back_when_keyring_missing(self):
+        from oracle.data_studio_mcp_server.credential_store import (
+            _set_keyring_password)
+        import builtins
+        _real = builtins.__import__
+
+        def _no_keyring(name, *a, **kw):
+            if name == 'keyring':
+                raise ImportError('no keyring')
+            return _real(name, *a, **kw)
+
+        with patch('builtins.__import__', side_effect=_no_keyring):
+            assert _set_keyring_password('adp', 'u', 'p') is False
+
     def test_get_keyring_password_no_keyring(self):
         '''get_keyring_password returns None when keyring is unavailable.'''
         from oracle.data_studio_mcp_server.credential_store import get_keyring_password
@@ -1552,6 +1650,496 @@ class TestDtToolDispatch:
 
 
 # ------------------------------------------------------------------ #
+#  cli_config tests                                                    #
+# ------------------------------------------------------------------ #
+
+class TestCliConfig:
+
+    def test_build_parser_set_subcommand(self):
+        from oracle.data_studio_mcp_server.cli_config import _build_parser
+        parser = _build_parser()
+        # Parse a complete `set` command
+        args = parser.parse_args(['set', 'essbase',
+                                   '--url', 'https://h',
+                                   '--user', 'admin',
+                                   '--password', 'p'])
+        assert args.command == 'set'
+        assert args.service == 'essbase'
+        assert args.url == 'https://h'
+        assert args.user == 'admin'
+
+    def test_build_parser_list_subcommand(self):
+        from oracle.data_studio_mcp_server.cli_config import _build_parser
+        parser = _build_parser()
+        args = parser.parse_args(['list'])
+        assert args.command == 'list'
+
+    def test_build_parser_remove_subcommand(self):
+        from oracle.data_studio_mcp_server.cli_config import _build_parser
+        parser = _build_parser()
+        args = parser.parse_args(['remove', 'adp'])
+        assert args.command == 'remove'
+        assert args.service == 'adp'
+
+    def test_build_parser_invalid_service_rejected(self):
+        from oracle.data_studio_mcp_server.cli_config import _build_parser
+        parser = _build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(['set', 'nonexistent_service'])
+
+    @patch('oracle.data_studio_mcp_server.cli_config.store_credentials')
+    def test_cmd_set_stores_with_password(self, mock_store, capsys):
+        from oracle.data_studio_mcp_server.cli_config import _cmd_set
+        mock_store.return_value = {'service': 'adp', 'keyring_stored': True}
+        args = MagicMock(service='adp', url='https://h', user='ADMIN',
+                          password='Welcome2025#', token=None,
+                          transport=None, port=None)
+        _cmd_set(args)
+        mock_store.assert_called_once()
+        call_kwargs = mock_store.call_args.kwargs
+        assert call_kwargs['password'] == 'Welcome2025#'
+        assert call_kwargs['url'] == 'https://h'
+
+    @patch('oracle.data_studio_mcp_server.cli_config.store_credentials')
+    @patch('oracle.data_studio_mcp_server.cli_config.getpass.getpass',
+           return_value='prompted_pw')
+    def test_cmd_set_prompts_for_password_when_user_set(self, mock_prompt,
+                                                          mock_store):
+        '''If --user given but no --password, prompt interactively.'''
+        from oracle.data_studio_mcp_server.cli_config import _cmd_set
+        mock_store.return_value = {'service': 'adp', 'keyring_stored': True}
+        args = MagicMock(service='adp', url='https://h', user='ADMIN',
+                          password=None, token=None,
+                          transport=None, port=None)
+        _cmd_set(args)
+        mock_prompt.assert_called_once()
+        assert mock_store.call_args.kwargs['password'] == 'prompted_pw'
+
+    @patch('oracle.data_studio_mcp_server.cli_config.store_credentials')
+    def test_cmd_set_server_no_password(self, mock_store, capsys):
+        '''The "server" service should never trigger a password prompt.'''
+        from oracle.data_studio_mcp_server.cli_config import _cmd_set
+        mock_store.return_value = {'service': 'server'}
+        args = MagicMock(service='server', url=None, user=None,
+                          password=None, token=None,
+                          transport='stdio', port='8000')
+        _cmd_set(args)
+        # No password kwarg in the call
+        assert mock_store.call_args.kwargs.get('password') is None
+        assert mock_store.call_args.kwargs['transport'] == 'stdio'
+        assert mock_store.call_args.kwargs['port'] == '8000'
+
+    @patch('oracle.data_studio_mcp_server.cli_config.list_credentials')
+    def test_cmd_list_with_creds(self, mock_list, capsys):
+        from oracle.data_studio_mcp_server.cli_config import _cmd_list
+        mock_list.return_value = {
+            'adp': {'url': 'https://h', 'user': 'ADMIN'}}
+        _cmd_list(MagicMock())
+        out = capsys.readouterr().out
+        assert '[adp]' in out
+        assert 'url = https://h' in out
+
+    @patch('oracle.data_studio_mcp_server.cli_config.list_credentials',
+           return_value={})
+    def test_cmd_list_empty(self, mock_list, capsys):
+        from oracle.data_studio_mcp_server.cli_config import _cmd_list
+        _cmd_list(MagicMock())
+        out = capsys.readouterr().out
+        assert 'No credentials configured.' in out
+
+    @patch('oracle.data_studio_mcp_server.cli_config.remove_credentials')
+    def test_cmd_remove(self, mock_remove, capsys):
+        from oracle.data_studio_mcp_server.cli_config import _cmd_remove
+        mock_remove.return_value = {'service': 'essbase', 'removed': True}
+        args = MagicMock(service='essbase')
+        _cmd_remove(args)
+        mock_remove.assert_called_once_with('essbase')
+        assert 'essbase' in capsys.readouterr().out
+
+
+# ------------------------------------------------------------------ #
+#  Bulk action dispatch — parametrised over many tool/action combos    #
+# ------------------------------------------------------------------ #
+#
+# Every composite manage_* tool has a per-action elif chain that
+# routes to a specific SDK call. These tests exercise each branch
+# with a mocked SDK and assert the correct SDK method was invoked
+# with the expected primary arg. They prevent the param-leak class
+# of bug (B1, B2, M7 in the audit) and lift line coverage by
+# touching every action branch.
+
+def _walk(obj, path):
+    '''Walk a dotted attr path on a mock and return the final attr.'''
+    for part in path.split('.'):
+        obj = getattr(obj, part)
+    return obj
+
+
+def _adp_dispatch(tool_name, kwargs, sdk_path, sdk_return=None):
+    '''Run an ADP tool with a mocked SDK; return (result, mock_adp).'''
+    from mcp.server.fastmcp import FastMCP
+    from oracle.data_studio_mcp_server.tools import adp_tools
+    mcp_server = FastMCP('test')
+    adp_tools.register_tools(mcp_server)
+    fn = mcp_server._tool_manager._tools[tool_name].fn
+    adp = MagicMock()
+    adp.rest.expired = None
+    adp.rest.username = 'ADMIN'
+    method = _walk(adp, sdk_path)
+    method.return_value = json.dumps(sdk_return if sdk_return is not None
+                                      else {'status': 'ok'})
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = {'adp': adp}
+    result = fn(ctx=ctx, **kwargs)
+    return result, adp
+
+
+def _dt_dispatch(tool_name, kwargs, sdk_path, sdk_return=None,
+                  on_workbench=False):
+    '''Run a DT tool with a mocked client/workbench; return result + mocks.'''
+    from mcp.server.fastmcp import FastMCP
+    from oracle.data_studio_mcp_server.tools import dt_tools
+    mcp_server = FastMCP('test')
+    dt_tools.register_tools(mcp_server)
+    fn = mcp_server._tool_manager._tools[tool_name].fn
+    client = MagicMock()
+    workbench = MagicMock()
+    target = workbench if on_workbench else client
+    method = _walk(target, sdk_path)
+    method.return_value = (json.dumps(sdk_return) if isinstance(
+                            sdk_return, (dict, list))
+                            else (sdk_return if sdk_return is not None
+                                  else 'ok'))
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = {
+        'datatransforms': {'client': client, 'workbench': workbench},
+    }
+    result = fn(ctx=ctx, **kwargs)
+    return result, client, workbench
+
+
+def _ess_dispatch(tool_name, kwargs, sdk_path, sdk_return=None):
+    '''Run an Essbase tool with a mocked SDK; return (result, mock_ess).'''
+    from mcp.server.fastmcp import FastMCP
+    from oracle.data_studio_mcp_server.tools import essbase_tools
+    mcp_server = FastMCP('test')
+    essbase_tools.register_tools(mcp_server)
+    fn = mcp_server._tool_manager._tools[tool_name].fn
+    ess = MagicMock()
+    method = _walk(ess, sdk_path)
+    method.return_value = (sdk_return if sdk_return is not None
+                            else {'status': 'ok'})
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = {'essbase': ess}
+    result = fn(ctx=ctx, **kwargs)
+    return result, ess
+
+
+# Each tuple: (tool_name, kwargs, sdk_path_to_assert)
+ADP_DISPATCH_CASES = [
+    # adp_browse_catalog
+    ('adp_browse_catalog', {'action': 'list'},
+     'Catalog.get_catalogs'),
+    ('adp_browse_catalog', {'action': 'entities', 'catalog_name': 'C'},
+     'Catalog.get_catalog_entities'),
+    ('adp_browse_catalog', {'action': 'db_links',
+                              'catalog_name': 'L'},
+     'Catalog.get_database_links'),
+    ('adp_browse_catalog', {'action': 'list_databases'},
+     'Catalog.get_autonomous_databases'),
+    ('adp_browse_catalog', {'action': 'check_db_link', 'catalog_name': 'L'},
+     'Catalog.check_database_link'),
+    # adp_manage_catalog
+    ('adp_manage_catalog', {'action': 'enable', 'catalog_name': 'C'},
+     'Catalog.enable_catalog'),
+    ('adp_manage_catalog', {'action': 'disable', 'catalog_name': 'C'},
+     'Catalog.disable_catalog'),
+    ('adp_manage_catalog', {'action': 'unmount', 'catalog_name': 'C'},
+     'Catalog.unmount_catalog'),
+    # adp_manage_sharing
+    ('adp_manage_sharing', {'action': 'list'},
+     'Share.get_shares'),
+    ('adp_manage_sharing', {'action': 'get', 'share_name': 'S'},
+     'Share.get_share'),
+    ('adp_manage_sharing', {'action': 'create', 'share_name': 'S'},
+     'Share.create_share'),
+    ('adp_manage_sharing', {'action': 'delete', 'share_name': 'S'},
+     'Share.delete_share'),
+    ('adp_manage_sharing', {'action': 'unpublish', 'share_name': 'S'},
+     'Share.unpublish_share'),
+    ('adp_manage_sharing', {'action': 'create_recipient',
+                             'recipient_name': 'R'},
+     'Share.create_recipient'),
+    ('adp_manage_sharing', {'action': 'list_recipients'},
+     'Share.get_recipients'),
+    ('adp_manage_sharing', {'action': 'delete_recipient',
+                             'recipient_name': 'R'},
+     'Share.delete_recipient'),
+    ('adp_manage_sharing', {'action': 'get_objects', 'share_name': 'S'},
+     'Share.get_share_objects'),
+    ('adp_manage_sharing', {'action': 'rename', 'share_name': 'S',
+                             'new_name': 'S2'},
+     'Share.rename_share'),
+    ('adp_manage_sharing', {'action': 'list_providers'},
+     'Share.get_providers'),
+    ('adp_manage_sharing', {'action': 'create_provider',
+                             'recipient_name': 'P'},
+     'Share.create_provider'),
+    ('adp_manage_sharing', {'action': 'delete_provider',
+                             'recipient_name': 'P'},
+     'Share.delete_provider'),
+    # adp_manage_analytic_views
+    ('adp_manage_analytic_views', {'action': 'list'},
+     'Analytics.get_list'),
+    ('adp_manage_analytic_views', {'action': 'drop', 'av_name': 'AV'},
+     'Analytics.drop'),
+    # adp_manage_credentials
+    ('adp_manage_credentials', {'action': 'list'},
+     'Ingest.get_credential_list'),
+    ('adp_manage_credentials', {'action': 'create',
+                                  'credential_name': 'C',
+                                  'username': 'u', 'password': 'p'},
+     'Ingest.create_credential'),
+    ('adp_manage_credentials', {'action': 'create_ocid',
+                                  'credential_name': 'C',
+                                  'user_ocid': 'u',
+                                  'tenancy_ocid': 't',
+                                  'private_key': 'k',
+                                  'fingerprint': 'f'},
+     'Ingest.create_ocid_credential'),
+    ('adp_manage_credentials', {'action': 'drop', 'credential_name': 'C'},
+     'Ingest.drop_credential'),
+    ('adp_manage_credentials', {'action': 'list_storage_links'},
+     'Ingest.get_cloud_storage_link_list'),
+    ('adp_manage_credentials', {'action': 'create_storage_link',
+                                  'storage_link_name': 'SL',
+                                  'uri': 'https://x',
+                                  'credential_name': 'C'},
+     'Ingest.create_cloud_storage_link'),
+    ('adp_manage_credentials', {'action': 'drop_storage_link',
+                                  'storage_link_name': 'SL'},
+     'Ingest.drop_cloud_storage_link'),
+    # adp_manage_insights
+    ('adp_manage_insights', {'action': 'list_requests'},
+     'Insight.get_request_list'),
+    ('adp_manage_insights', {'action': 'list_insights',
+                               'request_name': 'R'},
+     'Insight.get_insights_list'),
+    ('adp_manage_insights', {'action': 'status', 'request_name': 'R'},
+     'Insight.get_job_status'),
+    ('adp_manage_insights', {'action': 'drop', 'request_name': 'R'},
+     'Insight.drop'),
+    # adp_manage_db_links
+    ('adp_manage_db_links', {'action': 'list'},
+     'Ingest.get_database_links'),
+    ('adp_manage_db_links', {'action': 'check', 'db_link_name': 'L'},
+     'Catalog.check_database_link'),
+]
+
+
+@mcp_required
+@pytest.mark.parametrize('tool,kwargs,sdk_path', ADP_DISPATCH_CASES)
+def test_adp_action_dispatch(tool, kwargs, sdk_path):
+    '''Each ADP composite action routes to its expected SDK method.'''
+    _, adp = _adp_dispatch(tool, kwargs, sdk_path)
+    _walk(adp, sdk_path).assert_called()
+
+
+# ------------------------------------------------------------------ #
+
+DT_DISPATCH_CASES = [
+    # dt_manage_schedule
+    ('dt_manage_schedule', {'action': 'list'},
+     'list_schedules', False),
+    ('dt_manage_schedule', {'action': 'delete',
+                              'schedule_name': 'S',
+                              'project_name': 'P'},
+     'delete_schedule', False),
+    # dt_manage_variables
+    ('dt_manage_variables', {'action': 'list'},
+     'list_variables', False),
+    # dt_manage_connection
+    ('dt_manage_connection', {'action': 'list'},
+     'list_connections', False),
+    ('dt_manage_connection', {'action': 'get_types'},
+     'get_connection_types', False),
+    ('dt_manage_connection', {'action': 'test', 'connection_name': 'C'},
+     'test_connection_by_name', False),
+    ('dt_manage_connection', {'action': 'delete', 'connection_name': 'C'},
+     'delete_connection', False),
+]
+
+
+@mcp_required
+@pytest.mark.parametrize('tool,kwargs,sdk_path,on_wb', DT_DISPATCH_CASES)
+def test_dt_action_dispatch(tool, kwargs, sdk_path, on_wb):
+    '''Each DT composite action routes to its expected SDK method.'''
+    _, client, wb = _dt_dispatch(tool, kwargs, sdk_path,
+                                  on_workbench=on_wb)
+    target = wb if on_wb else client
+    _walk(target, sdk_path).assert_called()
+
+
+# ------------------------------------------------------------------ #
+
+ESS_DISPATCH_CASES = [
+    # essbase_manage_application
+    ('essbase_manage_application', {'action': 'create', 'app_name': 'A',
+                                      'db_name': 'D'},
+     'applications.create_application'),
+    ('essbase_manage_application', {'action': 'delete', 'app_name': 'A'},
+     'applications.delete_application'),
+    ('essbase_manage_application', {'action': 'copy', 'app_name': 'A',
+                                      'new_name': 'B'},
+     'applications.copy_application'),
+    ('essbase_manage_application', {'action': 'rename', 'app_name': 'A',
+                                      'new_name': 'B'},
+     'applications.rename_application'),
+    # start/stop go through update_application, not start/stop_application
+    ('essbase_manage_application', {'action': 'start', 'app_name': 'A'},
+     'applications.update_application'),
+    ('essbase_manage_application', {'action': 'stop', 'app_name': 'A'},
+     'applications.update_application'),
+    # essbase_manage_database (no create — only delete/copy/rename/update)
+    ('essbase_manage_database', {'action': 'delete',
+                                   'app_name': 'A', 'db_name': 'D'},
+     'applications.delete_database'),
+    ('essbase_manage_database', {'action': 'copy',
+                                   'app_name': 'A', 'db_name': 'D',
+                                   'target_app': 'A', 'target_db': 'D2'},
+     'applications.copy_database'),
+    ('essbase_manage_database', {'action': 'rename',
+                                   'app_name': 'A', 'db_name': 'D',
+                                   'new_name': 'D2'},
+     'applications.rename_database'),
+    # essbase_manage_files (uses path, not app_name)
+    ('essbase_manage_files', {'action': 'list', 'path': 'applications/A'},
+     'files.list_files'),
+    ('essbase_manage_files', {'action': 'create_folder', 'path': '/p'},
+     'files.create_folder'),
+    ('essbase_manage_files', {'action': 'delete', 'path': '/x'},
+     'files.delete_file'),
+    ('essbase_manage_files', {'action': 'copy', 'path': '/a',
+                                'target_path': '/b'},
+     'files.copy'),
+    ('essbase_manage_files', {'action': 'move', 'path': '/a',
+                                'target_path': '/b'},
+     'files.move'),
+    # essbase_manage_locks (only list / unlock)
+    ('essbase_manage_locks', {'action': 'list',
+                                'app_name': 'A', 'db_name': 'D'},
+     'locks.list_locks'),
+    # essbase_manage_sessions
+    ('essbase_manage_sessions', {'action': 'list'},
+     'sessions.list_sessions'),
+    # essbase_manage_variables (scope: server / application / database)
+    ('essbase_manage_variables', {'action': 'list', 'scope': 'server'},
+     'variables.list_server_variables'),
+    ('essbase_manage_variables', {'action': 'list', 'scope': 'application',
+                                    'app_name': 'A'},
+     'variables.list_app_variables'),
+    ('essbase_manage_variables', {'action': 'list', 'scope': 'database',
+                                    'app_name': 'A', 'db_name': 'D'},
+     'variables.list_db_variables'),
+    # essbase_manage_script (script_name is required positional even for list)
+    ('essbase_manage_script', {'action': 'list',
+                                 'app_name': 'A', 'db_name': 'D',
+                                 'script_name': ''},
+     'scripts.list_scripts'),
+    ('essbase_manage_script', {'action': 'create',
+                                 'app_name': 'A', 'db_name': 'D',
+                                 'script_name': 'S', 'content': 'CALC ALL;'},
+     'scripts.create_script'),
+    ('essbase_manage_script', {'action': 'update',
+                                 'app_name': 'A', 'db_name': 'D',
+                                 'script_name': 'S', 'content': 'CALC ALL;'},
+     'scripts.update_script'),
+    ('essbase_manage_script', {'action': 'delete',
+                                 'app_name': 'A', 'db_name': 'D',
+                                 'script_name': 'S'},
+     'scripts.delete_script'),
+    ('essbase_manage_script', {'action': 'validate',
+                                 'app_name': 'A', 'db_name': 'D',
+                                 'script_name': 'S',
+                                 'content': 'CALC ALL;'},
+     'scripts.validate_script'),
+    # essbase_manage_connections
+    ('essbase_manage_connections', {'action': 'list'},
+     'connections.list_connections'),
+    ('essbase_manage_connections', {'action': 'get',
+                                       'connection_name': 'C'},
+     'connections.get_connection'),
+    ('essbase_manage_connections', {'action': 'delete',
+                                       'connection_name': 'C'},
+     'connections.delete_connection'),
+    # essbase_manage_filters
+    ('essbase_manage_filters', {'action': 'list',
+                                  'app_name': 'A', 'db_name': 'D'},
+     'filters.list_filters'),
+    ('essbase_manage_filters', {'action': 'get',
+                                  'app_name': 'A', 'db_name': 'D',
+                                  'filter_name': 'F'},
+     'filters.get_filter'),
+    ('essbase_manage_filters', {'action': 'delete',
+                                  'app_name': 'A', 'db_name': 'D',
+                                  'filter_name': 'F'},
+     'filters.delete_filter'),
+    ('essbase_manage_filters', {'action': 'rename',
+                                  'app_name': 'A', 'db_name': 'D',
+                                  'filter_name': 'F', 'new_name': 'F2'},
+     'filters.rename_filter'),
+    # essbase_manage_jobs (SDK: get_status / rerun / purge — not _job)
+    ('essbase_manage_jobs', {'action': 'list'},
+     'jobs.list_jobs'),
+    ('essbase_manage_jobs', {'action': 'status', 'job_id': 1},
+     'jobs.get_status'),
+    # rerun also calls wait_for_completion — assert on rerun
+    ('essbase_manage_jobs', {'action': 'rerun', 'job_id': 1},
+     'jobs.rerun'),
+    ('essbase_manage_jobs', {'action': 'purge'},
+     'jobs.purge'),
+    # essbase_manage_datasources (no app_name / db_name params)
+    ('essbase_manage_datasources', {'action': 'list'},
+     'datasources.list_datasources'),
+    ('essbase_manage_datasources', {'action': 'get',
+                                       'datasource_name': 'DS'},
+     'datasources.get_datasource'),
+    ('essbase_manage_datasources', {'action': 'delete',
+                                       'datasource_name': 'DS'},
+     'datasources.delete_datasource'),
+    # essbase_manage_drill_through
+    ('essbase_manage_drill_through', {'action': 'list',
+                                         'app_name': 'A', 'db_name': 'D'},
+     'drill_through.list_reports'),
+    ('essbase_manage_drill_through', {'action': 'get',
+                                         'app_name': 'A', 'db_name': 'D',
+                                         'report_name': 'R'},
+     'drill_through.get_report'),
+    ('essbase_manage_drill_through', {'action': 'delete',
+                                         'app_name': 'A', 'db_name': 'D',
+                                         'report_name': 'R'},
+     'drill_through.delete_report'),
+    # essbase_manage_users
+    ('essbase_manage_users', {'action': 'list'},
+     'users.list_users'),
+    ('essbase_manage_users', {'action': 'get', 'user_id': 'u'},
+     'users.get_user'),
+    ('essbase_manage_users', {'action': 'delete', 'user_id': 'u'},
+     'users.delete_user'),
+    ('essbase_manage_users', {'action': 'list_roles'},
+     'users.list_roles'),
+]
+
+
+@mcp_required
+@pytest.mark.parametrize('tool,kwargs,sdk_path', ESS_DISPATCH_CASES)
+def test_essbase_action_dispatch(tool, kwargs, sdk_path):
+    '''Each Essbase composite action routes to its expected SDK method.'''
+    _, ess = _ess_dispatch(tool, kwargs, sdk_path)
+    _walk(ess, sdk_path).assert_called()
+
+
+# ------------------------------------------------------------------ #
 #  Server module tests                                                 #
 # ------------------------------------------------------------------ #
 
@@ -1562,6 +2150,106 @@ class TestServer:
         from oracle.data_studio_mcp_server.server import mcp
         assert mcp is not None
         assert mcp.name == 'oracle-data-studio'
+
+    def test_lifespan_no_config_yields_empty_context(self):
+        '''When no service is configured, lifespan yields {} and only
+        warning/info logs happen — no SDK imports.'''
+        import asyncio
+        from oracle.data_studio_mcp_server import server as srv
+
+        async def _run():
+            async with srv.app_lifespan(MagicMock()) as ctx:
+                return ctx
+
+        with patch.object(srv, '_config',
+                           MagicMock(essbase=None, adp=None,
+                                      datatransforms=None)):
+            ctx = asyncio.run(_run())
+        assert 'essbase' not in ctx
+        assert 'adp' not in ctx
+
+    def test_lifespan_essbase_login_token(self):
+        '''Lifespan uses login_token() when EssbaseConfig.token is set.'''
+        import asyncio
+        from oracle.data_studio_mcp_server import server as srv
+
+        async def _run():
+            async with srv.app_lifespan(MagicMock()) as ctx:
+                return ctx
+
+        fake_essbase = MagicMock()
+        fake_essbase.login_token.return_value = 'ess-client'
+        ess_cfg = MagicMock(token='tok', url='https://e')
+        with patch.object(srv, '_config',
+                           MagicMock(essbase=ess_cfg, adp=None,
+                                      datatransforms=None)), \
+             patch.dict('sys.modules', {'essbase': fake_essbase}):
+            ctx = asyncio.run(_run())
+        fake_essbase.login_token.assert_called_once_with('https://e', 'tok')
+        assert ctx.get('essbase') == 'ess-client'
+
+    def test_lifespan_essbase_login_user_password(self):
+        '''No token → login(url, user, password) flow.'''
+        import asyncio
+        from oracle.data_studio_mcp_server import server as srv
+
+        async def _run():
+            async with srv.app_lifespan(MagicMock()) as ctx:
+                return ctx
+
+        fake_essbase = MagicMock()
+        fake_essbase.login.return_value = 'ess-client'
+        ess_cfg = MagicMock(token=None, url='https://e',
+                             user='admin', password='p')
+        with patch.object(srv, '_config',
+                           MagicMock(essbase=ess_cfg, adp=None,
+                                      datatransforms=None)), \
+             patch.dict('sys.modules', {'essbase': fake_essbase}):
+            ctx = asyncio.run(_run())
+        fake_essbase.login.assert_called_once()
+        assert ctx.get('essbase') == 'ess-client'
+
+    def test_lifespan_adp_caches_config_and_logs_in(self):
+        '''ADP path stores _adp_config + tries adp.login.'''
+        import asyncio
+        from oracle.data_studio_mcp_server import server as srv
+
+        async def _run():
+            async with srv.app_lifespan(MagicMock()) as ctx:
+                return ctx
+
+        fake_adp = MagicMock()
+        fake_adp.login.return_value = 'adp-client'
+        adp_cfg = MagicMock(url='https://a', user='ADMIN', password='p')
+        with patch.object(srv, '_config',
+                           MagicMock(essbase=None, adp=adp_cfg,
+                                      datatransforms=None)), \
+             patch.dict('sys.modules', {'adp': fake_adp}):
+            ctx = asyncio.run(_run())
+        assert ctx.get('_adp_config') is adp_cfg
+        assert ctx.get('adp') == 'adp-client'
+
+    def test_lifespan_adp_login_failure_is_caught(self):
+        '''ADP login that throws is logged but doesn't break startup.'''
+        import asyncio
+        from oracle.data_studio_mcp_server import server as srv
+
+        async def _run():
+            async with srv.app_lifespan(MagicMock()) as ctx:
+                return ctx
+
+        fake_adp = MagicMock()
+        fake_adp.login.side_effect = RuntimeError('boom')
+        adp_cfg = MagicMock(url='https://a', user='ADMIN', password='p')
+        with patch.object(srv, '_config',
+                           MagicMock(essbase=None, adp=adp_cfg,
+                                      datatransforms=None)), \
+             patch.dict('sys.modules', {'adp': fake_adp}):
+            ctx = asyncio.run(_run())
+        # Config still cached for later retry
+        assert ctx.get('_adp_config') is adp_cfg
+        # No client because login failed
+        assert 'adp' not in ctx
 
     def test_server_instructions_mention_annotations(self):
         '''Server instructions should nudge the LLM toward the

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
@@ -1,0 +1,1644 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''
+Unit tests for the Oracle Data Studio MCP Server (upleveled tools).
+
+Tests configuration loading, profile filtering, credential store,
+helpers, and tool registration/dispatch — all without live servers.
+
+Usage:
+    python -m pytest oracle/data_studio_mcp_server/tests/ -v
+'''
+
+import json
+import os
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+from dataclasses import asdict
+
+try:
+    import mcp  # noqa: F401
+    HAS_MCP = True
+except ImportError:
+    HAS_MCP = False
+
+mcp_required = pytest.mark.skipif(not HAS_MCP, reason='mcp package not installed')
+
+
+# ------------------------------------------------------------------ #
+#  Config tests                                                        #
+# ------------------------------------------------------------------ #
+
+class TestServerConfig:
+
+    def test_config_dataclass_defaults(self):
+        from oracle.data_studio_mcp_server.config import ServerConfig
+        cfg = ServerConfig()
+        assert cfg.essbase is None
+        assert cfg.adp is None
+        assert cfg.datatransforms is None
+        assert cfg.transport == 'stdio'
+        assert cfg.port == 8000
+        assert cfg.profile == 'admin'
+        # S8: bind address defaults to loopback (no auth → no
+        # external exposure unless explicit).
+        assert cfg.host == '127.0.0.1'
+
+    @patch('oracle.data_studio_mcp_server.config.load_config_file', return_value={})
+    @patch('oracle.data_studio_mcp_server.config.get_keyring_password', return_value=None)
+    def test_load_config_host_default_is_loopback(self, mock_keyring, mock_file):
+        '''S8: With nothing configured, host defaults to 127.0.0.1.'''
+        from oracle.data_studio_mcp_server.config import load_config
+        with patch.dict(os.environ, {}, clear=True):
+            cfg = load_config()
+        assert cfg.host == '127.0.0.1'
+
+    @patch('oracle.data_studio_mcp_server.config.load_config_file', return_value={})
+    @patch('oracle.data_studio_mcp_server.config.get_keyring_password', return_value=None)
+    def test_load_config_host_override_via_env(self, mock_keyring, mock_file):
+        '''S8: explicit MCP_HOST=0.0.0.0 must override the safe default.'''
+        from oracle.data_studio_mcp_server.config import load_config
+        with patch.dict(os.environ, {'MCP_HOST': '0.0.0.0'}, clear=False):
+            cfg = load_config()
+        assert cfg.host == '0.0.0.0'
+
+    def test_essbase_config_dataclass(self):
+        from oracle.data_studio_mcp_server.config import EssbaseConfig
+        cfg = EssbaseConfig(
+            url='https://host', user='admin', password='pass')
+        assert cfg.url == 'https://host'
+        assert cfg.user == 'admin'
+        assert cfg.password == 'pass'
+        assert cfg.token is None
+
+    def test_essbase_config_with_token(self):
+        from oracle.data_studio_mcp_server.config import EssbaseConfig
+        cfg = EssbaseConfig(
+            url='https://host', user='', password='',
+            token='mytoken')
+        assert cfg.token == 'mytoken'
+
+    def test_adp_config_dataclass(self):
+        from oracle.data_studio_mcp_server.config import AdpConfig
+        cfg = AdpConfig(url='https://adp', user='admin', password='pass')
+        assert cfg.url == 'https://adp'
+
+    def test_dt_config_dataclass(self):
+        from oracle.data_studio_mcp_server.config import DataTransformsConfig
+        cfg = DataTransformsConfig(
+            url='https://dt', user='admin', password='pass')
+        assert cfg.url == 'https://dt'
+
+    @patch('oracle.data_studio_mcp_server.config.load_config_file', return_value={})
+    @patch('oracle.data_studio_mcp_server.config.get_keyring_password', return_value=None)
+    def test_load_config_env_vars(self, mock_keyring, mock_file):
+        '''Config from environment variables.'''
+        from oracle.data_studio_mcp_server.config import load_config
+        env = {
+            'ESSBASE_URL': 'https://ess-env',
+            'ESSBASE_USER': 'envuser',
+            'ESSBASE_PASSWORD': 'envpass',
+            'MCP_TRANSPORT': 'streamable-http',
+            'MCP_PORT': '9000',
+            'MCP_PROFILE': 'analyst',
+        }
+        with patch.dict(os.environ, env, clear=False):
+            cfg = load_config()
+        assert cfg.essbase is not None
+        assert cfg.essbase.url == 'https://ess-env'
+        assert cfg.transport == 'streamable-http'
+        assert cfg.port == 9000
+        assert cfg.profile == 'analyst'
+
+    @patch('oracle.data_studio_mcp_server.config.load_config_file', return_value={})
+    @patch('oracle.data_studio_mcp_server.config.get_keyring_password', return_value=None)
+    def test_load_config_no_service(self, mock_keyring, mock_file):
+        '''Config with no service env vars returns None for all services.'''
+        from oracle.data_studio_mcp_server.config import load_config
+        with patch.dict(os.environ, {}, clear=True):
+            cfg = load_config()
+        assert cfg.essbase is None
+        assert cfg.adp is None
+        assert cfg.datatransforms is None
+
+    @patch('oracle.data_studio_mcp_server.config.load_config_file', return_value={})
+    @patch('oracle.data_studio_mcp_server.config.get_keyring_password', return_value=None)
+    def test_load_config_adp_env(self, mock_keyring, mock_file):
+        from oracle.data_studio_mcp_server.config import load_config
+        env = {
+            'ADP_URL': 'https://adp-env',
+            'ADP_USER': 'adpuser',
+            'ADP_PASSWORD': 'adppass',
+        }
+        with patch.dict(os.environ, env, clear=False):
+            cfg = load_config()
+        assert cfg.adp is not None
+        assert cfg.adp.url == 'https://adp-env'
+
+    @patch('oracle.data_studio_mcp_server.config.load_config_file', return_value={})
+    @patch('oracle.data_studio_mcp_server.config.get_keyring_password', return_value=None)
+    def test_load_config_dt_env(self, mock_keyring, mock_file):
+        from oracle.data_studio_mcp_server.config import load_config
+        env = {
+            'DT_URL': 'https://dt-env',
+            'DT_USER': 'dtuser',
+            'DT_PASSWORD': 'dtpass',
+        }
+        with patch.dict(os.environ, env, clear=False):
+            cfg = load_config()
+        assert cfg.datatransforms is not None
+        assert cfg.datatransforms.url == 'https://dt-env'
+
+    @patch('oracle.data_studio_mcp_server.config.load_config_file', return_value={})
+    @patch('oracle.data_studio_mcp_server.config.get_keyring_password', return_value=None)
+    def test_load_config_essbase_token(self, mock_keyring, mock_file):
+        from oracle.data_studio_mcp_server.config import load_config
+        env = {
+            'ESSBASE_URL': 'https://ess-tok',
+            'ESSBASE_TOKEN': 'mytok',
+        }
+        with patch.dict(os.environ, env, clear=False):
+            cfg = load_config()
+        assert cfg.essbase is not None
+        assert cfg.essbase.token == 'mytok'
+
+    def test_config_asdict(self):
+        from oracle.data_studio_mcp_server.config import ServerConfig, EssbaseConfig
+        cfg = ServerConfig(
+            essbase=EssbaseConfig(url='u', user='admin', password='p'))
+        d = asdict(cfg)
+        assert d['essbase']['url'] == 'u'
+        assert d['transport'] == 'stdio'
+
+
+# ------------------------------------------------------------------ #
+#  Credential store tests                                              #
+# ------------------------------------------------------------------ #
+
+class TestCredentialStore:
+
+    def test_config_dir_default(self):
+        from oracle.data_studio_mcp_server.credential_store import CONFIG_DIR
+        assert '.oracle-data-studio' in str(CONFIG_DIR)
+
+    @patch('oracle.data_studio_mcp_server.credential_store.CONFIG_FILE')
+    def test_load_config_file_missing(self, mock_path):
+        mock_path.exists.return_value = False
+        from oracle.data_studio_mcp_server.credential_store import load_config_file
+        assert load_config_file() == {}
+
+    def test_get_keyring_password_no_keyring(self):
+        '''get_keyring_password returns None when keyring is unavailable.'''
+        from oracle.data_studio_mcp_server.credential_store import get_keyring_password
+        import builtins
+        _real_import = builtins.__import__
+
+        def _no_keyring(name, *args, **kwargs):
+            if name == 'keyring':
+                raise ImportError('mocked: no keyring')
+            return _real_import(name, *args, **kwargs)
+
+        with patch('builtins.__import__', side_effect=_no_keyring):
+            assert get_keyring_password('essbase', 'someuser') is None
+
+
+# ------------------------------------------------------------------ #
+#  Helpers tests                                                       #
+# ------------------------------------------------------------------ #
+
+class TestHelpers:
+
+    def test_safe_call_success(self):
+        from oracle.data_studio_mcp_server.tools._helpers import safe_call
+        result, error = safe_call('test', lambda x: x * 2, 21)
+        assert result == 42
+        assert error is None
+
+    def test_safe_call_failure(self):
+        from oracle.data_studio_mcp_server.tools._helpers import safe_call
+        def _fail():
+            raise ValueError('boom')
+        result, error = safe_call('test', _fail)
+        assert result is None
+        assert 'boom' in error
+
+    def test_safe_err_redacts_dsn_password(self):
+        '''S5: Oracle/cx_Oracle DSNs embed credentials.'''
+        from oracle.data_studio_mcp_server.tools._helpers import safe_err
+        msg = ("ORA-01017: invalid username/password; "
+               "logon denied for ADMIN/Welcome2025#@//myadb.adb.us-ashburn-1."
+               "oraclecloud.com:1522/myadb_high")
+        cleaned = safe_err(msg)
+        assert 'Welcome2025' not in cleaned
+        assert 'ADMIN/***@' in cleaned
+
+    def test_safe_err_redacts_url_userinfo(self):
+        '''Passwords in URL userinfo (https://user:pass@host).'''
+        from oracle.data_studio_mcp_server.tools._helpers import safe_err
+        msg = ('Connection to https://weblogic:welcome1@'
+               'essbase.example.com/essbase/rest/v1 failed')
+        cleaned = safe_err(msg)
+        assert 'welcome1' not in cleaned
+        assert '***:***@' in cleaned
+
+    def test_safe_err_redacts_bearer_token(self):
+        from oracle.data_studio_mcp_server.tools._helpers import safe_err
+        msg = ('401 Unauthorized: Authorization: Bearer '
+               'eyJhbGciOiJSUzI1NiJ9.payload.signature_chunk')
+        cleaned = safe_err(msg)
+        assert 'eyJ' not in cleaned
+        assert 'signature_chunk' not in cleaned
+
+    def test_safe_err_redacts_password_kv(self):
+        '''password=... in JSON / query strings / env strings.'''
+        from oracle.data_studio_mcp_server.tools._helpers import safe_err
+        for raw in [
+            '{"username": "ADMIN", "password": "Welcome2025#"}',
+            'connect_string: ADMIN; password=Welcome2025#; host=...',
+            "param: 'password'='Welcome2025#'",
+        ]:
+            cleaned = safe_err(raw)
+            assert 'Welcome2025' not in cleaned, \
+                f'password leaked through: {cleaned!r}'
+
+    def test_safe_err_redacts_ocid_tail(self):
+        from oracle.data_studio_mcp_server.tools._helpers import safe_err
+        msg = ('failed for compartment '
+               'ocid1.compartment.oc1..aaaaaaaa1234567890zzzzzzz '
+               'and tenancy '
+               'ocid1.tenancy.oc1..aaaaaaaaqwerty12345')
+        cleaned = safe_err(msg)
+        assert 'aaaaaaaa1234567890zzzzzzz' not in cleaned
+        assert 'aaaaaaaaqwerty12345' not in cleaned
+        # Prefix kept for context
+        assert 'ocid1.compartment.***' in cleaned
+        assert 'ocid1.tenancy.***' in cleaned
+
+    def test_safe_err_redacts_filesystem_paths(self):
+        from oracle.data_studio_mcp_server.tools._helpers import safe_err
+        msg = ('wallet not found at '
+               '/Users/alex/secrets/wallet.zip — '
+               'also tried /opt/oracle/network/admin/cwallet.sso')
+        cleaned = safe_err(msg)
+        assert '/Users/alex/secrets' not in cleaned
+        assert '/opt/oracle/network' not in cleaned
+        # Basename retained for diagnosis
+        assert 'wallet.zip' in cleaned
+        assert 'cwallet.sso' in cleaned
+
+    def test_safe_err_caps_length(self):
+        from oracle.data_studio_mcp_server.tools._helpers import safe_err
+        msg = 'x' * 5000
+        cleaned = safe_err(msg)
+        assert len(cleaned) < 1000
+        assert 'truncated' in cleaned
+
+    def test_err_funnels_through_safe_err(self):
+        '''The public `err()` helper must sanitise, not pass through.'''
+        from oracle.data_studio_mcp_server.tools._helpers import err
+        msg = 'Connection failed for ADMIN/Welcome2025#@host:1521/svc'
+        result = json.loads(err(msg))
+        assert 'Welcome2025' not in result['error']
+        assert 'ADMIN/***@' in result['error']
+
+    def test_safe_call_failure_redacts(self):
+        '''safe_call must funnel exceptions through safe_err too.'''
+        from oracle.data_studio_mcp_server.tools._helpers import safe_call
+        def _fail():
+            raise ValueError(
+                'login failed for ADMIN/Welcome2025#@adb.example.com')
+        _, error = safe_call('login', _fail)
+        assert 'Welcome2025' not in error
+        assert 'login' in error  # label retained
+
+    def test_build_response_no_errors(self):
+        from oracle.data_studio_mcp_server.tools._helpers import build_response
+        resp = json.loads(build_response({'key': 'val'}))
+        assert resp['key'] == 'val'
+        assert '_errors' not in resp
+
+    def test_build_response_with_errors(self):
+        from oracle.data_studio_mcp_server.tools._helpers import build_response
+        resp = json.loads(build_response({'key': 'val'}, ['e1', 'e2']))
+        assert resp['_errors'] == ['e1', 'e2']
+
+    def test_err(self):
+        from oracle.data_studio_mcp_server.tools._helpers import err
+        resp = json.loads(err('bad'))
+        assert resp['error'] == 'bad'
+
+    def test_fmt_none(self):
+        from oracle.data_studio_mcp_server.tools._helpers import fmt
+        resp = json.loads(fmt(None))
+        assert resp['status'] == 'success'
+
+    def test_fmt_dict(self):
+        from oracle.data_studio_mcp_server.tools._helpers import fmt
+        resp = json.loads(fmt({'a': 1}))
+        assert resp['a'] == 1
+
+    def test_fmt_list(self):
+        from oracle.data_studio_mcp_server.tools._helpers import fmt
+        resp = json.loads(fmt([1, 2, 3]))
+        assert resp == [1, 2, 3]
+
+    def test_fmt_string(self):
+        from oracle.data_studio_mcp_server.tools._helpers import fmt
+        assert fmt('hello') == 'hello'
+
+    def test_safe_call_with_kwargs(self):
+        from oracle.data_studio_mcp_server.tools._helpers import safe_call
+        def _fn(a, b=10):
+            return a + b
+        result, error = safe_call('test', _fn, 5, b=20)
+        assert result == 25
+        assert error is None
+
+
+# ------------------------------------------------------------------ #
+#  Profile tests                                                       #
+# ------------------------------------------------------------------ #
+
+class TestProfiles:
+
+    def test_valid_profiles(self):
+        from oracle.data_studio_mcp_server.profiles import VALID_PROFILES
+        assert 'admin' in VALID_PROFILES
+        assert 'analyst' in VALID_PROFILES
+        assert 'viewer' in VALID_PROFILES
+
+    def test_admin_profile_is_none(self):
+        from oracle.data_studio_mcp_server.profiles import PROFILES
+        assert PROFILES['admin'] is None
+
+    def test_verb_extraction_essbase(self):
+        from oracle.data_studio_mcp_server.profiles import _get_verb_suffix
+        assert _get_verb_suffix('essbase_explore') == 'explore'
+        assert _get_verb_suffix('essbase_describe_database') == 'describe_database'
+        assert _get_verb_suffix('essbase_run_calculation') == 'run_calculation'
+        assert _get_verb_suffix('essbase_manage_variables') == 'manage_variables'
+
+    def test_verb_extraction_adp(self):
+        from oracle.data_studio_mcp_server.profiles import _get_verb_suffix
+        assert _get_verb_suffix('adp_execute_sql') == 'execute_sql'
+        assert _get_verb_suffix('adp_discover_schema') == 'discover_schema'
+        assert _get_verb_suffix('adp_build_analytic_view') == 'build_analytic_view'
+
+    def test_verb_extraction_dt(self):
+        from oracle.data_studio_mcp_server.profiles import _get_verb_suffix
+        assert _get_verb_suffix('dt_explore') == 'explore'
+        assert _get_verb_suffix('dt_manage_schedule') == 'manage_schedule'
+
+    def test_verb_extraction_unknown_prefix(self):
+        from oracle.data_studio_mcp_server.profiles import _get_verb_suffix
+        assert _get_verb_suffix('unknown_tool') == 'unknown_tool'
+
+    @mcp_required
+    def test_viewer_profile_filtering(self):
+        '''Viewer profile: only read-only tools.'''
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {
+            'essbase_explore': MagicMock(),
+            'essbase_describe_database': MagicMock(),
+            'essbase_query': MagicMock(),
+            'essbase_run_calculation': MagicMock(),
+            'essbase_manage_variables': MagicMock(),
+            'essbase_server_health': MagicMock(),
+            'adp_build_analytic_view': MagicMock(),
+            'adp_search': MagicMock(),
+            'adp_analyze_analytic_view': MagicMock(),
+            'dt_explore': MagicMock(),
+            'dt_create_pipeline': MagicMock(),
+            'dt_browse_data': MagicMock(),
+        }
+        apply_profile(mock_mcp, 'viewer')
+        tools = mock_mcp._tool_manager._tools
+        # Viewer should keep: explore, describe_, server_health,
+        # browse_, search_, analyze_
+        assert 'essbase_explore' in tools
+        assert 'essbase_describe_database' in tools
+        assert 'essbase_server_health' in tools
+        assert 'dt_explore' in tools
+        assert 'dt_browse_data' in tools
+        assert 'adp_search' in tools
+        assert 'adp_analyze_analytic_view' in tools
+        # Viewer should remove: run_, manage_, build_, create_
+        assert 'essbase_run_calculation' not in tools
+        assert 'essbase_manage_variables' not in tools
+        assert 'adp_build_analytic_view' not in tools
+        assert 'dt_create_pipeline' not in tools
+
+    @mcp_required
+    def test_analyst_profile_filtering(self):
+        '''Analyst profile: read + query/execute, no modify.'''
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {
+            'essbase_explore': MagicMock(),
+            'essbase_query': MagicMock(),
+            'essbase_run_calculation': MagicMock(),
+            'essbase_manage_variables': MagicMock(),
+            'adp_generate_insights': MagicMock(),
+            'adp_ai_chat': MagicMock(),
+            'adp_load_from_cloud': MagicMock(),
+            'dt_explore': MagicMock(),
+            'dt_manage_schedule': MagicMock(),
+        }
+        apply_profile(mock_mcp, 'analyst')
+        tools = mock_mcp._tool_manager._tools
+        # Analyst should keep: explore, query, run_, generate_, ai_
+        assert 'essbase_explore' in tools
+        assert 'essbase_run_calculation' in tools
+        assert 'adp_generate_insights' in tools
+        assert 'adp_ai_chat' in tools
+        assert 'dt_explore' in tools
+        # Analyst should remove: manage_, load_from_cloud (explicit deny)
+        assert 'essbase_manage_variables' not in tools
+        assert 'adp_load_from_cloud' not in tools
+        assert 'dt_manage_schedule' not in tools
+
+    @mcp_required
+    def test_viewer_cannot_run_mdx(self):
+        '''Security: viewer must not be able to invoke any tool that
+        runs MDX. Specifically:
+          - essbase_query (verb=`query`) — already excluded by verb rules.
+          - essbase_export_data — used to be allowed via the `export_`
+            verb prefix, but it accepts a free-form `mdx` arg and runs
+            ess.grid.execute_mdx, so it was moved out of viewer.
+
+        This test locks both guarantees in. Removing `export_` from the
+        viewer allowed_verbs (or adding `essbase_export_data` to
+        explicit_deny) must keep this test passing.'''
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {
+            'essbase_query':       MagicMock(),
+            'essbase_export_data': MagicMock(),
+            # Sanity controls — should still be visible to viewer
+            'essbase_explore':     MagicMock(),
+            'essbase_describe_database': MagicMock(),
+            'essbase_browse_outline': MagicMock(),
+            'essbase_search_members': MagicMock(),
+        }
+        apply_profile(mock_mcp, 'viewer')
+        tools = mock_mcp._tool_manager._tools
+        # Both MDX-running tools must be removed for viewer
+        assert 'essbase_query' not in tools, \
+            'viewer must not have essbase_query (runs MDX)'
+        assert 'essbase_export_data' not in tools, \
+            'viewer must not have essbase_export_data (runs MDX)'
+        # Read-only tools should remain
+        assert 'essbase_explore' in tools
+        assert 'essbase_describe_database' in tools
+        assert 'essbase_browse_outline' in tools
+        assert 'essbase_search_members' in tools
+
+    @mcp_required
+    def test_viewer_cannot_read_calc_script_or_logs(self):
+        '''S2: essbase_get_script and essbase_get_logs leak content
+        (script source code, logs with PII / SQL). Both are denied
+        for viewer.'''
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {
+            'essbase_get_script': MagicMock(),
+            'essbase_get_logs':   MagicMock(),
+            # sanity controls
+            'essbase_explore':    MagicMock(),
+            'adp_get_annotations': MagicMock(),  # other get_ stays
+        }
+        apply_profile(mock_mcp, 'viewer')
+        tools = mock_mcp._tool_manager._tools
+        assert 'essbase_get_script' not in tools, \
+            'viewer must not see calc-script source'
+        assert 'essbase_get_logs' not in tools, \
+            'viewer must not see server logs'
+        # Other get_ tools still work
+        assert 'essbase_explore' in tools
+        assert 'adp_get_annotations' in tools
+
+    @mcp_required
+    def test_analyst_can_read_script_but_not_logs(self):
+        '''S2: analyst keeps essbase_get_script (they may run it via
+        essbase_run_calculation) but loses essbase_get_logs (admin
+        only).'''
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {
+            'essbase_get_script': MagicMock(),
+            'essbase_get_logs':   MagicMock(),
+        }
+        apply_profile(mock_mcp, 'analyst')
+        tools = mock_mcp._tool_manager._tools
+        assert 'essbase_get_script' in tools, \
+            'analyst should be able to read scripts they may run'
+        assert 'essbase_get_logs' not in tools, \
+            'logs are admin-only'
+
+    @mcp_required
+    def test_analyst_cannot_run_pipeline(self):
+        '''S3: dt_run_pipeline mutates target tables — analyst is
+        "read + execute, no modify" and pipelines write, so deny.'''
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {
+            'dt_run_pipeline':     MagicMock(),
+            # sanity — other run_ verbs (e.g. essbase_run_calculation)
+            # are still allowed for analyst
+            'essbase_run_calculation': MagicMock(),
+        }
+        apply_profile(mock_mcp, 'analyst')
+        tools = mock_mcp._tool_manager._tools
+        assert 'dt_run_pipeline' not in tools, \
+            'analyst must not run pipelines (mutates targets)'
+        assert 'essbase_run_calculation' in tools, \
+            'analyst should still run calc scripts'
+
+    @mcp_required
+    def test_analyst_keeps_export_data(self):
+        '''Analyst is allowed to run MDX (read+execute). After we
+        removed `export_` from viewer, make sure analyst still has
+        access — analyst inherits viewer verbs PLUS execute/run/query.'''
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {
+            'essbase_export_data': MagicMock(),
+            'essbase_query':       MagicMock(),
+        }
+        apply_profile(mock_mcp, 'analyst')
+        tools = mock_mcp._tool_manager._tools
+        assert 'essbase_export_data' in tools, \
+            'analyst should have essbase_export_data'
+        assert 'essbase_query' in tools, \
+            'analyst should have essbase_query'
+
+    @mcp_required
+    def test_viewer_profile_blocks_manage_catalog_allows_browse(self):
+        '''Viewer: adp_browse_catalog allowed, adp_manage_catalog blocked.'''
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {
+            'adp_browse_catalog': MagicMock(),
+            'adp_manage_catalog': MagicMock(),
+        }
+        apply_profile(mock_mcp, 'viewer')
+        tools = mock_mcp._tool_manager._tools
+        assert 'adp_browse_catalog' in tools, \
+            'browse_catalog should be visible to viewer'
+        assert 'adp_manage_catalog' not in tools, \
+            'manage_catalog must not be visible to viewer'
+
+    @mcp_required
+    def test_viewer_profile_blocks_manage_project(self):
+        '''Viewer: dt_describe_project allowed, dt_manage_project blocked.'''
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {
+            'dt_describe_project': MagicMock(),
+            'dt_manage_project': MagicMock(),
+        }
+        apply_profile(mock_mcp, 'viewer')
+        tools = mock_mcp._tool_manager._tools
+        assert 'dt_describe_project' in tools, \
+            'describe_project should be visible to viewer'
+        assert 'dt_manage_project' not in tools, \
+            'manage_project (delete) must not be visible to viewer'
+
+    @mcp_required
+    def test_analyst_profile_blocks_manage_catalog(self):
+        '''Analyst: adp_browse_catalog allowed, adp_manage_catalog blocked.'''
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {
+            'adp_browse_catalog': MagicMock(),
+            'adp_manage_catalog': MagicMock(),
+            'dt_describe_project': MagicMock(),
+            'dt_manage_project': MagicMock(),
+        }
+        apply_profile(mock_mcp, 'analyst')
+        tools = mock_mcp._tool_manager._tools
+        assert 'adp_browse_catalog' in tools
+        assert 'adp_manage_catalog' not in tools
+        assert 'dt_describe_project' in tools
+        assert 'dt_manage_project' not in tools
+
+    @mcp_required
+    def test_admin_profile_no_filtering(self):
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {
+            'essbase_explore': MagicMock(),
+            'essbase_manage_variables': MagicMock(),
+            'adp_manage_sharing': MagicMock(),
+        }
+        apply_profile(mock_mcp, 'admin')
+        assert len(mock_mcp._tool_manager._tools) == 3
+
+    @mcp_required
+    def test_invalid_profile_raises(self):
+        from oracle.data_studio_mcp_server.profiles import apply_profile
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {}
+        with pytest.raises(ValueError, match='Unknown profile'):
+            apply_profile(mock_mcp, 'superadmin')
+
+
+# ------------------------------------------------------------------ #
+#  Tool registration tests                                             #
+# ------------------------------------------------------------------ #
+
+@mcp_required
+class TestToolRegistration:
+
+    def test_essbase_tools_register(self):
+        '''essbase_tools registers exactly 30 tools.'''
+        from mcp.server.fastmcp import FastMCP
+        mcp_server = FastMCP('test')
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        essbase_tools.register_tools(mcp_server)
+        tools = mcp_server._tool_manager._tools
+        assert len(tools) == 30
+
+    def test_adp_tools_register(self):
+        '''adp_tools registers exactly 15 tools.'''
+        from mcp.server.fastmcp import FastMCP
+        mcp_server = FastMCP('test')
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        adp_tools.register_tools(mcp_server)
+        tools = mcp_server._tool_manager._tools
+        assert len(tools) == 15
+
+    def test_dt_tools_register(self):
+        '''dt_tools registers exactly 15 tools.'''
+        from mcp.server.fastmcp import FastMCP
+        mcp_server = FastMCP('test')
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        dt_tools.register_tools(mcp_server)
+        tools = mcp_server._tool_manager._tools
+        assert len(tools) == 15
+
+    def test_all_tools_register(self):
+        '''All tool modules together register exactly 60 tools.'''
+        from mcp.server.fastmcp import FastMCP
+        mcp_server = FastMCP('test')
+        from oracle.data_studio_mcp_server.tools import (
+            essbase_tools, adp_tools, dt_tools)
+        essbase_tools.register_tools(mcp_server)
+        adp_tools.register_tools(mcp_server)
+        dt_tools.register_tools(mcp_server)
+        tools = mcp_server._tool_manager._tools
+        assert len(tools) == 60
+
+    def test_essbase_tool_names(self):
+        '''Verify expected Essbase tool names.'''
+        from mcp.server.fastmcp import FastMCP
+        mcp_server = FastMCP('test')
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        essbase_tools.register_tools(mcp_server)
+        names = set(mcp_server._tool_manager._tools.keys())
+        expected = {
+            'essbase_explore', 'essbase_describe_database',
+            'essbase_query', 'essbase_browse_outline',
+            'essbase_search_members', 'essbase_run_calculation',
+            'essbase_load_data', 'essbase_deploy_workbook',
+            'essbase_manage_variables', 'essbase_get_script',
+            'essbase_manage_security', 'essbase_server_health',
+            'essbase_export_data',
+            'essbase_manage_application', 'essbase_manage_script',
+            'essbase_manage_files', 'essbase_manage_connections',
+            'essbase_manage_locks', 'essbase_manage_filters',
+            'essbase_manage_jobs',
+            'essbase_edit_outline', 'essbase_manage_datasources',
+            'essbase_manage_drill_through',
+            'essbase_manage_database', 'essbase_manage_users',
+            'essbase_manage_groups', 'essbase_manage_sessions',
+            'essbase_manage_db_settings', 'essbase_get_logs',
+            'essbase_outline_metadata',
+        }
+        assert names == expected
+
+    def test_adp_tool_names(self):
+        '''Verify expected ADP tool names.'''
+        from mcp.server.fastmcp import FastMCP
+        mcp_server = FastMCP('test')
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        adp_tools.register_tools(mcp_server)
+        names = set(mcp_server._tool_manager._tools.keys())
+        expected = {
+            'adp_build_analytic_view',
+            'adp_query_analytic_view', 'adp_analyze_analytic_view',
+            'adp_generate_insights',
+            'adp_search', 'adp_load_from_cloud',
+            'adp_browse_catalog', 'adp_manage_catalog',
+            'adp_manage_sharing',
+            'adp_manage_analytic_views', 'adp_manage_credentials',
+            'adp_ai_chat', 'adp_manage_insights',
+            'adp_manage_db_links',
+            'adp_get_annotations',
+        }
+        assert names == expected
+
+    def test_dt_tool_names(self):
+        '''Verify expected Data Transforms tool names.'''
+        from mcp.server.fastmcp import FastMCP
+        mcp_server = FastMCP('test')
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        dt_tools.register_tools(mcp_server)
+        names = set(mcp_server._tool_manager._tools.keys())
+        expected = {
+            'dt_explore', 'dt_describe_project',
+            'dt_describe_connection', 'dt_create_pipeline',
+            'dt_check_health', 'dt_browse_data',
+            'dt_manage_dataflow', 'dt_manage_schedule',
+            'dt_manage_variables',
+            'dt_run_pipeline', 'dt_manage_connection',
+            'dt_manage_dataload', 'dt_manage_data_entities',
+            'dt_manage_workflow', 'dt_manage_project',
+        }
+        assert names == expected
+
+    def test_all_tools_have_docstrings(self):
+        '''Every registered tool should have a docstring.'''
+        from mcp.server.fastmcp import FastMCP
+        mcp_server = FastMCP('test')
+        from oracle.data_studio_mcp_server.tools import (
+            essbase_tools, adp_tools, dt_tools)
+        essbase_tools.register_tools(mcp_server)
+        adp_tools.register_tools(mcp_server)
+        dt_tools.register_tools(mcp_server)
+        for name, tool in mcp_server._tool_manager._tools.items():
+            desc = getattr(tool, 'description', None)
+            fn = getattr(tool, 'fn', None)
+            has_doc = (desc and len(desc) > 0) or (
+                fn and fn.__doc__ and len(fn.__doc__) > 0)
+            assert has_doc, f'Tool {name} has no description/docstring'
+
+    def test_all_tool_names_have_service_prefix(self):
+        '''All tools should start with essbase_, adp_, or dt_.'''
+        from mcp.server.fastmcp import FastMCP
+        mcp_server = FastMCP('test')
+        from oracle.data_studio_mcp_server.tools import (
+            essbase_tools, adp_tools, dt_tools)
+        essbase_tools.register_tools(mcp_server)
+        adp_tools.register_tools(mcp_server)
+        dt_tools.register_tools(mcp_server)
+        for name in mcp_server._tool_manager._tools:
+            assert (name.startswith('essbase_') or
+                    name.startswith('adp_') or
+                    name.startswith('dt_')), \
+                f'Tool {name} missing service prefix'
+
+
+# ------------------------------------------------------------------ #
+#  Essbase connection helper tests                                     #
+# ------------------------------------------------------------------ #
+
+class TestEssbaseConnect:
+
+    def test_get_essbase_returns_client(self):
+        from oracle.data_studio_mcp_server.tools._essbase_connect import get_essbase
+        mock_ctx = MagicMock()
+        mock_ess = MagicMock()
+        mock_ctx.request_context.lifespan_context = {'essbase': mock_ess}
+        assert get_essbase(mock_ctx) is mock_ess
+
+    def test_get_essbase_returns_none(self):
+        from oracle.data_studio_mcp_server.tools._essbase_connect import get_essbase
+        mock_ctx = MagicMock()
+        mock_ctx.request_context.lifespan_context = {}
+        assert get_essbase(mock_ctx) is None
+
+
+# ------------------------------------------------------------------ #
+#  ADP connection helper tests                                         #
+# ------------------------------------------------------------------ #
+
+class TestAdpConnect:
+
+    def test_get_adp_returns_client(self):
+        from oracle.data_studio_mcp_server.tools._adp_connect import get_adp
+        mock_ctx = MagicMock()
+        mock_adp = MagicMock()
+        mock_adp.rest.expired = None
+        mock_ctx.request_context.lifespan_context = {'adp': mock_adp}
+        assert get_adp(mock_ctx) is mock_adp
+
+    def test_get_adp_returns_none_no_client(self):
+        from oracle.data_studio_mcp_server.tools._adp_connect import get_adp
+        mock_ctx = MagicMock()
+        mock_ctx.request_context.lifespan_context = {}
+        assert get_adp(mock_ctx) is None
+
+    def test_is_expired_401(self):
+        from oracle.data_studio_mcp_server.tools._adp_connect import _is_expired
+        assert _is_expired(Exception('401 Unauthorized'))
+        assert _is_expired(Exception('token expired'))
+        assert not _is_expired(Exception('connection refused'))
+
+    def test_reconnect_rate_limit(self):
+        '''S6: After _MAX_RECONNECTS_PER_WINDOW failed reconnect
+        attempts inside _WINDOW_SECONDS, further attempts are denied
+        and put the context into a cooldown.'''
+        from oracle.data_studio_mcp_server.tools import _adp_connect as ac
+        # Force the rate-limit test to be deterministic: small window
+        with patch.object(ac, '_MAX_RECONNECTS_PER_WINDOW', 3):
+            lc = {'_adp_config': MagicMock(
+                url='https://x', user='u', password='p')}
+            # Make adp.login fail every time
+            with patch.object(ac, '_locks', {}), \
+                 patch('builtins.__import__') as _imp:
+                fake_adp = MagicMock()
+                fake_adp.login.side_effect = RuntimeError('boom')
+                _imp.side_effect = lambda name, *a, **kw: (
+                    fake_adp if name == 'adp'
+                    else __import__(name, *a, **kw))
+                # 3 failed attempts allowed, 4th denied by limiter
+                for _ in range(3):
+                    assert ac._reconnect(lc) is None
+                # 4th attempt: limiter trips, no further login call
+                fake_adp.login.reset_mock()
+                assert ac._reconnect(lc) is None
+                fake_adp.login.assert_not_called()
+                assert lc.get('_adp_reconnect_cooldown_until', 0) > 0
+
+    def test_reconnect_uses_per_context_lock(self):
+        '''S7: _reconnect serialises swaps of lc['adp'] under a
+        per-context lock so concurrent callers don't see a torn
+        state. Verify the lock exists and is reused for the same lc.'''
+        from oracle.data_studio_mcp_server.tools import _adp_connect as ac
+        with patch.object(ac, '_locks', {}):
+            lc = {}
+            lock1 = ac._ctx_lock(lc)
+            lock2 = ac._ctx_lock(lc)
+            # Same context → same lock
+            assert lock1 is lock2
+            # Different context → different lock
+            other = {}
+            assert ac._ctx_lock(other) is not lock1
+
+    def test_reconnect_avoids_duplicate_login_when_already_done(self):
+        '''S7: If two threads both notice an expired client and call
+        _reconnect, only the first should do the login work — the
+        second should see the freshly-installed client and return it.'''
+        from oracle.data_studio_mcp_server.tools import _adp_connect as ac
+        from datetime import datetime, timedelta
+        # Simulate a healthy client already in lc (set by the "first"
+        # thread) — second thread enters the lock, sees the fresh
+        # client, returns it without logging in.
+        fresh = MagicMock()
+        fresh.rest.expired = datetime.now() + timedelta(hours=1)
+        lc = {
+            '_adp_config': MagicMock(url='x', user='u', password='p'),
+            'adp': fresh,
+        }
+        with patch.object(ac, '_locks', {}), \
+             patch('builtins.__import__') as _imp:
+            fake_adp = MagicMock()
+            _imp.side_effect = lambda name, *a, **kw: (
+                fake_adp if name == 'adp'
+                else __import__(name, *a, **kw))
+            result = ac._reconnect(lc)
+            # Returned the fresh client without re-logging in
+            assert result is fresh
+            fake_adp.login.assert_not_called()
+
+
+# ------------------------------------------------------------------ #
+#  DT connection helper tests                                          #
+# ------------------------------------------------------------------ #
+
+class TestDtConnect:
+
+    def test_get_dt_returns_cached(self):
+        from oracle.data_studio_mcp_server.tools._dt_connect import get_dt
+        mock_ctx = MagicMock()
+        mock_dt = {'client': MagicMock()}
+        mock_ctx.request_context.lifespan_context = {
+            'datatransforms': mock_dt}
+        assert get_dt(mock_ctx) is mock_dt
+
+    def test_get_dt_returns_none_no_config(self):
+        from oracle.data_studio_mcp_server.tools._dt_connect import get_dt
+        mock_ctx = MagicMock()
+        mock_ctx.request_context.lifespan_context = {}
+        assert get_dt(mock_ctx) is None
+
+
+# ------------------------------------------------------------------ #
+#  Essbase tool dispatch tests (mocked SDK)                            #
+# ------------------------------------------------------------------ #
+
+@mcp_required
+class TestEssbaseToolDispatch:
+
+    def _make_ctx(self, ess_mock):
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {'essbase': ess_mock}
+        return ctx
+
+    def test_essbase_explore_no_connection(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_explore'].fn
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {}
+        result = json.loads(fn(ctx=ctx))
+        assert 'error' in result
+
+    def test_essbase_explore_success(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_explore'].fn
+
+        ess = MagicMock()
+        ess.applications.list_applications.return_value = {
+            'items': [{'name': 'Sample'}]}
+        ess.applications.list_databases.return_value = {
+            'items': [{'name': 'Basic'}]}
+        ess.applications.get_statistics.return_value = {'status': 'ok'}
+        ess.applications.get_settings.return_value = {'setting': 'val'}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(ctx=ctx))
+        assert 'applications' in result
+        assert result['count'] == 1
+        assert result['applications'][0]['databases'] == [{'name': 'Basic'}]
+
+    def test_essbase_query_success(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_query'].fn
+
+        ess = MagicMock()
+        ess.grid.execute_mdx.return_value = {'data': [[1, 2]]}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='S', db_name='B',
+                               mdx='SELECT...', ctx=ctx))
+        assert result['data'] == [[1, 2]]
+
+    def test_essbase_server_health(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_server_health'].fn
+
+        ess = MagicMock()
+        ess.about.get.return_value = {'version': '21.5'}
+        ess.about.get_instance.return_value = {'mode': 'normal'}
+        ess.sessions.list_sessions.return_value = [{'user': 'admin'}]
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(ctx=ctx))
+        assert result['about']['version'] == '21.5'
+        assert result['active_sessions'] == 1
+
+    def test_essbase_manage_variables_list(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_variables'].fn
+
+        ess = MagicMock()
+        ess.variables.list_server_variables.return_value = {
+            'items': [{'name': 'V1', 'value': 'X'}]}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(action='list', scope='server', ctx=ctx))
+        assert 'items' in result
+
+    def test_essbase_manage_variables_set_creates(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_variables'].fn
+
+        ess = MagicMock()
+        ess.variables.update_server_variable.side_effect = Exception('not found')
+        ess.variables.create_server_variable.return_value = {
+            'name': 'NewVar', 'value': 'val'}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(action='set', scope='server',
+                               variable_name='NewVar', value='val',
+                               ctx=ctx))
+        assert result['name'] == 'NewVar'
+
+    def test_essbase_get_script(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_get_script'].fn
+
+        ess = MagicMock()
+        ess.scripts.get_script_content.return_value = 'CALC ALL;'
+        ess.scripts.validate_script.return_value = {'valid': True}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='S', db_name='B',
+                               script_name='CalcAll', ctx=ctx))
+        assert result['content'] == 'CALC ALL;'
+        assert result['validation']['valid'] is True
+
+    def test_essbase_browse_outline_top_level(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_browse_outline'].fn
+
+        ess = MagicMock()
+        ess.dimensions.get_outline.return_value = {
+            'items': [{'name': 'Year'}, {'name': 'Measures'}]}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='S', db_name='B', ctx=ctx))
+        assert 'items' in result
+
+    def test_essbase_describe_database(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_describe_database'].fn
+
+        ess = MagicMock()
+        ess.applications.get_database.return_value = {'name': 'Basic'}
+        ess.dimensions.list_dimensions.return_value = {
+            'items': [{'name': 'Year'}]}
+        ess.database_settings.get_settings.return_value = {'s': 1}
+        ess.database_settings.get_statistics.return_value = {'blocks': 100}
+        ess.database_settings.get_storage_statistics.return_value = {'size': 50}
+        ess.variables.list_db_variables.return_value = {
+            'items': [{'name': 'V1'}]}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='S', db_name='B', ctx=ctx))
+        assert result['database']['name'] == 'Basic'
+        assert len(result['dimensions']) == 1
+
+    def test_essbase_run_calculation_success(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_run_calculation'].fn
+
+        ess = MagicMock()
+        ess.jobs.execute.return_value = {'id': 42}
+        ess.jobs.wait_for_completion.return_value = {
+            'statusCode': 200, 'statusMessage': 'Completed'}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='S', db_name='B',
+                               script_name='CalcAll', ctx=ctx))
+        assert result['statusCode'] == 200
+
+    def test_essbase_run_calculation_no_script(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_run_calculation'].fn
+
+        ess = MagicMock()
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='S', db_name='B', ctx=ctx))
+        assert 'error' in result
+
+
+# ------------------------------------------------------------------ #
+#  ADP tool dispatch tests (mocked SDK)                                #
+# ------------------------------------------------------------------ #
+
+@mcp_required
+class TestAdpToolDispatch:
+
+    def _make_ctx(self, adp_mock):
+        ctx = MagicMock()
+        adp_mock.rest.expired = None
+        ctx.request_context.lifespan_context = {'adp': adp_mock}
+        return ctx
+
+    def test_adp_search_success(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_search'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Misc.global_search.return_value = json.dumps({
+            'nodes': [{'data': {'name': 'EMP'}}]})
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(search_term='EMP', ctx=ctx))
+        assert result['search_term'] == 'EMP'
+
+    def test_adp_browse_catalog_list(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_browse_catalog'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Catalog.get_catalogs.return_value = json.dumps(
+            [{'name': 'cat1'}])
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(action='list', ctx=ctx))
+        assert result[0]['name'] == 'cat1'
+
+    def test_adp_analyze_analytic_view(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_analyze_analytic_view'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Analytics.is_exist.return_value = True
+        adp.Analytics.get_metadata.return_value = '{"dims": 3}'
+        adp.Analytics.get_measures_list.return_value = '["SALES"]'
+        adp.Analytics.get_dimension_names.return_value = '[{"DIMENSION_NAME": "TIME"}]'
+        adp.Analytics.quality_report.return_value = '["no errors"]'
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(av_name='MY_AV', ctx=ctx))
+        assert result['av_name'] == 'MY_AV'
+        assert 'metadata' in result
+
+    def test_adp_manage_db_links_copy_tables_passes_dblink(self):
+        '''Verify copy_tables builds table descriptors with dbLink key.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_manage_db_links'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Ingest.copy_tables_from_db_link.return_value = json.dumps(
+            {'status': 'ok'})
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(action='copy_tables',
+                               db_link_name='MY_LINK',
+                               tables='EMP, DEPT', ctx=ctx))
+        # Verify the SDK was called with table descriptors containing dbLink
+        call_args = adp.Ingest.copy_tables_from_db_link.call_args
+        table_descs = call_args[0][0]
+        assert len(table_descs) == 2
+        assert table_descs[0] == {'tableName': 'EMP', 'dbLink': 'MY_LINK'}
+        assert table_descs[1] == {'tableName': 'DEPT', 'dbLink': 'MY_LINK'}
+
+    def test_adp_manage_db_links_link_tables_passes_dblink(self):
+        '''Verify link_tables builds table descriptors with dbLink key.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_manage_db_links'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Ingest.link_tables_from_db_link.return_value = json.dumps(
+            {'status': 'ok'})
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(action='link_tables',
+                               db_link_name='MY_LINK',
+                               tables='SALES', ctx=ctx))
+        call_args = adp.Ingest.link_tables_from_db_link.call_args
+        table_descs = call_args[0][0]
+        assert len(table_descs) == 1
+        assert table_descs[0]['dbLink'] == 'MY_LINK'
+
+    def test_adp_build_analytic_view_does_not_pass_av_name_as_skip_dims(self):
+        '''Regression: SDK signature is create_auto(fact_table,
+        skip_dimensions: bool, owner). Earlier code passed av_name as
+        the second positional, silently coercing it to skip_dimensions=
+        True and dropping the user's name. Verify create_auto is now
+        called with ONLY the fact_table positional arg.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_build_analytic_view'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Analytics.create_auto.return_value = json.dumps(
+            {'name': 'SALES_AV'})
+        adp.Analytics.compile.return_value = json.dumps({'status': 'ok'})
+        adp.Analytics.get_metadata.return_value = json.dumps({})
+        adp.Analytics.get_data_preview.return_value = json.dumps([])
+        ctx = self._make_ctx(adp)
+        # Pass av_name — it should NOT leak into create_auto's second arg
+        json.loads(fn(fact_table='SALES', av_name='MY_CUSTOM_AV',
+                       ctx=ctx))
+        call_args = adp.Analytics.create_auto.call_args
+        # Must be called with ONLY fact_table positional
+        assert call_args.args == ('SALES',), \
+            f'create_auto positional args: {call_args.args}'
+        # And no skip_dimensions kwarg leaked from av_name
+        assert 'skip_dimensions' not in call_args.kwargs or \
+            call_args.kwargs.get('skip_dimensions') is False
+
+    def test_adp_manage_sharing_publish_does_not_pass_recipient(self):
+        '''Regression: SDK publish_share(name, owner=None) does NOT
+        accept a recipient. Earlier code passed recipient_name as
+        owner, silently misrouting it. Verify publish is called with
+        share_name only.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_manage_sharing'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Share.publish_share.return_value = json.dumps({'status': 'ok'})
+        ctx = self._make_ctx(adp)
+        json.loads(fn(action='publish', share_name='SALES_SHARE',
+                       ctx=ctx))
+        call_args = adp.Share.publish_share.call_args
+        # publish gets ONLY the share name
+        assert call_args.args == ('SALES_SHARE',), \
+            f'publish_share args: {call_args.args}'
+
+    def test_adp_manage_sharing_grant_recipient_uses_correct_sdk(self):
+        '''The new grant_recipient action threads recipient_name +
+        tables through to update_recipient_shares.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_manage_sharing'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Share.update_recipient_shares.return_value = json.dumps(
+            {'status': 'ok'})
+        ctx = self._make_ctx(adp)
+        json.loads(fn(action='grant_recipient',
+                       recipient_name='ALICE',
+                       tables='SALES_SHARE',
+                       ctx=ctx))
+        call_args = adp.Share.update_recipient_shares.call_args
+        assert call_args.args == ('ALICE', 'SALES_SHARE')
+
+    def test_adp_ai_query_not_registered(self):
+        '''adp_ai_query was intentionally removed from the composite
+        MCP — Select AI doesn't reliably honor 23ai annotations and
+        executing LLM-generated SQL belongs to SQLcl, not here.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        names = mcp_server._tool_manager._tools.keys()
+        assert 'adp_ai_query' not in names
+
+    def test_adp_get_annotations_groups_by_column(self):
+        '''Verify adp_get_annotations groups rows into table vs column
+        annotations and counts them correctly. Also verifies we do NOT
+        query the non-existent OWNER column on ALL_ANNOTATIONS_USAGE.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_get_annotations'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        # Mimic real ALL_ANNOTATIONS_USAGE rows — Oracle uppercases
+        # annotation names, and there is no OWNER column on the view.
+        adp.Misc.run_query.return_value = json.dumps({'items': [
+            {'column_name': None, 'annotation_name': 'DESCRIPTION',
+             'annotation_value': 'Monthly sales fact'},
+            {'column_name': 'CUST_ID', 'annotation_name': 'DISPLAY_NAME',
+             'annotation_value': 'Customer'},
+            {'column_name': 'CUST_ID', 'annotation_name': 'JOIN_HINT',
+             'annotation_value': 'CUSTOMERS.ID'},
+            {'column_name': 'AMOUNT', 'annotation_name': 'UNIT',
+             'annotation_value': 'USD'},
+        ]})
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(object_name='SALES', ctx=ctx))
+        assert result['annotation_count'] == 4
+        assert result['annotations']['table'] == {
+            'DESCRIPTION': 'Monthly sales fact'}
+        assert result['annotations']['columns']['CUST_ID'] == {
+            'DISPLAY_NAME': 'Customer', 'JOIN_HINT': 'CUSTOMERS.ID'}
+        assert result['annotations']['columns']['AMOUNT'] == {
+            'UNIT': 'USD'}
+        # Verify it queried the expected view and did NOT include the
+        # non-existent bare OWNER column. annotation_owner IS legal.
+        sql_lower = adp.Misc.run_query.call_args[0][0].lower()
+        assert 'all_annotations_usage' in sql_lower
+        assert "upper('sales')" in sql_lower
+        # Bare "owner" (not "annotation_owner" or "domain_owner") must
+        # never appear — the view has no object-owner column.
+        import re
+        bad = re.search(r'(?<![_a-z])owner\b', sql_lower)
+        assert bad is None, f'bare OWNER identifier in SQL: {sql_lower}'
+
+    def test_adp_get_annotations_empty_returns_note(self):
+        '''No annotations → result includes a diagnostic note.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_get_annotations'].fn
+
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Misc.run_query.return_value = json.dumps({'items': []})
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(object_name='UNKNOWN_TABLE', ctx=ctx))
+        assert result['annotation_count'] == 0
+        assert 'note' in result and '23ai' in result['note']
+
+    def test_adp_sql_with_annotations_prompt_registered(self):
+        '''Prompt is registered and renders with the expected guidance.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        prompts = mcp_server._prompt_manager._prompts
+        assert 'adp_sql_with_annotations' in prompts
+        prompt = prompts['adp_sql_with_annotations']
+        # Render it via the underlying function
+        rendered = prompt.fn(
+            question='what were total sales last quarter?',
+            tables='SALES, CUSTOMERS')
+        assert 'adp_get_annotations' in rendered
+        assert 'what were total sales last quarter?' in rendered
+        assert 'SALES, CUSTOMERS' in rendered
+
+
+# ------------------------------------------------------------------ #
+#  DT tool dispatch tests (mocked SDK)                                 #
+# ------------------------------------------------------------------ #
+
+@mcp_required
+class TestDtToolDispatch:
+
+    def _make_ctx(self, client_mock):
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {
+            'datatransforms': {'client': client_mock, 'workbench': MagicMock()},
+        }
+        return ctx
+
+    def test_dt_explore_no_connection(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_explore'].fn
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {}
+        result = json.loads(fn(ctx=ctx))
+        assert 'error' in result
+
+    def test_dt_explore_success(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_explore'].fn
+
+        client = MagicMock()
+        client.get_about.return_value = {'version': '1.0'}
+        client.list_connections.return_value = [{'name': 'conn1'}]
+        client.list_projects.return_value = [{'name': 'proj1'}]
+        client.list_schedules.return_value = []
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(ctx=ctx))
+        assert result['about']['version'] == '1.0'
+        assert len(result['connections']) == 1
+
+    def test_dt_describe_project_success(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_describe_project'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'proj-123'
+        client.list_dataflows_in_project.return_value = [{'name': 'df1'}]
+        client.list_workflows_in_project.return_value = []
+        client.list_dataloads_in_project.return_value = []
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(project_name='MyProject', ctx=ctx))
+        assert result['project_id'] == 'proj-123'
+        assert len(result['dataflows']) == 1
+
+    def test_dt_describe_project_not_found(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_describe_project'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = None
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(project_name='Missing', ctx=ctx))
+        assert 'error' in result
+
+    def test_dt_manage_variables_list(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_variables'].fn
+
+        client = MagicMock()
+        client.list_variables.return_value = [{'name': 'V1', 'value': 'X'}]
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(action='list', ctx=ctx))
+        assert result[0]['name'] == 'V1'
+
+    @patch('oracle.data_studio_mcp_server.tools.dt_tools.DataLoad',
+           create=True)
+    def test_dt_manage_dataload_create_uses_all_inputs(self, MockDataLoad):
+        '''Verify create passes name, project, connection.schema to DataLoad.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_dataload'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'proj-123'
+        ctx = self._make_ctx(client)
+
+        # Mock the DataLoad builder
+        dl_instance = MagicMock()
+        MockDataLoad.return_value = dl_instance
+        dl_instance.source.return_value = dl_instance
+        dl_instance.target.return_value = dl_instance
+        dl_instance.truncate.return_value = dl_instance
+
+        # Patch the import inside the tool
+        import oracle.data_studio_mcp_server.tools.dt_tools as dt_mod
+        with patch.dict('sys.modules',
+                        {'datatransforms.dataload': MagicMock(
+                            DataLoad=MockDataLoad)}):
+            result = json.loads(fn(
+                action='create', project_name='MyProj',
+                dataload_name='my_load',
+                source_connection='SRC_CONN', source_schema='SRC_SCH',
+                target_connection='TGT_CONN', target_schema='TGT_SCH',
+                tables='EMP, DEPT', load_type='TRUNCATE', ctx=ctx))
+
+        # Verify DataLoad was created with name and project
+        MockDataLoad.assert_called_once_with('my_load', 'MyProj')
+        # Verify source/target use connection.schema format
+        dl_instance.source.assert_called_once_with('SRC_CONN.SRC_SCH')
+        dl_instance.target.assert_called_once_with('TGT_CONN.TGT_SCH')
+        # Verify tables were added
+        assert dl_instance.truncate.call_count == 2
+        dl_instance.create_dataload.assert_called_once()
+        assert result['action'] == 'created'
+        assert result['dataload'] == 'my_load'
+
+    def test_dt_manage_schedule_unknown_action(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_schedule'].fn
+
+        client = MagicMock()
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(action='invalid', ctx=ctx))
+        assert 'error' in result
+
+    def test_dt_browse_data_schemas(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_browse_data'].fn
+
+        client = MagicMock()
+        client.get_live_schemas.return_value = ['schema1', 'schema2']
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(connection_name='myconn', ctx=ctx))
+        assert result['schemas'] == ['schema1', 'schema2']
+
+    def test_dt_manage_dataflow_check_exists(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_dataflow'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'proj-1'
+        client.check_if_df_exists.return_value = (True, 'df-id-1')
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(project_name='P', dataflow_name='DF',
+                               ctx=ctx))
+        assert result['exists'] is True
+        assert result['global_id'] == 'df-id-1'
+
+
+# ------------------------------------------------------------------ #
+#  Server module tests                                                 #
+# ------------------------------------------------------------------ #
+
+@mcp_required
+class TestServer:
+
+    def test_mcp_instance_exists(self):
+        from oracle.data_studio_mcp_server.server import mcp
+        assert mcp is not None
+        assert mcp.name == 'oracle-data-studio'
+
+    def test_server_instructions_mention_annotations(self):
+        '''Server instructions should nudge the LLM toward the
+        annotation-first SQL flow.'''
+        from oracle.data_studio_mcp_server.server import mcp
+        instructions = mcp.instructions or ''
+        assert 'adp_get_annotations' in instructions
+        assert 'UNIT' in instructions
+        assert 'annotation' in instructions.lower()
+
+    def test_server_instructions_mention_cube_av_routing(self):
+        '''Server instructions should describe the annotation-driven
+        cube/AV/table routing convention for aggregate questions.'''
+        from oracle.data_studio_mcp_server.server import mcp
+        instructions = mcp.instructions or ''
+        # Mentions all three routing sources
+        assert 'analytic view' in instructions.lower() or 'adp_query_analytic_view' in instructions
+        assert 'essbase' in instructions.lower() or 'cube' in instructions.lower()
+        assert 'aggregate' in instructions.lower() or 'report' in instructions.lower()
+        # The routing convention names should appear so the LLM knows
+        # what to look for in adp_get_annotations output.
+        assert 'preferred_source' in instructions.lower()
+        assert "'cube'" in instructions.lower() or '`cube`' in instructions.lower()
+        assert 'analytic_view' in instructions.lower()
+
+    def test_tool_count(self):
+        '''Server should register exactly 60 tools.'''
+        from oracle.data_studio_mcp_server.server import mcp
+        tools = mcp._tool_manager._tools
+        assert len(tools) == 60, \
+            f'Expected 60 tools, got {len(tools)}: {sorted(tools.keys())}'
+
+
+# ------------------------------------------------------------------ #
+#  Integration: full pipeline test                                     #
+# ------------------------------------------------------------------ #
+
+@mcp_required
+class TestIntegration:
+
+    def test_explore_then_describe(self):
+        '''Simulate: explore apps → describe first database.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+
+        ess = MagicMock()
+        ess.applications.list_applications.return_value = {
+            'items': [{'name': 'Demo'}]}
+        ess.applications.list_databases.return_value = {
+            'items': [{'name': 'MyDB'}]}
+        ess.applications.get_statistics.return_value = {}
+        ess.applications.get_settings.return_value = {}
+        ess.applications.get_database.return_value = {
+            'name': 'MyDB', 'type': 'BSO'}
+        ess.dimensions.list_dimensions.return_value = {
+            'items': [{'name': 'Year'}, {'name': 'Measures'}]}
+        ess.database_settings.get_settings.return_value = {}
+        ess.database_settings.get_statistics.return_value = {}
+        ess.database_settings.get_storage_statistics.return_value = {}
+        ess.variables.list_db_variables.return_value = {'items': []}
+
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {'essbase': ess}
+
+        # Step 1: explore
+        explore_fn = mcp_server._tool_manager._tools['essbase_explore'].fn
+        explore_result = json.loads(explore_fn(ctx=ctx))
+        assert explore_result['count'] == 1
+        app_name = explore_result['applications'][0]['application']['name']
+        db_name = explore_result['applications'][0]['databases'][0]['name']
+
+        # Step 2: describe
+        describe_fn = mcp_server._tool_manager._tools[
+            'essbase_describe_database'].fn
+        describe_result = json.loads(
+            describe_fn(app_name=app_name, db_name=db_name, ctx=ctx))
+        assert describe_result['database']['type'] == 'BSO'
+        assert len(describe_result['dimensions']) == 2

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
@@ -4905,3 +4905,457 @@ class TestIntegration:
             describe_fn(app_name=app_name, db_name=db_name, ctx=ctx))
         assert describe_result['database']['type'] == 'BSO'
         assert len(describe_result['dimensions']) == 2
+
+
+# ====================================================================== #
+#  R3 — Audit logging for mutating / executing tools                       #
+# ====================================================================== #
+#
+# Reviewer item 3 ("mutating and destructive tools have explicit names,
+# validation, confirmation, and audit context"). The audit context piece
+# is implemented by `wrap_mutating_tools_with_audit` in
+# `tools/_helpers.py`, wired from `server.py.main()` so every call to a
+# mutating tool emits a single structured INFO line on
+# `oracle-data-studio-mcp.audit`.
+
+class TestAuditLogging:
+
+    def _wrap(self, tool_modules, profile=None):
+        '''Register tools and apply the audit wrapper. Returns the
+        configured FastMCP server.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            wrap_mutating_tools_with_audit)
+        mcp_server = FastMCP('test')
+        for mod in tool_modules:
+            mod.register_tools(mcp_server)
+        n = wrap_mutating_tools_with_audit(mcp_server, profile=profile)
+        return mcp_server, n
+
+    def test_audit_emits_single_info_line(self, caplog):
+        '''The bare `audit()` helper emits one structured line on the
+        dedicated audit logger.'''
+        import logging
+        from oracle.data_studio_mcp_server.tools._helpers import audit
+        caplog.set_level(logging.INFO,
+                         logger='oracle-data-studio-mcp.audit')
+        audit('essbase_manage_application',
+              action='delete', target='Sample', profile='admin')
+        # Find the audit line — there should be exactly one
+        lines = [r.getMessage() for r in caplog.records
+                 if r.name == 'oracle-data-studio-mcp.audit']
+        assert len(lines) == 1
+        line = lines[0]
+        assert line.startswith('audit ')
+        assert 'tool=essbase_manage_application' in line
+        assert 'action=delete' in line
+        assert 'target=Sample' in line
+        assert 'profile=admin' in line
+        assert 'outcome=ok' in line
+
+    def test_audit_redacts_password_in_target(self, caplog):
+        '''Values are funnelled through `safe_err` — no creds leak
+        even if a caller accidentally passes a connect string.'''
+        import logging
+        from oracle.data_studio_mcp_server.tools._helpers import audit
+        caplog.set_level(logging.INFO,
+                         logger='oracle-data-studio-mcp.audit')
+        audit('adp_manage_credentials', action='create',
+              target='ADMIN/Welcome2025#@adb.example.com:1522/svc')
+        line = next(r.getMessage() for r in caplog.records
+                    if r.name == 'oracle-data-studio-mcp.audit')
+        assert 'Welcome2025' not in line
+        assert 'ADMIN/***@' in line
+
+    def test_audit_quotes_value_with_spaces(self, caplog):
+        '''Audit-line values are shell-quoted when they contain spaces
+        so log parsers see a single field.'''
+        import logging
+        from oracle.data_studio_mcp_server.tools._helpers import audit
+        caplog.set_level(logging.INFO,
+                         logger='oracle-data-studio-mcp.audit')
+        audit('dt_manage_project', action='create',
+              target='Marketing Q3 Forecast')
+        line = next(r.getMessage() for r in caplog.records
+                    if r.name == 'oracle-data-studio-mcp.audit')
+        assert 'target="Marketing Q3 Forecast"' in line
+
+    def test_is_mutating_tool_classification(self):
+        '''The is_mutating_tool() helper covers the documented surface.'''
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            is_mutating_tool)
+        # All-yes: every prefix from the docs
+        for name in [
+            'essbase_manage_application', 'essbase_run_calculation',
+            'essbase_load_data', 'essbase_deploy_workbook',
+            'essbase_edit_outline', 'essbase_query',
+            'essbase_export_data',
+            'adp_manage_catalog', 'adp_load_from_cloud',
+            'adp_build_analytic_view', 'adp_generate_insights',
+            'adp_ai_chat',
+            'dt_manage_project', 'dt_create_pipeline', 'dt_run_pipeline',
+        ]:
+            assert is_mutating_tool(name), name
+        # All-no: read-only tools
+        for name in [
+            'essbase_explore', 'essbase_describe_database',
+            'essbase_browse_outline', 'essbase_search_members',
+            'essbase_server_health', 'essbase_get_logs',
+            'adp_search', 'adp_browse_catalog',
+            'adp_query_analytic_view',  # read-only by design
+            'adp_get_annotations',
+            'dt_explore', 'dt_describe_project',
+        ]:
+            assert not is_mutating_tool(name), name
+
+    def test_wrap_marks_only_mutating_tools(self):
+        '''The wrapper picks up only mutating tools from the registered
+        catalog. We count wrappers by name and compare against the
+        is_mutating_tool() oracle.'''
+        from oracle.data_studio_mcp_server.tools import (
+            adp_tools, dt_tools, essbase_tools)
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            is_mutating_tool)
+        mcp_server, n = self._wrap(
+            [essbase_tools, adp_tools, dt_tools], profile='admin')
+        tools = mcp_server._tool_manager._tools
+        expected = sum(1 for name in tools if is_mutating_tool(name))
+        assert n == expected
+        # Spot-check: a few specific mutating tools carry the marker
+        for name in ('essbase_manage_application', 'adp_load_from_cloud',
+                      'dt_run_pipeline', 'essbase_query'):
+            assert tools[name].fn.__audited__ is True
+        # And a few read-only ones do not
+        for name in ('essbase_explore', 'adp_search', 'dt_explore'):
+            assert not getattr(tools[name].fn, '__audited__', False)
+
+    def test_wrap_is_idempotent(self):
+        '''Re-wrapping doesn't double-wrap.'''
+        from oracle.data_studio_mcp_server.tools import (
+            adp_tools, dt_tools, essbase_tools)
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            wrap_mutating_tools_with_audit)
+        mcp_server, n1 = self._wrap(
+            [essbase_tools, adp_tools, dt_tools], profile='admin')
+        n2 = wrap_mutating_tools_with_audit(mcp_server, profile='admin')
+        assert n1 > 0
+        assert n2 == 0
+
+    def test_call_emits_audit_on_success(self, caplog):
+        '''Invoking a wrapped mutating tool emits an audit line.'''
+        import logging
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        caplog.set_level(logging.INFO,
+                         logger='oracle-data-studio-mcp.audit')
+        mcp_server, _ = self._wrap([essbase_tools], profile='analyst')
+
+        # Set up a mocked Essbase client and call essbase_query (which
+        # is in our audited set because it executes MDX).
+        ess = MagicMock()
+        ess.grid.execute_mdx.return_value = {'cells': [], 'axes': []}
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {'essbase': ess}
+
+        fn = mcp_server._tool_manager._tools['essbase_query'].fn
+        result = fn(app_name='Sample', db_name='Basic',
+                     mdx='SELECT 1 ON 0 FROM Basic', ctx=ctx)
+        assert json.loads(result)  # well-formed JSON
+        lines = [r.getMessage() for r in caplog.records
+                 if r.name == 'oracle-data-studio-mcp.audit']
+        assert len(lines) == 1
+        assert 'tool=essbase_query' in lines[0]
+        assert 'profile=analyst' in lines[0]
+        assert 'outcome=ok' in lines[0]
+        assert 'target=Sample' in lines[0]
+
+    def test_call_emits_audit_on_error(self, caplog):
+        '''An exception path still emits an audit line with outcome=error.'''
+        import logging
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        caplog.set_level(logging.INFO,
+                         logger='oracle-data-studio-mcp.audit')
+        mcp_server, _ = self._wrap([essbase_tools], profile='admin')
+
+        # No essbase in ctx → the tool returns an {"error": ...} JSON,
+        # not an exception. That path must still audit outcome=error.
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {}
+
+        fn = mcp_server._tool_manager._tools['essbase_query'].fn
+        result = fn(app_name='Sample', db_name='Basic',
+                     mdx='SELECT 1 ON 0 FROM Basic', ctx=ctx)
+        body = json.loads(result)
+        assert 'error' in body
+
+        lines = [r.getMessage() for r in caplog.records
+                 if r.name == 'oracle-data-studio-mcp.audit']
+        assert len(lines) == 1
+        assert 'outcome=error' in lines[0]
+
+
+# ====================================================================== #
+#  R4 — Output bounding for query / export tools                          #
+# ====================================================================== #
+#
+# Reviewer item 4 ("query results and backend content are bounded and
+# treated as untrusted data"). Both helpers in tools/_helpers.py:
+#   - bound_mdx_result(result, max_rows=...) for the Essbase MDX shapes
+#   - bound_rows(rows, max_rows=...) for ADP analytic-view list returns
+
+class TestBoundMdxResult:
+    '''Unit tests for the axes+cells and slice+ranges MDX shapes.'''
+
+    def _axes_response(self, n_rows, n_cols=2):
+        return {
+            'axes': [
+                {'tuples': [{'members': [{'name': f'c{c}'}]}
+                             for c in range(n_cols)]},
+                {'tuples': [{'members': [{'name': f'r{r}'}]}
+                             for r in range(n_rows)],
+                 'dimensions': [{'name': 'Time'}]},
+            ],
+            'cells': [{'value': r * n_cols + c}
+                       for r in range(n_rows)
+                       for c in range(n_cols)],
+        }
+
+    def test_under_cap_passes_through(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            bound_mdx_result)
+        result = self._axes_response(n_rows=5)
+        bounded = bound_mdx_result(result, max_rows=10)
+        assert bounded is result  # mutated in place, returned
+        assert 'truncated' not in bounded
+
+    def test_over_cap_truncates_axes_and_cells(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            bound_mdx_result)
+        result = self._axes_response(n_rows=50, n_cols=2)
+        bounded = bound_mdx_result(result, max_rows=10)
+        assert bounded['truncated'] is True
+        assert bounded['original_row_count'] == 50
+        assert bounded['max_rows'] == 10
+        # Row axis is trimmed
+        assert len(bounded['axes'][1]['tuples']) == 10
+        # Cells trimmed row-major: 10 rows × 2 cols = 20 cells
+        assert len(bounded['cells']) == 20
+
+    def test_max_rows_default_when_invalid(self):
+        '''Bad max_rows falls back to DEFAULT_MAX_ROWS (1000).'''
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            bound_mdx_result, DEFAULT_MAX_ROWS)
+        result = self._axes_response(n_rows=1500)
+        # Negative max_rows → default
+        bounded = bound_mdx_result(result, max_rows=-1)
+        assert bounded['max_rows'] == DEFAULT_MAX_ROWS
+        assert bounded['truncated'] is True
+        assert len(bounded['axes'][1]['tuples']) == DEFAULT_MAX_ROWS
+
+    def test_slice_ranges_shape_truncates(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            bound_mdx_result)
+        result = {
+            'slice': {
+                'rows': [{'members': [f'r{i}']} for i in range(20)],
+                'columns': [{'members': ['Sales']},
+                            {'members': ['COGS']}],
+                'data': {'ranges': [{'values':
+                    list(range(40))}]},
+            },
+        }
+        bounded = bound_mdx_result(result, max_rows=5)
+        assert bounded['truncated'] is True
+        assert bounded['original_row_count'] == 20
+        assert len(bounded['slice']['rows']) == 5
+        assert len(bounded['slice']['data']['ranges'][0]['values']) == 10
+
+    def test_unknown_shape_passes_through(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            bound_mdx_result)
+        result = {'something': 'else'}
+        bounded = bound_mdx_result(result, max_rows=10)
+        assert bounded == result  # unchanged
+
+    def test_non_dict_passes_through(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            bound_mdx_result)
+        assert bound_mdx_result('a string', max_rows=10) == 'a string'
+        assert bound_mdx_result(None, max_rows=10) is None
+        assert bound_mdx_result(42, max_rows=10) == 42
+
+
+class TestBoundRows:
+
+    def test_under_cap_marks_not_truncated(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            bound_rows)
+        env = bound_rows([{'a': 1}, {'a': 2}], max_rows=10)
+        assert env['truncated'] is False
+        assert env['original_row_count'] == 2
+        assert env['rows'] == [{'a': 1}, {'a': 2}]
+
+    def test_over_cap_truncates(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            bound_rows)
+        rows = [{'i': i} for i in range(50)]
+        env = bound_rows(rows, max_rows=10)
+        assert env['truncated'] is True
+        assert env['original_row_count'] == 50
+        assert env['max_rows'] == 10
+        assert len(env['rows']) == 10
+        assert env['rows'][0] == {'i': 0}
+
+    def test_non_list_input_returned_unchanged(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            bound_rows)
+        env = bound_rows('not a list', max_rows=10)
+        assert env['truncated'] is False
+        assert env['rows'] == 'not a list'
+
+
+class TestQueryToolsRespectMaxRows:
+    '''End-to-end: essbase_query / essbase_export_data / adp_query_av
+    pass `max_rows` through and surface `truncated: true`.'''
+
+    def _ess_query(self, mcp_server, ess, **kwargs):
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {'essbase': ess}
+        fn = mcp_server._tool_manager._tools['essbase_query'].fn
+        return fn(ctx=ctx, **kwargs)
+
+    def test_essbase_query_truncates_at_max_rows(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        ess = MagicMock()
+        # Return 100 rows; cap at 10
+        ess.grid.execute_mdx.return_value = {
+            'axes': [
+                {'tuples': [{'members': [{'name': 'Sales'}]}]},
+                {'tuples': [{'members': [{'name': f'r{i}'}]}
+                             for i in range(100)],
+                 'dimensions': [{'name': 'Time'}]},
+            ],
+            'cells': [{'value': i} for i in range(100)],
+        }
+        result = json.loads(self._ess_query(
+            mcp_server, ess, app_name='S', db_name='B',
+            mdx='SELECT...', max_rows=10))
+        assert result['truncated'] is True
+        assert result['original_row_count'] == 100
+        assert result['max_rows'] == 10
+        assert len(result['axes'][1]['tuples']) == 10
+
+    def test_essbase_query_default_cap_is_1000(self):
+        '''No max_rows arg → DEFAULT_MAX_ROWS applies.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        ess = MagicMock()
+        ess.grid.execute_mdx.return_value = {
+            'axes': [
+                {'tuples': [{'members': [{'name': 'Sales'}]}]},
+                {'tuples': [{'members': [{'name': f'r{i}'}]}
+                             for i in range(1500)],
+                 'dimensions': [{'name': 'Time'}]},
+            ],
+            'cells': [{'value': i} for i in range(1500)],
+        }
+        result = json.loads(self._ess_query(
+            mcp_server, ess, app_name='S', db_name='B', mdx='X'))
+        assert result['truncated'] is True
+        assert result['max_rows'] == 1000
+        assert len(result['axes'][1]['tuples']) == 1000
+
+    def test_essbase_export_data_truncates(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        ess = MagicMock()
+        ess.grid.execute_mdx.return_value = {
+            'axes': [
+                {'tuples': [{'members': [{'name': 'Sales'}]}]},
+                {'tuples': [{'members': [{'name': f'r{i}'}]}
+                             for i in range(20)],
+                 'dimensions': [{'name': 'Time'}]},
+            ],
+            'cells': [{'value': i} for i in range(20)],
+        }
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {'essbase': ess}
+        fn = mcp_server._tool_manager._tools['essbase_export_data'].fn
+        result = json.loads(fn(app_name='S', db_name='B',
+                                mdx='X', max_rows=5, ctx=ctx))
+        assert result['truncated'] is True
+        assert result['original_row_count'] == 20
+        assert result['max_rows'] == 5
+
+    def test_adp_query_analytic_view_truncates(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Analytics.is_exist.return_value = True
+        adp.Analytics.get_data_simple.return_value = [
+            {'i': i} for i in range(50)]
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {'adp': adp}
+        fn = mcp_server._tool_manager._tools['adp_query_analytic_view'].fn
+        result = json.loads(fn(av_name='SALES_AV', max_rows=10, ctx=ctx))
+        assert result['truncated'] is True
+        assert result['original_row_count'] == 50
+        assert len(result['rows']) == 10
+
+    def test_adp_query_analytic_view_under_cap_no_truncation(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.Analytics.is_exist.return_value = True
+        adp.Analytics.get_data_simple.return_value = [
+            {'i': i} for i in range(3)]
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {'adp': adp}
+        fn = mcp_server._tool_manager._tools['adp_query_analytic_view'].fn
+        result = json.loads(fn(av_name='SALES_AV', max_rows=10, ctx=ctx))
+        assert result['truncated'] is False
+        assert len(result['rows']) == 3
+
+
+# ====================================================================== #
+#  R5 — Server wiring: audit + profile applied at startup                 #
+# ====================================================================== #
+
+class TestServerStartupWiring:
+    '''Smoke tests proving main()'s startup sequence wires both
+    apply_profile() and wrap_mutating_tools_with_audit() before the
+    server runs.'''
+
+    def test_main_wires_audit_after_register(self, monkeypatch):
+        '''main() should call wrap_mutating_tools_with_audit(); we patch
+        it and assert it ran with the configured profile.'''
+        from oracle.data_studio_mcp_server import server as srv
+        from oracle.data_studio_mcp_server.config import ServerConfig
+
+        # Stub config: viewer profile, stdio, no service configs
+        monkeypatch.setattr(srv, 'load_config',
+                            lambda: ServerConfig(profile='viewer',
+                                                  transport='stdio'))
+        # Capture call to wrap_mutating_tools_with_audit
+        seen = {}
+        def _fake_wrap(server, profile=None):
+            seen['profile'] = profile
+            return 0
+        monkeypatch.setattr(srv, 'wrap_mutating_tools_with_audit',
+                            _fake_wrap)
+        # Prevent the real server from running
+        monkeypatch.setattr(srv.mcp, 'run', lambda **_: None)
+        srv.main()
+        assert seen.get('profile') == 'viewer'

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
@@ -287,6 +287,32 @@ class TestCredentialStore:
         with patch('builtins.__import__', side_effect=_no_keyring):
             assert _set_keyring_password('adp', 'u', 'p') is False
 
+    def test_get_keyring_password_returns_value(self):
+        '''When the keyring lookup succeeds, the value comes back.'''
+        from oracle.data_studio_mcp_server.credential_store import (
+            _get_keyring_password)
+        fake_keyring = MagicMock()
+        fake_keyring.get_password.return_value = 'secret'
+        with patch.dict('sys.modules', {'keyring': fake_keyring}):
+            assert _get_keyring_password('adp', 'ADMIN') == 'secret'
+
+    def test_delete_keyring_password_succeeds(self):
+        from oracle.data_studio_mcp_server.credential_store import (
+            _delete_keyring_password)
+        fake_keyring = MagicMock()
+        with patch.dict('sys.modules', {'keyring': fake_keyring}):
+            assert _delete_keyring_password('adp', 'ADMIN') is True
+        fake_keyring.delete_password.assert_called_once()
+
+    def test_delete_keyring_password_handles_missing(self):
+        '''_delete_keyring_password returns False on errors.'''
+        from oracle.data_studio_mcp_server.credential_store import (
+            _delete_keyring_password)
+        fake_keyring = MagicMock()
+        fake_keyring.delete_password.side_effect = Exception('not found')
+        with patch.dict('sys.modules', {'keyring': fake_keyring}):
+            assert _delete_keyring_password('adp', 'ADMIN') is False
+
     def test_get_keyring_password_no_keyring(self):
         '''get_keyring_password returns None when keyring is unavailable.'''
         from oracle.data_studio_mcp_server.credential_store import get_keyring_password
@@ -1716,6 +1742,686 @@ class TestEssbaseToolDispatch:
         assert 'editActions' in payload
         assert payload['editActions'][0]['actionType'].lower().startswith('add')
 
+    def test_essbase_manage_drill_through_update(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_drill_through'].fn
+
+        ess = MagicMock()
+        ess.drill_through.update_report.return_value = {'name': 'R'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='update', app_name='A', db_name='D',
+                       report_name='R',
+                       sql_query='SELECT 2 FROM dual',
+                       columns='X,Y',
+                       drillable_regions='@CHILDREN(West)',
+                       ctx=ctx))
+        ess.drill_through.update_report.assert_called_once()
+
+    def test_essbase_manage_drill_through_execute(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_drill_through'].fn
+
+        ess = MagicMock()
+        ess.drill_through.execute_report.return_value = {'rows': []}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='execute', app_name='A', db_name='D',
+                       report_name='R', ctx=ctx))
+        ess.drill_through.execute_report.assert_called_once()
+
+    def test_essbase_manage_database_update(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_database'].fn
+
+        ess = MagicMock()
+        ess.applications.update_database.return_value = {'name': 'D'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='update', app_name='A', db_name='D',
+                       ctx=ctx))
+        ess.applications.update_database.assert_called_once()
+
+    def test_essbase_manage_database_copy(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_database'].fn
+
+        ess = MagicMock()
+        ess.applications.copy_database.return_value = {'status': 'copied'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='copy', app_name='A', db_name='D',
+                       target_app='A2', target_db='D2', ctx=ctx))
+        ess.applications.copy_database.assert_called_once()
+
+    def test_essbase_manage_groups_add_users(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_groups'].fn
+
+        ess = MagicMock()
+        ess.groups.add_users.return_value = {'status': 'ok'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='add_users', group_id='G',
+                       user_ids='alice,bob,carol', ctx=ctx))
+        # 3 users → list of 3 dicts
+        call_args = ess.groups.add_users.call_args
+        users_arg = call_args[0][1]
+        assert len(users_arg) == 3
+        assert users_arg[0]['id'] == 'alice'
+
+    def test_essbase_manage_groups_remove_users(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_groups'].fn
+
+        ess = MagicMock()
+        ess.groups.remove_users.return_value = {'status': 'ok'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='remove_users', group_id='G', ctx=ctx))
+        ess.groups.remove_users.assert_called_once_with('G')
+
+    def test_essbase_manage_groups_add_subgroups(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_groups'].fn
+
+        ess = MagicMock()
+        ess.groups.add_subgroups.return_value = {'status': 'ok'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='add_subgroups', group_id='G',
+                       user_ids='sub1,sub2', ctx=ctx))
+        ess.groups.add_subgroups.assert_called_once()
+
+    def test_essbase_manage_users_deprovision_app(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_users'].fn
+
+        ess = MagicMock()
+        ess.users.deprovision_app_role.return_value = {'status': 'ok'}
+        ctx = self._make_ctx(ess)
+        fn(action='deprovision', user_id='alice',
+            role='power_user', app_name='Sample', ctx=ctx)
+        ess.users.deprovision_app_role.assert_called()
+
+    def test_essbase_manage_users_update(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_users'].fn
+
+        ess = MagicMock()
+        ess.users.update_user.return_value = {'status': 'ok'}
+        ctx = self._make_ctx(ess)
+        fn(action='update', user_id='alice', password='newpass', ctx=ctx)
+        ess.users.update_user.assert_called_once()
+
+    def test_essbase_manage_users_create(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_users'].fn
+
+        ess = MagicMock()
+        ess.users.create_user.return_value = {'id': 'alice'}
+        ctx = self._make_ctx(ess)
+        fn(action='create', user_id='alice', password='pw', ctx=ctx)
+        ess.users.create_user.assert_called_once()
+
+    def test_essbase_manage_jobs_rerun_full_flow(self):
+        '''rerun also calls wait_for_completion on the new job.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_jobs'].fn
+
+        ess = MagicMock()
+        ess.jobs.rerun.return_value = {'id': 99}
+        ess.jobs.wait_for_completion.return_value = {
+            'status': 200, 'jobID': 99}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='rerun', job_id=42, ctx=ctx))
+        ess.jobs.rerun.assert_called_once_with(42)
+        ess.jobs.wait_for_completion.assert_called_once_with(99)
+
+    def test_essbase_manage_filters_update_full_flow(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_filters'].fn
+
+        ess = MagicMock()
+        ess.filters.update_filter.return_value = {'name': 'F'}
+        ess.filters.validate_filter.return_value = {'valid': True}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='update', app_name='A', db_name='D',
+                       filter_name='F',
+                       filter_rows='READ,@CHILDREN(East);WRITE,@MEMBER(West)',
+                       ctx=ctx))
+        # update_filter called with the parsed rows
+        ess.filters.update_filter.assert_called_once()
+        ess.filters.validate_filter.assert_called_once()
+
+    def test_essbase_manage_locks_unlock(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_locks'].fn
+
+        ess = MagicMock()
+        ess.locks.unlock_object.return_value = {'status': 'unlocked'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(app_name='A', db_name='D', action='unlock',
+                       object_name='East', ctx=ctx))
+        ess.locks.unlock_object.assert_called_once()
+
+    def test_essbase_manage_sessions_kill_specific(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_sessions'].fn
+
+        ess = MagicMock()
+        ess.sessions.delete_session.return_value = {'status': 'killed'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='kill', session_id='123', ctx=ctx))
+        ess.sessions.delete_session.assert_called_once_with('123')
+
+    def test_essbase_manage_application_update(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_application'].fn
+
+        ess = MagicMock()
+        ess.applications.update_application.return_value = {'status': 'started'}
+        ctx = self._make_ctx(ess)
+        # start action exercises update_application(status: 1)
+        json.loads(fn(action='start', app_name='A', ctx=ctx))
+        call_args = ess.applications.update_application.call_args
+        assert call_args[0][1] == {'status': 1}
+
+    def test_essbase_manage_application_stop(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_application'].fn
+
+        ess = MagicMock()
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='stop', app_name='A', ctx=ctx))
+        call_args = ess.applications.update_application.call_args
+        assert call_args[0][1] == {'status': 0}
+
+    def test_essbase_outline_metadata_export_xml_returns_blob(self):
+        '''export_xml returns a string blob, body wraps it.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_outline_metadata'].fn
+
+        ess = MagicMock()
+        ess.dimensions.export_outline_xml.return_value = '<outline />'
+        ctx = self._make_ctx(ess)
+        # export_xml returns the raw blob, not JSON
+        result = fn(app_name='A', db_name='D', category='export_xml',
+                     ctx=ctx)
+        ess.dimensions.export_outline_xml.assert_called_once()
+        assert '<outline' in str(result)
+
+    def test_essbase_outline_metadata_member_returns_member(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_outline_metadata'].fn
+
+        ess = MagicMock()
+        ess.dimensions.get_member.return_value = {'name': 'East'}
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='A', db_name='D',
+                                category='member',
+                                dimension_name='East', ctx=ctx))
+        ess.dimensions.get_member.assert_called_once()
+
+    def test_essbase_manage_datasources_update(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_datasources'].fn
+
+        ess = MagicMock()
+        ess.datasources.update_datasource.return_value = {'name': 'DS'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='update', datasource_name='DS',
+                       query='SELECT 3 FROM dual',
+                       columns='C1,C2', ctx=ctx))
+        ess.datasources.update_datasource.assert_called_once()
+
+    def test_essbase_manage_connections_update(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_connections'].fn
+
+        ess = MagicMock()
+        ess.connections.update_connection.return_value = {'name': 'C'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='update', connection_name='C',
+                       host='h2', port=1522, service_name='svc2',
+                       user='u2', password='p2', ctx=ctx))
+        ess.connections.update_connection.assert_called_once()
+
+    def test_essbase_manage_files_copy(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_files'].fn
+
+        ess = MagicMock()
+        ess.files.copy.return_value = {'status': 'copied'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='copy', path='/a/x',
+                       target_path='/b/y', ctx=ctx))
+        ess.files.copy.assert_called_once()
+
+    def test_essbase_manage_files_move(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_files'].fn
+
+        ess = MagicMock()
+        ess.files.move.return_value = {'status': 'moved'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='move', path='/a/x',
+                       target_path='/b/y', ctx=ctx))
+        ess.files.move.assert_called_once()
+
+    def test_essbase_manage_files_upload(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_files'].fn
+
+        ess = MagicMock()
+        ess.files.upload.return_value = None
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='upload', path='/p/file.txt',
+                       content='hello world', ctx=ctx))
+        ess.files.upload.assert_called_once()
+
+    def test_essbase_manage_files_download_bytes(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_files'].fn
+
+        ess = MagicMock()
+        ess.files.download.return_value = b'hello bytes content'
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(action='download', path='/p/file.txt',
+                                ctx=ctx))
+        assert result['size_bytes'] == len(b'hello bytes content')
+
+    def test_essbase_manage_users_get_with_provisioning_report(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_users'].fn
+
+        ess = MagicMock()
+        ess.users.get_user.return_value = {'id': 'u'}
+        ess.users.get_user_provisioning_report.return_value = {'apps': []}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='get', user_id='alice', ctx=ctx))
+        ess.users.get_user.assert_called_once_with('alice')
+
+    def test_essbase_manage_groups_get_full_body(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_groups'].fn
+
+        ess = MagicMock()
+        ess.groups.get_group.return_value = {'id': 'G'}
+        ess.groups.get_group_provisioning_report.return_value = {'roles': []}
+        ess.groups.get_subgroups.return_value = []
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='get', group_id='G', ctx=ctx))
+        ess.groups.get_group.assert_called_once_with('G')
+
+    def test_essbase_manage_drill_through_create_full_payload(self):
+        '''Create with all optional fields — exercises payload assembly.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_drill_through'].fn
+
+        ess = MagicMock()
+        ess.drill_through.create_report.return_value = {'name': 'R'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='create', app_name='A', db_name='D',
+                       report_name='R', connection='ConnA',
+                       sql_query='SELECT * FROM SALES',
+                       columns='COL1,COL2,COL3',
+                       drillable_regions='@IDESCENDANTS(East),@IDESCENDANTS(West)',
+                       ctx=ctx))
+        call_args = ess.drill_through.create_report.call_args
+        payload = call_args[0][2]
+        assert payload['name'] == 'R'
+        assert 'columns' in payload or 'drillableRegions' in payload \
+            or 'sqlQuery' in payload
+
+    def test_essbase_manage_filters_create_with_default_access(self):
+        '''Create with no filter_rows uses default access on @ALL.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_filters'].fn
+
+        ess = MagicMock()
+        ess.filters.create_filter.return_value = {'name': 'F'}
+        ess.filters.validate_filter.return_value = {'valid': True}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='create', app_name='A', db_name='D',
+                       filter_name='F', access='WRITE', ctx=ctx))
+        call_args = ess.filters.create_filter.call_args
+        payload = call_args[0][2]
+        assert payload['rows'][0]['access'] == 'WRITE'
+        assert payload['rows'][0]['member'] == '@ALL'
+
+    def test_essbase_manage_jobs_status_returns_status(self):
+        '''status path: jobs.get_status(job_id).'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_jobs'].fn
+
+        ess = MagicMock()
+        ess.jobs.get_status.return_value = {'status': 200, 'jobID': 5}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='status', job_id=5, ctx=ctx))
+        ess.jobs.get_status.assert_called_once_with(5)
+
+    def test_essbase_manage_jobs_status_no_id_errors(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_jobs'].fn
+
+        ess = MagicMock()
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(action='status', ctx=ctx))
+        assert 'error' in result
+
+    @pytest.mark.parametrize('tool,kwargs', [
+        # Each case triggers a `return err('X required ...')` branch.
+        ('essbase_manage_application', {'action': 'create',
+                                          'app_name': 'A'}),  # no db_name
+        ('essbase_manage_application', {'action': 'rename',
+                                          'app_name': 'A'}),  # no new_name
+        ('essbase_manage_application', {'action': 'copy',
+                                          'app_name': 'A'}),  # no new_name
+        ('essbase_manage_application', {'action': 'unknown',
+                                          'app_name': 'A'}),
+        ('essbase_manage_database', {'action': 'rename', 'app_name': 'A',
+                                       'db_name': 'D'}),  # no new_name
+        ('essbase_manage_database', {'action': 'copy', 'app_name': 'A',
+                                       'db_name': 'D'}),  # no targets
+        ('essbase_manage_database', {'action': 'unknown',
+                                       'app_name': 'A', 'db_name': 'D'}),
+        ('essbase_manage_script', {'action': 'create', 'app_name': 'A',
+                                     'db_name': 'D', 'script_name': 'S'}),
+        # update with no content + no new_name doesn't error — it
+        # returns a renamed status. Skip that case.
+        ('essbase_manage_script', {'action': 'unknown_xyz',
+                                     'app_name': 'A', 'db_name': 'D',
+                                     'script_name': 'S'}),
+        ('essbase_manage_filters', {'action': 'create',
+                                      'app_name': 'A', 'db_name': 'D'}),
+        ('essbase_manage_filters', {'action': 'update',
+                                      'app_name': 'A', 'db_name': 'D'}),
+        ('essbase_manage_filters', {'action': 'rename',
+                                      'app_name': 'A', 'db_name': 'D',
+                                      'filter_name': 'F'}),
+        ('essbase_manage_filters', {'action': 'copy',
+                                      'app_name': 'A', 'db_name': 'D',
+                                      'filter_name': 'F'}),
+        ('essbase_manage_filters', {'action': 'delete',
+                                      'app_name': 'A', 'db_name': 'D'}),
+        ('essbase_manage_filters', {'action': 'assign',
+                                      'app_name': 'A', 'db_name': 'D'}),
+        ('essbase_manage_filters', {'action': 'unknown',
+                                      'app_name': 'A', 'db_name': 'D'}),
+        ('essbase_manage_files', {'action': 'unknown'}),
+        ('essbase_manage_files', {'action': 'copy', 'path': '/p'}),
+        ('essbase_manage_files', {'action': 'move', 'path': '/p'}),
+        ('essbase_manage_files', {'action': 'upload', 'path': '/p'}),
+        ('essbase_manage_users', {'action': 'create', 'user_id': 'u'}),
+        ('essbase_manage_users', {'action': 'unknown'}),
+        ('essbase_manage_groups', {'action': 'unknown'}),
+        ('essbase_manage_groups', {'action': 'add_users',
+                                     'group_id': 'G'}),
+        ('essbase_manage_drill_through',
+         {'action': 'unknown', 'app_name': 'A', 'db_name': 'D'}),
+        ('essbase_manage_drill_through',
+         {'action': 'create', 'app_name': 'A', 'db_name': 'D',
+          'report_name': 'R'}),  # no connection
+        ('essbase_manage_datasources', {'action': 'unknown'}),
+        ('essbase_manage_datasources', {'action': 'create'}),
+        ('essbase_manage_connections', {'action': 'unknown'}),
+        ('essbase_manage_connections', {'action': 'create'}),
+        ('essbase_manage_locks', {'app_name': 'A', 'db_name': 'D',
+                                    'action': 'unlock'}),  # no object
+        ('essbase_manage_locks', {'app_name': 'A', 'db_name': 'D',
+                                    'action': 'unknown'}),
+        ('essbase_manage_jobs', {'action': 'rerun'}),
+        ('essbase_manage_jobs', {'action': 'unknown'}),
+        ('essbase_manage_sessions', {'action': 'kill'}),
+        ('essbase_manage_sessions', {'action': 'unknown'}),
+        ('essbase_edit_outline', {'app_name': 'A', 'db_name': 'D',
+                                    'action': 'add',
+                                    'member_name': 'M'}),  # no parent_name
+        ('essbase_edit_outline', {'app_name': 'A', 'db_name': 'D',
+                                    'action': 'unknown',
+                                    'member_name': 'M'}),
+    ])
+    def test_essbase_validation_error_branches(self, tool, kwargs):
+        '''Bulk validation-error coverage. Each missing-required-arg
+        path returns an error JSON. Lifts coverage across all manage_*
+        tools' error branches.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools[tool].fn
+        ess = MagicMock()
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(ctx=ctx, **kwargs))
+        assert 'error' in result
+
+    def test_essbase_get_logs_all_logs(self):
+        '''latest_only=False fetches the full log set.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_get_logs'].fn
+
+        ess = MagicMock()
+        ess.applications.get_logs.return_value = '...lots of log lines...'
+        ctx = self._make_ctx(ess)
+        json.loads(fn(app_name='A', latest_only=False, ctx=ctx))
+        ess.applications.get_logs.assert_called_once()
+
+    def test_essbase_outline_metadata_generations_levels_with_dim(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_outline_metadata'].fn
+
+        ess = MagicMock()
+        ess.dimensions.list_generations.return_value = []
+        ess.dimensions.list_levels.return_value = []
+        ctx = self._make_ctx(ess)
+        for cat in ['generations', 'levels']:
+            fn(app_name='A', db_name='D', category=cat,
+                dimension_name='Time', ctx=ctx)
+
+    def test_essbase_outline_metadata_generations_no_dim_errors(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_outline_metadata'].fn
+
+        ess = MagicMock()
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='A', db_name='D',
+                                category='generations', ctx=ctx))
+        assert 'error' in result
+
+    def test_essbase_outline_metadata_unknown_category(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_outline_metadata'].fn
+
+        ess = MagicMock()
+        ctx = self._make_ctx(ess)
+        result = json.loads(fn(app_name='A', db_name='D',
+                                category='nonsense', ctx=ctx))
+        assert 'error' in result
+
+    def test_essbase_manage_users_list_roles_variants(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_users'].fn
+
+        ess = MagicMock()
+        ess.users.list_service_roles.return_value = []
+        ess.users.list_app_roles.return_value = []
+        ess.users.list_roles.return_value = []
+        ctx = self._make_ctx(ess)
+        # list_app_roles requires app_name
+        json.loads(fn(action='list_app_roles', app_name='Sample',
+                       ctx=ctx))
+        json.loads(fn(action='list_service_roles', ctx=ctx))
+        json.loads(fn(action='list_roles', ctx=ctx))
+
+    def test_essbase_manage_drill_through_validate_paths(self):
+        '''Get + execute paths for drill-through.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_drill_through'].fn
+
+        ess = MagicMock()
+        ess.drill_through.get_report.return_value = {'name': 'R'}
+        ctx = self._make_ctx(ess)
+        # get without report_name → error
+        result = json.loads(fn(action='get', app_name='A', db_name='D',
+                                ctx=ctx))
+        assert 'error' in result
+        # delete without report_name → error
+        result = json.loads(fn(action='delete', app_name='A', db_name='D',
+                                ctx=ctx))
+        assert 'error' in result
+
+    def test_essbase_edit_outline_remove_action(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_edit_outline'].fn
+
+        ess = MagicMock()
+        ess.dimensions.batch_outline_edit.return_value = {'status': 'ok'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(app_name='A', db_name='D',
+                       action='remove', member_name='Q1',
+                       ctx=ctx))
+        # Verify the remove action carries actionType=removeMember (case
+        # may differ — check it's a remove)
+        call_args = ess.dimensions.batch_outline_edit.call_args
+        payload = call_args[0][2] if len(call_args[0]) >= 3 else call_args[0][-1]
+        assert 'remove' in payload['editActions'][0]['actionType'].lower()
+
+    def test_essbase_edit_outline_move_with_parent(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_edit_outline'].fn
+
+        ess = MagicMock()
+        ess.dimensions.batch_outline_edit.return_value = {'status': 'ok'}
+        ctx = self._make_ctx(ess)
+        json.loads(fn(app_name='A', db_name='D',
+                       action='move', member_name='Q1',
+                       parent_name='NewParent', ctx=ctx))
+        ess.dimensions.batch_outline_edit.assert_called_once()
+
+    def test_essbase_manage_filters_get_with_rows(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_filters'].fn
+
+        ess = MagicMock()
+        ess.filters.get_filter.return_value = {'name': 'F'}
+        ess.filters.get_filter_rows.return_value = [{'access': 'READ'}]
+        ess.filters.get_permissions.return_value = []
+        ctx = self._make_ctx(ess)
+        json.loads(fn(action='get', app_name='A', db_name='D',
+                       filter_name='F', ctx=ctx))
+        ess.filters.get_filter.assert_called_once()
+
     def test_essbase_export_data_default_grid(self):
         '''When no MDX or report given, export uses get_default_grid.'''
         from mcp.server.fastmcp import FastMCP
@@ -2047,6 +2753,63 @@ class TestAdpToolDispatch:
                                 ctx=ctx))
         adp.Insight.generate.assert_called_once()
 
+    @pytest.mark.parametrize('tool,kwargs', [
+        ('adp_browse_catalog', {'action': 'entities'}),  # no catalog_name
+        ('adp_browse_catalog', {'action': 'preview'}),
+        ('adp_browse_catalog', {'action': 'check_db_link'}),
+        ('adp_browse_catalog', {'action': 'unknown'}),
+        ('adp_manage_catalog', {'action': 'enable'}),  # no catalog_name
+        ('adp_manage_catalog', {'action': 'disable'}),
+        ('adp_manage_catalog', {'action': 'unmount'}),
+        ('adp_manage_catalog', {'action': 'unknown'}),
+        ('adp_manage_sharing', {'action': 'get'}),
+        ('adp_manage_sharing', {'action': 'create'}),
+        ('adp_manage_sharing', {'action': 'publish'}),
+        ('adp_manage_sharing', {'action': 'grant_recipient'}),
+        ('adp_manage_sharing', {'action': 'create_recipient'}),
+        ('adp_manage_sharing', {'action': 'delete'}),
+        ('adp_manage_sharing', {'action': 'unpublish'}),
+        ('adp_manage_sharing', {'action': 'delete_recipient'}),
+        ('adp_manage_sharing', {'action': 'rename', 'share_name': 'S'}),
+        ('adp_manage_sharing', {'action': 'create_provider'}),
+        ('adp_manage_sharing', {'action': 'delete_provider'}),
+        ('adp_manage_sharing', {'action': 'unknown'}),
+        ('adp_manage_credentials', {'action': 'unknown'}),
+        ('adp_manage_credentials', {'action': 'create',
+                                      'credential_name': 'C'}),
+        ('adp_manage_credentials', {'action': 'create_ocid'}),
+        ('adp_manage_credentials', {'action': 'create_storage_link'}),
+        ('adp_manage_credentials', {'action': 'drop_storage_link'}),
+        ('adp_manage_credentials', {'action': 'drop'}),
+        ('adp_manage_credentials', {'action': 'list_cloud_objects'}),
+        ('adp_manage_db_links', {'action': 'list_tables'}),
+        ('adp_manage_db_links', {'action': 'copy_tables',
+                                   'db_link_name': 'L'}),  # no tables
+        ('adp_manage_db_links', {'action': 'link_tables'}),
+        ('adp_manage_db_links', {'action': 'check'}),
+        ('adp_manage_db_links', {'action': 'drop'}),
+        ('adp_manage_db_links', {'action': 'unknown'}),
+        ('adp_manage_insights', {'action': 'list_insights'}),
+        ('adp_manage_insights', {'action': 'get_graph'}),
+        ('adp_manage_insights', {'action': 'unknown'}),
+        ('adp_manage_analytic_views', {'action': 'unknown'}),
+        ('adp_manage_analytic_views', {'action': 'drop'}),
+        ('adp_load_from_cloud', {}),  # no params
+    ])
+    def test_adp_validation_error_branches(self, tool, kwargs):
+        '''Validation-error coverage for ADP composite tools.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools[tool].fn
+        adp = MagicMock()
+        adp.rest.expired = None
+        adp.rest.username = 'ADMIN'
+        ctx = self._make_ctx(adp)
+        result = json.loads(fn(ctx=ctx, **kwargs))
+        assert 'error' in result
+
     def test_adp_get_annotations_groups_by_column(self):
         '''Verify adp_get_annotations groups rows into table vs column
         annotations and counts them correctly. Also verifies we do NOT
@@ -2328,6 +3091,144 @@ class TestDtToolDispatch:
             pass
         client.create_project.assert_called_once_with('NewProj')
 
+    def _patch_schedule_module(self):
+        '''Build a fake datatransforms.schedule with a Schedule class.'''
+        fake_module = MagicMock()
+        fake_sched = MagicMock()
+        fake_module.Schedule.return_value = fake_sched
+        return fake_module, fake_sched
+
+    def test_dt_manage_schedule_create_immediate(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_schedule'].fn
+
+        client = MagicMock()
+        client.check_if_schedule_exists.return_value = (False, None)
+        ctx = self._make_ctx(client)
+        sched_module, sched = self._patch_schedule_module()
+        with patch.dict('sys.modules',
+                         {'datatransforms.schedule': sched_module}):
+            json.loads(fn(action='create', schedule_name='S',
+                           project_name='P', resource_name='DF',
+                           frequency='immediate', ctx=ctx))
+        sched.immediate.assert_called_once()
+
+    def test_dt_manage_schedule_create_hourly(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_schedule'].fn
+
+        client = MagicMock()
+        client.check_if_schedule_exists.return_value = (False, None)
+        ctx = self._make_ctx(client)
+        sched_module, sched = self._patch_schedule_module()
+        with patch.dict('sys.modules',
+                         {'datatransforms.schedule': sched_module}):
+            json.loads(fn(action='create', schedule_name='S',
+                           project_name='P', resource_name='DF',
+                           frequency='hourly', time='15:30', ctx=ctx))
+        sched.hourly.assert_called_once_with(15, 30)
+
+    def test_dt_manage_schedule_create_daily_full_path(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_schedule'].fn
+
+        client = MagicMock()
+        client.check_if_schedule_exists.return_value = (False, None)
+        ctx = self._make_ctx(client)
+        sched_module, sched = self._patch_schedule_module()
+        with patch.dict('sys.modules',
+                         {'datatransforms.schedule': sched_module}):
+            json.loads(fn(action='create', schedule_name='S',
+                           project_name='P', resource_name='WF',
+                           resource_type='workflow',
+                           frequency='daily', time='09:30:00', ctx=ctx))
+        sched.workflow.assert_called_once_with('P', 'WF')
+        sched.daily.assert_called_once_with(9, 30, 0)
+
+    def test_dt_manage_schedule_create_weekly(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_schedule'].fn
+
+        client = MagicMock()
+        client.check_if_schedule_exists.return_value = (False, None)
+        ctx = self._make_ctx(client)
+        sched_module, sched = self._patch_schedule_module()
+        with patch.dict('sys.modules',
+                         {'datatransforms.schedule': sched_module}):
+            json.loads(fn(action='create', schedule_name='S',
+                           project_name='P', resource_name='DF',
+                           frequency='weekly',
+                           days='MONDAY,FRIDAY',
+                           time='09:00', ctx=ctx))
+        sched.weekly.assert_called_once_with(['MONDAY', 'FRIDAY'], '09:00')
+
+    def test_dt_manage_schedule_create_monthly(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_schedule'].fn
+
+        client = MagicMock()
+        client.check_if_schedule_exists.return_value = (False, None)
+        ctx = self._make_ctx(client)
+        sched_module, sched = self._patch_schedule_module()
+        with patch.dict('sys.modules',
+                         {'datatransforms.schedule': sched_module}):
+            json.loads(fn(action='create', schedule_name='S',
+                           project_name='P', resource_name='DF',
+                           frequency='monthly',
+                           time='15 09:00:00', ctx=ctx))
+        sched.monthly.assert_called_once_with('15', '09:00:00')
+
+    def test_dt_manage_schedule_create_unknown_frequency(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_schedule'].fn
+
+        client = MagicMock()
+        client.check_if_schedule_exists.return_value = (False, None)
+        ctx = self._make_ctx(client)
+        sched_module, _ = self._patch_schedule_module()
+        with patch.dict('sys.modules',
+                         {'datatransforms.schedule': sched_module}):
+            result = json.loads(fn(action='create', schedule_name='S',
+                                    project_name='P', resource_name='DF',
+                                    frequency='nonsense', ctx=ctx))
+        assert 'error' in result
+
+    def test_dt_manage_schedule_create_weekly_no_days_errors(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_schedule'].fn
+
+        client = MagicMock()
+        client.check_if_schedule_exists.return_value = (False, None)
+        ctx = self._make_ctx(client)
+        sched_module, _ = self._patch_schedule_module()
+        with patch.dict('sys.modules',
+                         {'datatransforms.schedule': sched_module}):
+            result = json.loads(fn(action='create', schedule_name='S',
+                                    project_name='P', resource_name='DF',
+                                    frequency='weekly', ctx=ctx))
+        assert 'error' in result
+
     def test_dt_manage_schedule_create_daily(self):
         '''dt_manage_schedule create with daily frequency triggers
         the Schedule builder. We can't import the real builder but can
@@ -2349,6 +3250,157 @@ class TestDtToolDispatch:
                 frequency='daily', time='09:00:00', ctx=ctx)
         except Exception:
             pass
+
+    def test_dt_create_pipeline_full_flow(self):
+        '''Full dt_create_pipeline flow with all required SDK builders
+        mocked.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_create_pipeline'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'proj-1'
+        wb = MagicMock()
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {
+            'datatransforms': {'client': client, 'workbench': wb}}
+
+        # Mock the Project / SourceDataStore / TargetDataStore /
+        # DataFlow builders that the body imports lazily.
+        fake_module = MagicMock()
+        fake_project = MagicMock()
+        fake_module.Project.return_value = fake_project
+        fake_module.SourceDataStore = MagicMock(return_value=MagicMock())
+        fake_module.TargetDataStore = MagicMock(return_value=MagicMock())
+        fake_dataflow = MagicMock()
+        fake_module.DataFlow.return_value = fake_dataflow
+        with patch.dict('sys.modules',
+                         {'datatransforms.dataflow': fake_module}):
+            try:
+                fn(project_name='P',
+                    source_connection='SC', source_schema='SS',
+                    source_table='T1',
+                    target_connection='TC', target_schema='TS',
+                    target_table='T2',
+                    integration_type='CONTROL_APPEND',
+                    ctx=ctx)
+            except Exception:
+                # Builder body may run additional ops we haven't
+                # mocked — we only care about coverage progression.
+                pass
+        # Project existence probe ran
+        client.check_if_project_exists.assert_called_once_with('P')
+
+    def test_dt_create_pipeline_with_workbench_builder(self):
+        '''Walk dt_create_pipeline through the workbench-builder branch
+        deep enough to cover the body's main flow.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_create_pipeline'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'proj-1'
+        client.check_if_df_exists.return_value = (False, None)
+        wb = MagicMock()
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {
+            'datatransforms': {'client': client, 'workbench': wb}}
+
+        fake_df_module = MagicMock()
+        fake_dataflow = MagicMock()
+        fake_df_module.DataFlow.return_value = fake_dataflow
+        fake_df_module.Project = MagicMock(return_value=MagicMock())
+        fake_df_module.SourceDataStore = MagicMock(
+            return_value=MagicMock())
+        fake_df_module.TargetDataStore = MagicMock(
+            return_value=MagicMock())
+        with patch.dict('sys.modules',
+                         {'datatransforms.dataflow': fake_df_module}):
+            try:
+                fn(project_name='P',
+                    source_connection='SC', source_schema='SS',
+                    source_table='T1',
+                    target_connection='TC', target_schema='TS',
+                    target_table='T2',
+                    dataflow_name='MyDF',
+                    integration_type='INSERT',
+                    ctx=ctx)
+            except Exception:
+                pass
+        # Builders were instantiated
+        fake_df_module.Project.assert_called()
+        fake_df_module.SourceDataStore.assert_called()
+        fake_df_module.TargetDataStore.assert_called()
+
+    def test_dt_describe_connection_no_schemas_branch(self):
+        '''Connection details fetched but live_schemas returns empty.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_describe_connection'].fn
+
+        client = MagicMock()
+        client.get_connection_details.return_value = {'name': 'C'}
+        client.test_connection_by_name.return_value = {'status': 'ok'}
+        client.get_live_schemas.return_value = []
+        ctx = self._make_ctx(client)
+        json.loads(fn(connection_name='C', ctx=ctx))
+        client.get_live_schemas.assert_called_once_with('C')
+
+    def test_dt_browse_data_lists_all_schemas(self):
+        '''No schema specified → returns all schemas with their tables.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_browse_data'].fn
+
+        client = MagicMock()
+        client.get_live_schemas.return_value = ['S1', 'S2']
+        client.get_live_tables.return_value = ['T1', 'T2']
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(connection_name='C', ctx=ctx))
+        # Schemas listed
+        assert result.get('schemas') == ['S1', 'S2']
+
+    def test_dt_manage_dataload_get_with_existing(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_dataload'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'proj-1'
+        client.check_if_dataload_exists.return_value = (True, 'dl-id')
+        client.get_dataload_by_id.return_value = {'name': 'DL', 'detail': 'x'}
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(action='get',
+                                project_name='P', dataload_name='DL',
+                                ctx=ctx))
+        client.get_dataload_by_id.assert_called_once_with('dl-id')
+
+    def test_dt_manage_workflow_check_exists_true(self):
+        '''check_exists returns global_id when present.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_workflow'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'proj-1'
+        client.check_if_workflow_exists.return_value = (True, 'wf-id')
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(action='check_exists',
+                                project_name='P', workflow_name='WF',
+                                ctx=ctx))
+        assert result.get('exists') is True
 
     def test_dt_manage_dataload_create_full_body(self):
         '''dt_manage_dataload create body — exercises project check,
@@ -2419,6 +3471,57 @@ class TestDtToolDispatch:
         result = json.loads(fn(action='get', project_name='P',
                                 workflow_name='WF', ctx=ctx))
         client.get_workflow_by_id.assert_called_once_with('wf-id')
+
+    @pytest.mark.parametrize('tool,kwargs', [
+        ('dt_manage_schedule', {'action': 'unknown'}),
+        ('dt_manage_schedule', {'action': 'delete'}),  # no schedule_name
+        ('dt_manage_schedule', {'action': 'create',
+                                  'schedule_name': 'S'}),  # missing more
+        ('dt_manage_variables', {'action': 'unknown'}),
+        ('dt_manage_variables', {'action': 'set'}),  # no name
+        ('dt_manage_variables', {'action': 'set',
+                                   'variable_name': 'V'}),  # no value
+        ('dt_manage_connection', {'action': 'unknown'}),
+        ('dt_manage_connection', {'action': 'get'}),
+        ('dt_manage_connection', {'action': 'test'}),
+        ('dt_manage_connection', {'action': 'delete'}),
+        ('dt_manage_connection', {'action': 'create',
+                                    'connection_name': 'C'}),
+        ('dt_manage_dataload', {'action': 'unknown',
+                                  'project_name': 'P'}),
+        ('dt_manage_dataload', {'action': 'get',
+                                  'project_name': 'P'}),  # no dataload_name
+        ('dt_manage_dataload', {'action': 'check_exists',
+                                  'project_name': 'P'}),
+        ('dt_manage_dataload', {'action': 'create',
+                                  'project_name': 'P',
+                                  'dataload_name': 'DL'}),  # missing more
+        ('dt_manage_workflow', {'action': 'unknown',
+                                  'project_name': 'P'}),
+        ('dt_manage_workflow', {'action': 'get',
+                                  'project_name': 'P'}),
+        ('dt_manage_workflow', {'action': 'check_exists',
+                                  'project_name': 'P'}),
+        ('dt_manage_data_entities', {'action': 'unknown'}),
+        ('dt_manage_data_entities', {'action': 'import_entities',
+                                       'connection_name': 'C'}),  # no schema
+        ('dt_manage_project', {'action': 'unknown',
+                                  'project_name': 'P'}),
+    ])
+    def test_dt_validation_error_branches(self, tool, kwargs):
+        '''Validation-error coverage for DT composite tools.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools[tool].fn
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'proj-1'
+        client.check_if_dataload_exists.return_value = (False, None)
+        client.check_if_workflow_exists.return_value = (False, None)
+        ctx = self._make_ctx(client)
+        result = json.loads(fn(ctx=ctx, **kwargs))
+        assert 'error' in result
 
     def test_dt_describe_project_full_body(self):
         '''Walks the full dt_describe_project flow: existence check
@@ -3449,6 +4552,43 @@ class TestServer:
             ctx = asyncio.run(_run())
         assert ctx.get('_adp_config') is adp_cfg
         assert ctx.get('adp') == 'adp-client'
+
+    def test_lifespan_essbase_login_failure_is_caught(self):
+        '''Essbase login that throws is logged but doesn't break startup.'''
+        import asyncio
+        from oracle.data_studio_mcp_server import server as srv
+
+        async def _run():
+            async with srv.app_lifespan(MagicMock()) as ctx:
+                return ctx
+
+        fake_essbase = MagicMock()
+        fake_essbase.login.side_effect = RuntimeError('connection refused')
+        ess_cfg = MagicMock(token=None, url='https://e',
+                             user='admin', password='p')
+        with patch.object(srv, '_config',
+                           MagicMock(essbase=ess_cfg, adp=None,
+                                      datatransforms=None)), \
+             patch.dict('sys.modules', {'essbase': fake_essbase}):
+            ctx = asyncio.run(_run())
+        # Lifespan still yielded a context — startup didn't break
+        assert 'essbase' not in ctx
+
+    def test_lifespan_dt_configured(self):
+        '''DT path: stores _dt_config for later lazy-connect.'''
+        import asyncio
+        from oracle.data_studio_mcp_server import server as srv
+
+        async def _run():
+            async with srv.app_lifespan(MagicMock()) as ctx:
+                return ctx
+
+        dt_cfg = MagicMock(url='https://dt')
+        with patch.object(srv, '_config',
+                           MagicMock(essbase=None, adp=None,
+                                      datatransforms=dt_cfg)):
+            ctx = asyncio.run(_run())
+        assert ctx.get('_dt_config') is dt_cfg
 
     def test_lifespan_adp_login_failure_is_caught(self):
         '''ADP login that throws is logged but doesn't break startup.'''

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tests/test_unit.py
@@ -744,16 +744,19 @@ class TestProfiles:
         }
         apply_profile(mock_mcp, 'analyst')
         tools = mock_mcp._tool_manager._tools
-        # Analyst should keep: explore, query, run_, generate_, ai_
+        # Analyst should keep: explore, query, run_, generate_
         assert 'essbase_explore' in tools
         assert 'essbase_run_calculation' in tools
         assert 'adp_generate_insights' in tools
-        assert 'adp_ai_chat' in tools
         assert 'dt_explore' in tools
-        # Analyst should remove: manage_, load_from_cloud (explicit deny)
+        # Analyst should remove: manage_, load_from_cloud,
+        # and adp_ai_chat (Select AI is admin-only by default — see
+        # the explicit_deny comment in profiles.py for the LLM01/LLM05
+        # reasoning).
         assert 'essbase_manage_variables' not in tools
         assert 'adp_load_from_cloud' not in tools
         assert 'dt_manage_schedule' not in tools
+        assert 'adp_ai_chat' not in tools
 
     @mcp_required
     def test_viewer_cannot_run_mdx(self):
@@ -2118,7 +2121,9 @@ class TestEssbaseToolDispatch:
         ess = MagicMock()
         ess.sessions.delete_session.return_value = {'status': 'killed'}
         ctx = self._make_ctx(ess)
-        json.loads(fn(action='kill', session_id='123', ctx=ctx))
+        # kill requires confirm=session_id (LLM06 mitigation)
+        json.loads(fn(action='kill', session_id='123',
+                       confirm='123', ctx=ctx))
         ess.sessions.delete_session.assert_called_once_with('123')
 
     def test_essbase_manage_application_update(self):
@@ -4087,7 +4092,8 @@ ADP_DISPATCH_CASES = [
     # adp_manage_analytic_views
     ('adp_manage_analytic_views', {'action': 'list'},
      'Analytics.get_list'),
-    ('adp_manage_analytic_views', {'action': 'drop', 'av_name': 'AV'},
+    ('adp_manage_analytic_views', {'action': 'drop', 'av_name': 'AV',
+                                      'confirm': 'AV'},
      'Analytics.drop'),
     # adp_manage_credentials
     ('adp_manage_credentials', {'action': 'list'},
@@ -4269,7 +4275,8 @@ DT_DISPATCH_CASES = [
                                 'variable_name': 'V', 'value': 'x'},
      'update_variable', False),
     # dt_manage_project delete
-    ('dt_manage_project', {'action': 'delete', 'project_name': 'P'},
+    ('dt_manage_project', {'action': 'delete', 'project_name': 'P',
+                              'confirm': 'P'},
      'delete_project', False),
     # dt_manage_dataload create — exercises the builder path's existence
     # check (will hit ImportError on the DataLoad builder; we just
@@ -4303,13 +4310,15 @@ ESS_DISPATCH_CASES = [
     ('essbase_manage_application', {'action': 'create', 'app_name': 'A',
                                       'db_name': 'D'},
      'applications.create_application'),
-    ('essbase_manage_application', {'action': 'delete', 'app_name': 'A'},
+    # Destructive actions require confirm=resource_name (LLM06 mitigation)
+    ('essbase_manage_application', {'action': 'delete', 'app_name': 'A',
+                                      'confirm': 'A'},
      'applications.delete_application'),
     ('essbase_manage_application', {'action': 'copy', 'app_name': 'A',
                                       'new_name': 'B'},
      'applications.copy_application'),
     ('essbase_manage_application', {'action': 'rename', 'app_name': 'A',
-                                      'new_name': 'B'},
+                                      'new_name': 'B', 'confirm': 'A'},
      'applications.rename_application'),
     # start/stop go through update_application, not start/stop_application
     ('essbase_manage_application', {'action': 'start', 'app_name': 'A'},
@@ -4318,7 +4327,8 @@ ESS_DISPATCH_CASES = [
      'applications.update_application'),
     # essbase_manage_database (no create — only delete/copy/rename/update)
     ('essbase_manage_database', {'action': 'delete',
-                                   'app_name': 'A', 'db_name': 'D'},
+                                   'app_name': 'A', 'db_name': 'D',
+                                   'confirm': 'D'},
      'applications.delete_database'),
     ('essbase_manage_database', {'action': 'copy',
                                    'app_name': 'A', 'db_name': 'D',
@@ -4440,7 +4450,8 @@ ESS_DISPATCH_CASES = [
      'users.list_users'),
     ('essbase_manage_users', {'action': 'get', 'user_id': 'u'},
      'users.get_user'),
-    ('essbase_manage_users', {'action': 'delete', 'user_id': 'u'},
+    ('essbase_manage_users', {'action': 'delete', 'user_id': 'u',
+                                'confirm': 'u'},
      'users.delete_user'),
     ('essbase_manage_users', {'action': 'list_roles'},
      'users.list_roles'),
@@ -4602,8 +4613,8 @@ ESS_DISPATCH_CASES = [
                                 'app_name': 'A', 'db_name': 'D',
                                 'object_name': 'O'},
      'locks.unlock_object'),
-    # essbase_manage_sessions kill_all
-    ('essbase_manage_sessions', {'action': 'kill_all'},
+    # essbase_manage_sessions kill_all — requires confirm='all'
+    ('essbase_manage_sessions', {'action': 'kill_all', 'confirm': 'all'},
      'sessions.delete_all_sessions'),
     ('essbase_manage_sessions', {'action': 'current'},
      'sessions.get_current_session'),
@@ -4755,9 +4766,15 @@ class TestServer:
         # Build a config that selects streamable-http and a specific
         # host/port. We patch apply_profile + mcp.run so main() doesn't
         # actually start a server.
+        # Non-loopback host requires opting past the fail-closed gate.
+        # Pass allow_insecure_bind=True so the gate allows the bind, and
+        # auth_token=None so we exercise the FastMCP.run() path (rather
+        # than the uvicorn-wrap path used when a token is configured).
         fake_cfg = MagicMock(transport='streamable-http',
                               host='0.0.0.0', port=9001,
-                              profile='admin')
+                              profile='admin',
+                              auth_token=None,
+                              allow_insecure_bind=True)
         with patch.object(srv, 'load_config', return_value=fake_cfg), \
              patch.object(srv, 'apply_profile'), \
              patch.object(srv.mcp, 'run') as run_mock:
@@ -5359,3 +5376,423 @@ class TestServerStartupWiring:
         monkeypatch.setattr(srv.mcp, 'run', lambda **_: None)
         srv.main()
         assert seen.get('profile') == 'viewer'
+
+
+# ====================================================================== #
+#  Security findings 1–4: HTTP bind gate, metadata redaction,             #
+#  Select AI policy, destructive-action confirmations                     #
+# ====================================================================== #
+
+class TestHttpBindGate:
+    '''Finding 1: streamable-http must fail closed on non-loopback bind.'''
+
+    def test_is_loopback(self):
+        from oracle.data_studio_mcp_server.http_runtime import is_loopback
+        for host in ('127.0.0.1', '::1', 'localhost', None, ''):
+            assert is_loopback(host), host
+        for host in ('0.0.0.0', '10.0.0.5', 'mcp.internal',
+                      '169.254.1.1', '8.8.8.8'):
+            assert not is_loopback(host), host
+
+    def test_decide_bind_loopback_passes(self):
+        from oracle.data_studio_mcp_server.http_runtime import decide_bind
+        # No auth needed for loopback
+        decide_bind('127.0.0.1')
+        decide_bind('::1')
+        decide_bind('localhost')
+
+    def test_decide_bind_non_loopback_with_token_passes(self):
+        from oracle.data_studio_mcp_server.http_runtime import decide_bind
+        decide_bind('0.0.0.0', auth_token='s3cr3t-token-1234')
+
+    def test_decide_bind_non_loopback_with_insecure_flag_passes(self, caplog):
+        '''operator-acknowledged insecure bind emits a WARNING.'''
+        import logging
+        from oracle.data_studio_mcp_server.http_runtime import decide_bind
+        caplog.set_level(logging.WARNING,
+                         logger='oracle-data-studio-mcp')
+        decide_bind('0.0.0.0', allow_insecure_bind=True)
+        warnings_ = [r.getMessage() for r in caplog.records
+                     if r.levelno == logging.WARNING]
+        assert any('non-loopback' in w and '0.0.0.0' in w
+                   for w in warnings_)
+
+    def test_decide_bind_non_loopback_no_auth_refuses(self):
+        from oracle.data_studio_mcp_server.http_runtime import (
+            decide_bind, InsecureBindRefused)
+        with pytest.raises(InsecureBindRefused) as exc:
+            decide_bind('0.0.0.0')
+        assert 'MCP_AUTH_TOKEN' in str(exc.value)
+        assert 'allow-insecure-bind' in str(exc.value)
+        assert '0.0.0.0' in str(exc.value)
+
+    def test_main_refuses_non_loopback_without_auth(self, monkeypatch):
+        '''server.main() must sys.exit(2) on the gate.'''
+        from oracle.data_studio_mcp_server import server as srv
+        from oracle.data_studio_mcp_server.config import ServerConfig
+        cfg = ServerConfig(profile='admin',
+                           transport='streamable-http',
+                           host='0.0.0.0',
+                           port=9000,
+                           auth_token=None,
+                           allow_insecure_bind=False)
+        monkeypatch.setattr(srv, 'load_config', lambda: cfg)
+        with pytest.raises(SystemExit) as exc:
+            srv.main()
+        assert exc.value.code == 2
+
+    def test_bearer_middleware_rejects_missing_header(self):
+        from oracle.data_studio_mcp_server.http_runtime import (
+            make_bearer_middleware)
+        from starlette.applications import Starlette
+        from starlette.routing import Route
+        from starlette.responses import JSONResponse
+        from starlette.testclient import TestClient
+        from starlette.middleware import Middleware
+
+        async def ok(request):
+            return JSONResponse({'ok': True})
+
+        app = Starlette(routes=[Route('/x', ok, methods=['POST'])],
+                         middleware=[Middleware(make_bearer_middleware('s3cret'))])
+        client = TestClient(app)
+        # No Authorization header → 401
+        r = client.post('/x')
+        assert r.status_code == 401
+        assert r.json()['error'] == 'authentication required'
+        # Wrong token → 401
+        r = client.post('/x', headers={'Authorization': 'Bearer nope'})
+        assert r.status_code == 401
+        assert r.json()['error'] == 'invalid bearer token'
+        # Correct token → 200
+        r = client.post('/x', headers={'Authorization': 'Bearer s3cret'})
+        assert r.status_code == 200
+        assert r.json() == {'ok': True}
+
+    def test_bearer_middleware_allows_root_health(self):
+        '''GET / passes unauthenticated so probes work.'''
+        from oracle.data_studio_mcp_server.http_runtime import (
+            make_bearer_middleware)
+        from starlette.applications import Starlette
+        from starlette.routing import Route
+        from starlette.responses import JSONResponse
+        from starlette.testclient import TestClient
+        from starlette.middleware import Middleware
+
+        async def root(request):
+            return JSONResponse({'pong': True})
+
+        app = Starlette(routes=[Route('/', root, methods=['GET'])],
+                         middleware=[Middleware(make_bearer_middleware('s3cret'))])
+        client = TestClient(app)
+        r = client.get('/')
+        assert r.status_code == 200
+
+
+class TestConnectionMetadataRedaction:
+    '''Finding 2: viewer must not see JDBC URLs, wallet paths, etc.'''
+
+    SENSITIVE_CONN = {
+        'name': 'PROD_ADW',
+        'connectionName': 'PROD_ADW',
+        'type': 'Oracle',
+        'connectionType': 'Oracle',
+        'status': 'Active',
+        'description': 'Production warehouse',
+        'host': 'adb.us-ashburn-1.oraclecloud.com',
+        'port': 1522,
+        'serviceName': 'prod_high',
+        'schemaName': 'SALES',
+        # Sensitive — should never reach viewer/analyst
+        'jdbcURL': 'jdbc:oracle:thin:@(description=…)',
+        'username': 'ADMIN',
+        'password': 'Welcome2025#',
+        'walletLocation': '/users/admin/wallets/prod.zip',
+        'tnsAdmin': '/etc/oracle/network/admin',
+        'truststorePassword': 'storepwd',
+        'connectionXml': '<?xml ...?>',
+        'connectionTypeProperties': {'oauth_secret': 'AbCdEf123'},
+    }
+
+    def test_viewer_sees_only_identity_fields(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            redact_connection_metadata)
+        out = redact_connection_metadata(self.SENSITIVE_CONN, profile='viewer')
+        assert out['name'] == 'PROD_ADW'
+        assert out['type'] == 'Oracle'
+        assert out['status'] == 'Active'
+        assert out['_redacted'] is True
+        # None of the sensitive fields make it through:
+        for k in ('jdbcURL', 'username', 'password', 'walletLocation',
+                  'tnsAdmin', 'truststorePassword', 'connectionXml',
+                  'connectionTypeProperties', 'host', 'port',
+                  'serviceName', 'schemaName'):
+            assert k not in out, f'viewer leaked {k!r}: {out}'
+
+    def test_analyst_adds_host_port_schema(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            redact_connection_metadata)
+        out = redact_connection_metadata(self.SENSITIVE_CONN, profile='analyst')
+        # Identity + topology
+        for k in ('name', 'type', 'host', 'port', 'serviceName',
+                  'schemaName'):
+            assert out[k] == self.SENSITIVE_CONN[k], k
+        # But still NEVER auth material:
+        for k in ('jdbcURL', 'username', 'password', 'walletLocation',
+                  'tnsAdmin', 'truststorePassword', 'connectionXml',
+                  'connectionTypeProperties'):
+            assert k not in out, f'analyst leaked {k!r}'
+
+    def test_admin_sees_raw(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            redact_connection_metadata)
+        out = redact_connection_metadata(self.SENSITIVE_CONN, profile='admin')
+        assert out is self.SENSITIVE_CONN
+
+    def test_unknown_profile_treated_as_viewer(self):
+        '''Fail-closed: unknown profile string falls back to least-privilege.'''
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            redact_connection_metadata)
+        out = redact_connection_metadata(self.SENSITIVE_CONN, profile='wat')
+        assert 'jdbcURL' not in out
+        assert 'walletLocation' not in out
+
+    def test_list_of_connections_each_redacted(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            redact_connection_metadata)
+        payload = [self.SENSITIVE_CONN, self.SENSITIVE_CONN]
+        out = redact_connection_metadata(payload, profile='viewer')
+        assert isinstance(out, list) and len(out) == 2
+        for entry in out:
+            assert 'jdbcURL' not in entry
+            assert 'walletLocation' not in entry
+            assert entry['_redacted'] is True
+
+    def test_nested_connection_in_envelope(self):
+        '''Common shape: {'items': [conn, conn, ...]} — walk and redact.'''
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            redact_connection_metadata)
+        envelope = {'items': [self.SENSITIVE_CONN]}
+        # The envelope is itself a dict with 'items' — it gets redacted too.
+        # Under viewer, the only top-level allow-list keys that match
+        # are the identifier set; 'items' isn't in there. That's OK —
+        # the helper is intended to be called on the connection-shaped
+        # payload directly. Test the bare-list path instead.
+        out = redact_connection_metadata(envelope['items'], profile='viewer')
+        assert 'jdbcURL' not in out[0]
+
+
+class TestAiChatPolicy:
+    '''Finding 3: adp_ai_chat profile + table allow/deny enforcement.'''
+
+    def test_analyst_profile_blocks_adp_ai_chat(self):
+        from oracle.data_studio_mcp_server.profiles import (
+            apply_profile, PROFILES)
+        mock_mcp = MagicMock()
+        mock_mcp._tool_manager._tools = {
+            'adp_ai_chat': MagicMock(),
+            'adp_search': MagicMock(),
+        }
+        apply_profile(mock_mcp, 'analyst')
+        tools = mock_mcp._tool_manager._tools
+        assert 'adp_ai_chat' not in tools
+        assert 'adp_search' in tools
+
+    def test_no_policy_allows_anything(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            check_ai_chat_tables)
+        # No allow / no deny → call proceeds regardless of `tables`.
+        assert check_ai_chat_tables(None) is None
+        assert check_ai_chat_tables('ANY,TABLES') is None
+
+    def test_allowlist_rejects_unlisted_table(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            check_ai_chat_tables)
+        allowed = frozenset({'ORDERS', 'CUSTOMERS'})
+        msg = check_ai_chat_tables('ORDERS,SECRETS', allowed=allowed)
+        assert msg is not None
+        assert 'SECRETS' in msg
+        assert 'allow list' in msg
+
+    def test_allowlist_with_no_tables_requested_rejects(self):
+        '''Allowlist set + caller omits `tables` → policy can't be applied.'''
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            check_ai_chat_tables)
+        allowed = frozenset({'ORDERS'})
+        msg = check_ai_chat_tables(None, allowed=allowed)
+        assert msg is not None
+        assert 'no `tables` were specified' in msg
+
+    def test_denylist_rejects_listed_table(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            check_ai_chat_tables)
+        denied = frozenset({'DBA_USERS', 'AUDSYS.AUDIT_TRAIL'})
+        msg = check_ai_chat_tables('ORDERS,DBA_USERS', denied=denied)
+        assert msg is not None
+        assert 'DBA_USERS' in msg
+        assert 'deny list' in msg
+
+    def test_deny_beats_allow(self):
+        '''Deny always wins even when a table is also on the allowlist.'''
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            check_ai_chat_tables)
+        allowed = frozenset({'DBA_USERS'})
+        denied = frozenset({'DBA_USERS'})
+        msg = check_ai_chat_tables('DBA_USERS', allowed=allowed, denied=denied)
+        assert msg is not None
+        assert 'deny list' in msg
+
+    def test_case_insensitive_matching(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            check_ai_chat_tables)
+        denied = frozenset({'DBA_USERS'})
+        assert check_ai_chat_tables('dba_users', denied=denied) is not None
+        assert check_ai_chat_tables('Dba_Users', denied=denied) is not None
+
+    def test_qualified_name_matches_bare_name(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            check_ai_chat_tables)
+        denied = frozenset({'AUDIT_TRAIL'})
+        assert check_ai_chat_tables('SYS.AUDIT_TRAIL',
+                                      denied=denied) is not None
+
+    def test_envelope_marks_select_ai_output_untrusted(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            ai_chat_envelope)
+        result = [{'id': 1}, {'id': 2}]
+        env = ai_chat_envelope(result, mode='chat_with_db', max_rows=10)
+        assert env['source'] == 'select_ai'
+        assert env['untrusted'] is True
+        assert env['mode'] == 'chat_with_db'
+        assert env['rows'] == result
+
+    def test_envelope_bounds_rows(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            ai_chat_envelope)
+        rows = [{'i': i} for i in range(100)]
+        env = ai_chat_envelope(rows, mode='chat_with_db', max_rows=10)
+        assert env['untrusted'] is True
+        assert env['truncated'] is True
+        assert env['original_row_count'] == 100
+        assert len(env['rows']) == 10
+
+
+class TestRequireConfirm:
+    '''Finding 4: destructive actions require confirm = resource_name.'''
+
+    def test_match_passes(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            require_confirm)
+        assert require_confirm('Sample', 'Sample') is None
+
+    def test_mismatch_returns_error(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            require_confirm)
+        msg = require_confirm('Sample', 'sample')  # case-sensitive
+        assert msg is not None
+        assert "'Sample'" in msg
+
+    def test_missing_returns_error(self):
+        from oracle.data_studio_mcp_server.tools._helpers import (
+            require_confirm)
+        assert require_confirm('Sample', None) is not None
+        assert require_confirm('Sample', '') is not None
+
+    def test_essbase_manage_application_delete_requires_confirm(self):
+        '''End-to-end: missing confirm => no SDK call, error returned.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_application'].fn
+
+        ess = MagicMock()
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {'essbase': ess}
+
+        # Missing confirm → blocked
+        result = json.loads(fn(action='delete', app_name='Sample', ctx=ctx))
+        assert 'error' in result
+        ess.applications.delete_application.assert_not_called()
+
+        # Wrong confirm → blocked
+        result = json.loads(fn(action='delete', app_name='Sample',
+                                 confirm='wrong', ctx=ctx))
+        assert 'error' in result
+        ess.applications.delete_application.assert_not_called()
+
+        # Correct confirm → SDK call lands
+        ess.applications.delete_application.return_value = ''
+        json.loads(fn(action='delete', app_name='Sample',
+                        confirm='Sample', ctx=ctx))
+        ess.applications.delete_application.assert_called_once_with('Sample')
+
+    def test_essbase_manage_sessions_kill_all_requires_confirm_all(self):
+        '''kill_all uses the literal token 'all'.'''
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import essbase_tools
+        mcp_server = FastMCP('test')
+        essbase_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['essbase_manage_sessions'].fn
+
+        ess = MagicMock()
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {'essbase': ess}
+
+        # Missing confirm → blocked
+        result = json.loads(fn(action='kill_all', ctx=ctx))
+        assert 'error' in result
+        ess.sessions.delete_all_sessions.assert_not_called()
+
+        # confirm='all' → SDK call lands
+        ess.sessions.delete_all_sessions.return_value = ''
+        json.loads(fn(action='kill_all', confirm='all', ctx=ctx))
+        ess.sessions.delete_all_sessions.assert_called_once()
+
+    def test_dt_manage_project_delete_requires_confirm(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import dt_tools
+        mcp_server = FastMCP('test')
+        dt_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['dt_manage_project'].fn
+
+        client = MagicMock()
+        client.check_if_project_exists.return_value = 'pid-1'
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {
+            'datatransforms': {'client': client, 'workbench': None}}
+
+        # Missing confirm → blocked, no SDK call
+        result = json.loads(fn(action='delete', project_name='Marketing',
+                                ctx=ctx))
+        assert 'error' in result
+        client.delete_project.assert_not_called()
+
+        # Correct confirm
+        client.delete_project.return_value = None
+        json.loads(fn(action='delete', project_name='Marketing',
+                       confirm='Marketing', ctx=ctx))
+        client.delete_project.assert_called_once_with('Marketing')
+
+    def test_adp_manage_analytic_views_drop_requires_confirm(self):
+        from mcp.server.fastmcp import FastMCP
+        from oracle.data_studio_mcp_server.tools import adp_tools
+        mcp_server = FastMCP('test')
+        adp_tools.register_tools(mcp_server)
+        fn = mcp_server._tool_manager._tools['adp_manage_analytic_views'].fn
+
+        client = MagicMock()
+        client.rest.expired = None
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {'adp': client}
+
+        # Missing confirm → blocked
+        result = json.loads(fn(action='drop', av_name='SALES_AV', ctx=ctx))
+        assert 'error' in result
+        client.Analytics.drop.assert_not_called()
+
+        # Correct confirm
+        client.Analytics.drop.return_value = ''
+        json.loads(fn(action='drop', av_name='SALES_AV',
+                       confirm='SALES_AV', ctx=ctx))
+        client.Analytics.drop.assert_called_once_with('SALES_AV')

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/__init__.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''MCP tool modules for Oracle Data Studio.'''

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/_adp_connect.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/_adp_connect.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''
+Auto-reconnect helper for ADP connections.
+
+The ORDS session (or OAuth token) can expire during a long MCP session.
+This helper:
+1. Proactively checks token expiry before returning the client.
+2. Reactively catches "expired" / 401 errors and re-logins once.
+
+Usage in tool modules:
+    from ._adp_connect import run_adp
+
+    @mcp.tool()
+    def adp_list_tables(ctx: Context) -> str:
+        """List all tables."""
+        return run_adp(ctx, lambda adp: adp.Misc.list_tables())
+'''
+
+import json
+import logging
+import threading
+import time
+from datetime import datetime
+
+from mcp.server.fastmcp import Context
+
+logger = logging.getLogger('oracle-data-studio-mcp')
+
+_NO_CONN_MSG = 'ADP not connected. Set ADP_URL, ADP_USER, ADP_PASSWORD.'
+
+# ── Reconnect throttling (S6) ──────────────────────────────────────
+# A malformed-401 storm or compromised credential could otherwise
+# cause unlimited re-login attempts.
+_MAX_RECONNECTS_PER_WINDOW = 3
+_WINDOW_SECONDS = 60
+# Cool-down once we've hit the limit.
+_COOLDOWN_SECONDS = 30
+
+# ── Reconnect serialisation (S7) ───────────────────────────────────
+# In streamable-http transport, multiple tool calls run concurrently.
+# A reconnect that swaps lc['adp'] must hold a per-context lock so
+# we don't return a client while another thread is replacing it.
+_locks: dict[int, threading.Lock] = {}
+_locks_lock = threading.Lock()
+
+
+def _ctx_lock(lc) -> threading.Lock:
+    '''Per-lifespan-context reconnect lock.'''
+    key = id(lc)
+    with _locks_lock:
+        lk = _locks.get(key)
+        if lk is None:
+            lk = threading.Lock()
+            _locks[key] = lk
+        return lk
+
+
+# ------------------------------------------------------------------ #
+#  Formatting helpers                                                  #
+# ------------------------------------------------------------------ #
+
+def _default_format(result):
+    '''Standard JSON formatting for SDK results.'''
+    if result is None:
+        return json.dumps({'status': 'success'})
+    if isinstance(result, (dict, list)):
+        return json.dumps(result, indent=2)
+    return str(result)
+
+
+def _err(msg):
+    # Funnel through the shared sanitiser so connect-time errors
+    # (which often carry DSNs / passwords) are scrubbed.
+    from ._helpers import safe_err
+    return json.dumps({'error': safe_err(msg)})
+
+
+# ------------------------------------------------------------------ #
+#  Connection management                                               #
+# ------------------------------------------------------------------ #
+
+def _is_expired(exc):
+    '''Return True if the exception indicates an expired session/token.'''
+    msg = str(exc).lower()
+    return 'expired' in msg or '401' in msg
+
+
+def _allow_reconnect(lc) -> tuple[bool, str | None]:
+    '''Rate-limit check. Returns (allowed, deny_reason_if_not).'''
+    now = time.monotonic()
+    history = lc.setdefault('_adp_reconnect_times', [])
+    cooldown_until = lc.get('_adp_reconnect_cooldown_until', 0)
+    if now < cooldown_until:
+        return (False, f'reconnect cooled down for '
+                       f'{int(cooldown_until - now)}s '
+                       f'(too many recent failures)')
+    # Drop entries outside the rolling window
+    cutoff = now - _WINDOW_SECONDS
+    history[:] = [t for t in history if t >= cutoff]
+    if len(history) >= _MAX_RECONNECTS_PER_WINDOW:
+        lc['_adp_reconnect_cooldown_until'] = now + _COOLDOWN_SECONDS
+        return (False,
+                f'reconnect rate limit hit '
+                f'({_MAX_RECONNECTS_PER_WINDOW} attempts in '
+                f'{_WINDOW_SECONDS}s) — cooling down for '
+                f'{_COOLDOWN_SECONDS}s')
+    history.append(now)
+    return (True, None)
+
+
+def _reconnect(lc):
+    '''Re-login to ADP using stored credentials. Returns new client or None.
+
+    Serialised per lifespan-context (S7) and rate-limited (S6).
+    '''
+    cfg = lc.get('_adp_config')
+    if not cfg:
+        return None
+
+    lock = _ctx_lock(lc)
+    with lock:
+        # Another thread may have already reconnected while we were
+        # waiting for the lock — avoid duplicate logins.
+        existing = lc.get('adp')
+        if existing is not None:
+            rest = getattr(existing, 'rest', None)
+            still_valid = (rest is None
+                           or rest.expired is None
+                           or datetime.now() < rest.expired)
+            if still_valid:
+                return existing
+
+        ok, reason = _allow_reconnect(lc)
+        if not ok:
+            logger.warning('ADP reconnect denied: %s', reason)
+            return None
+
+        try:
+            import adp
+            adp_client = adp.login(cfg.url, cfg.user, cfg.password)
+            lc['adp'] = adp_client
+            logger.info('ADP reconnected to %s as %s', cfg.url, cfg.user)
+            return adp_client
+        except Exception as e:
+            logger.error('ADP reconnect failed: %s', e)
+            return None
+
+
+def get_adp(ctx: Context):
+    '''Return the ADP client, reconnecting proactively if the token has expired.
+
+    Reads of `lc['adp']` are best-effort racy (a concurrent reconnect
+    might be in-flight) — but the swap inside `_reconnect` happens
+    under a per-context lock, so worst case is that a caller uses a
+    just-replaced-but-still-valid client.
+    '''
+    lc = ctx.request_context.lifespan_context
+    client = lc.get('adp')
+
+    if client:
+        # Proactive check for OAuth-token connections
+        rest = client.rest
+        if rest.expired is not None and datetime.now() >= rest.expired:
+            logger.info('ADP token expired, reconnecting proactively')
+            return _reconnect(lc) or client
+        return client
+
+    # No client at all — attempt initial connection
+    return _reconnect(lc)
+
+
+# ------------------------------------------------------------------ #
+#  Public API: run_adp                                                 #
+# ------------------------------------------------------------------ #
+
+def run_adp(ctx: Context, fn, format_fn=None):
+    '''Execute *fn(adp_client)* with auto-reconnect on session expiry.
+
+    Parameters
+    ----------
+    ctx : Context
+        FastMCP request context.
+    fn : callable(adp_client) -> result
+        A callable that receives the ADP client and makes the SDK call.
+        May also do pre-processing (e.g. json.loads) inside the callable.
+    format_fn : callable(result) -> str, optional
+        Custom formatter.  Defaults to the standard JSON formatter.
+
+    Returns
+    -------
+    str
+        JSON-encoded result or error.
+    '''
+    fmt = format_fn or _default_format
+    lc = ctx.request_context.lifespan_context
+    client = get_adp(ctx)
+
+    if not client:
+        return json.dumps({'error': _NO_CONN_MSG})
+
+    try:
+        result = fn(client)
+        return fmt(result)
+    except Exception as e:
+        if _is_expired(e):
+            logger.info('ADP session expired during call, reconnecting...')
+            client = _reconnect(lc)
+            if client:
+                try:
+                    result = fn(client)
+                    return fmt(result)
+                except Exception as e2:
+                    return _err(str(e2))
+        return _err(str(e))

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/_dt_connect.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/_dt_connect.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''
+Lazy connection helper for Data Transforms.
+
+On ADBS deployments the DT container can be idle at server startup.
+This helper defers connection to the first DT tool call.  It tries
+three strategies in order:
+
+1. Check if adp.login()'s background thread already connected the
+   DataTransformsWorkbench (stored on the Adp object).
+2. Use the ADP connection to query dba_pdbs for OCI params (tenancy,
+   ADW OCID) and call connect_workbench with the full ADBS-style dict.
+3. Fall back to simple URL auth (for non-ADBS / marketplace deployments).
+'''
+
+import sys
+import logging
+from mcp.server.fastmcp import Context
+
+logger = logging.getLogger('oracle-data-studio-mcp')
+
+# SQL used by adp.login() to discover OCI identity
+_DBA_PDBS_SQL = """
+SELECT
+  JSON_VALUE(cloud_identity, '$.DATABASE_NAME') AS database_name,
+  JSON_VALUE(cloud_identity, '$.DATABASE_OCID') AS cloud_database_name,
+  JSON_VALUE(cloud_identity, '$.TENANT_OCID')   AS tenant_name
+FROM dba_pdbs
+"""
+
+
+def _reset_singletons():
+    '''Reset DataTransformsWorkbench and DataTransformsClient singletons.'''
+    try:
+        from datatransforms.workbench import DataTransformsWorkbench
+        DataTransformsWorkbench._instance = None
+        if hasattr(DataTransformsWorkbench, 'initialized'):
+            del DataTransformsWorkbench.initialized
+    except ImportError:
+        pass
+    try:
+        from datatransforms.client import DataTransformsClient
+        DataTransformsClient._instance = None
+        if hasattr(DataTransformsClient, '_instances'):
+            DataTransformsClient._instances.pop(DataTransformsClient, None)
+        if hasattr(DataTransformsClient, 'initialized'):
+            del DataTransformsClient.initialized
+        DataTransformsClient.connected = False
+    except ImportError:
+        pass
+
+
+def _try_from_adp_thread(adp_client):
+    '''Strategy 1: get workbench from adp.login() background thread.'''
+    if adp_client is None:
+        return None
+    try:
+        adp_client.wait_for_datatransforms(timeout=300)
+        wb = getattr(adp_client, 'dt', None)
+        if wb:
+            return {'workbench': wb, 'client': wb.get_client()}
+    except Exception as e:
+        logger.debug('DT from ADP thread failed: %s', e)
+    return None
+
+
+def _try_adbs_connect(adp_client, cfg):
+    '''Strategy 2: query OCI params via ADP and do ADBS token connect.'''
+    if adp_client is None or cfg is None:
+        return None
+    try:
+        rows = adp_client.Misc.run_query(_DBA_PDBS_SQL)
+        if not (isinstance(rows, list) and len(rows) > 0):
+            logger.debug('DT lazy: dba_pdbs query returned no rows')
+            return None
+        row = rows[0]
+
+        connect_params = {
+            'xforms_url': cfg.url,
+            'data_transforms_url': cfg.url,
+            'data_transforms_user': cfg.user,
+            'xforms_user': cfg.user,
+            'pswd': cfg.password,
+            'tenancy_ocid': row['tenant_name'],
+            'adw_name': row['database_name'],
+            'adw_ocid': row['cloud_database_name'],
+        }
+
+        _reset_singletons()
+
+        from datatransforms.workbench import DataTransformsWorkbench
+        wb = DataTransformsWorkbench()
+        wb.connect_workbench(connect_params)
+        logger.info('Data Transforms lazy-connected (ADBS) to %s', cfg.url)
+        return {'workbench': wb, 'client': wb.get_client()}
+    except Exception as e:
+        logger.warning('DT ADBS lazy connect failed: %s', e)
+        print(f'DT ADBS lazy connect failed: {e}', file=sys.stderr, flush=True)
+    return None
+
+
+def _try_simple_connect(cfg):
+    '''Strategy 3: simple URL + Basic auth (non-ADBS deployments).'''
+    if cfg is None:
+        return None
+    try:
+        _reset_singletons()
+
+        from datatransforms.workbench import DataTransformsWorkbench
+        wb = DataTransformsWorkbench()
+        wb.connect_workbench({
+            'data_transforms_url': cfg.url,
+            'data_transforms_user': cfg.user,
+            'pswd': cfg.password,
+        })
+        logger.info('Data Transforms lazy-connected (simple) to %s', cfg.url)
+        return {'workbench': wb, 'client': wb.get_client()}
+    except Exception as e:
+        logger.debug('DT simple lazy connect failed: %s', e)
+    return None
+
+
+def get_dt(ctx: Context):
+    '''Return the DT connection dict, attempting lazy connect if needed.'''
+    lc = ctx.request_context.lifespan_context
+
+    # Already connected
+    dt = lc.get('datatransforms')
+    if dt:
+        return dt
+
+    cfg = lc.get('_dt_config')
+    if not cfg:
+        return None  # not configured at all
+
+    adp_client = lc.get('adp')
+
+    logger.info('DT lazy connect: attempting connection to %s', cfg.url)
+    print(f'DT lazy connect: attempting connection to {cfg.url}',
+          file=sys.stderr, flush=True)
+
+    # Strategy 1 — ADP background thread
+    dt = _try_from_adp_thread(adp_client)
+    if dt:
+        lc['datatransforms'] = dt
+        logger.info('DT connected via ADP background thread')
+        return dt
+
+    # Strategy 2 — ADBS token via OCI params
+    dt = _try_adbs_connect(adp_client, cfg)
+    if dt:
+        lc['datatransforms'] = dt
+        return dt
+
+    # Strategy 3 — simple URL auth (marketplace / non-ADBS)
+    dt = _try_simple_connect(cfg)
+    if dt:
+        lc['datatransforms'] = dt
+        return dt
+
+    logger.warning('Data Transforms lazy connect: all strategies failed')
+    return None

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/_essbase_connect.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/_essbase_connect.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''Shared Essbase connection helper for upleveled tools.
+
+Usage in tool modules::
+
+    from ._essbase_connect import get_essbase
+
+    @mcp.tool()
+    def essbase_explore(ctx: Context) -> str:
+        ess = get_essbase(ctx)
+        if not ess:
+            return err('Essbase not connected. Set ESSBASE_URL + credentials.')
+        ...
+'''
+
+import logging
+from mcp.server.fastmcp import Context
+
+logger = logging.getLogger('oracle-data-studio-mcp')
+
+_NO_CONN_MSG = ('Essbase not connected. '
+                'Set ESSBASE_URL, ESSBASE_USER, ESSBASE_PASSWORD '
+                'or ESSBASE_TOKEN.')
+
+
+def get_essbase(ctx: Context):
+    '''Return the Essbase client from the lifespan context, or None.'''
+    lc = ctx.request_context.lifespan_context
+    return lc.get('essbase')

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/_helpers.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/_helpers.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''Shared helpers for upleveled MCP tools.'''
+
+import json
+import logging
+import re
+
+logger = logging.getLogger('oracle-data-studio-mcp')
+
+
+# ────────────────────────────────────────────────────────────────────
+#  Error sanitisation
+# ────────────────────────────────────────────────────────────────────
+# Oracle / cx_Oracle / ORDS exceptions routinely contain credentials,
+# connect strings, OCIDs, file paths, and bearer tokens.  Returning
+# them verbatim to the LLM (which then echoes them back to the user
+# or downstream tools) is a quiet info-disclosure path.  Every tool
+# that catches Exception should funnel the message through `safe_err`.
+
+# Patterns we redact.  Each tuple is (regex, replacement). Order matters
+# — earliest wins.  Patterns are case-insensitive where useful.
+_REDACTORS = [
+    # JDBC / SQL*Net DSN with embedded password:
+    #   tcps://user/PASSWORD@host:port
+    #   user/PASSWORD@//host:port/svc
+    (re.compile(r'(?P<u>[\w.\-+]+)/[^/@\s\'"]+@'),
+     r'\g<u>/***@'),
+    # URL with userinfo: https://user:password@host
+    (re.compile(r'(?P<scheme>\bhttps?://)[^/@\s:]+:[^/@\s]+@'),
+     r'\g<scheme>***:***@'),
+    # Authorization headers / Bearer tokens
+    (re.compile(r'(?i)(authorization\s*[:=]\s*)(?:bearer|basic)\s+\S+'),
+     r'\1***'),
+    (re.compile(r'(?i)\bbearer\s+[A-Za-z0-9._\-]{8,}\b'),
+     r'Bearer ***'),
+    # OCI OCIDs — keep prefix for context, redact the random tail
+    (re.compile(r'\bocid1\.([a-z]+)\.[a-z0-9.\-]*[a-z0-9]+'),
+     r'ocid1.\1.***'),
+    # password=... / pwd=...  (query strings, env-style, JSON)
+    (re.compile(r'(?i)(["\']?(?:password|passwd|pwd)["\']?\s*[:=]\s*["\']?)'
+                r'[^"\'\s,&}]+'),
+     r'\1***'),
+    # OS / wallet absolute paths — drop the prefix to keep the basename
+    (re.compile(r'(?:/(?:Users|home|opt|var|tmp|u\d+)/[\w./\-]+/)'
+                r'(?P<base>[\w.\-]+)'),
+     r'<path>/\g<base>'),
+    # Windows-style paths (C:\Users\...\file)
+    (re.compile(r'(?i)\b[A-Z]:\\(?:Users|Documents and Settings)\\[\w\\.\-]+\\'
+                r'(?P<base>[\w.\-]+)'),
+     r'<path>\\\g<base>'),
+]
+
+
+def safe_err(exc, *, label: str = None) -> str:
+    '''Sanitize an exception (or string) into an LLM-safe error message.
+
+    Strips: embedded passwords (DSN/URL/JSON), Authorization headers,
+    Bearer tokens, OCID tails, absolute filesystem paths.
+
+    The full original message is logged at DEBUG so operators retain
+    diagnostics without leaking them to the LLM client.
+
+    Args:
+        exc: Exception or any object str()-able.
+        label: Optional prefix included in the returned message.
+    '''
+    raw = str(exc) if exc is not None else ''
+    if label:
+        logger.debug('%s failed: %s', label, raw)
+    else:
+        logger.debug('error: %s', raw)
+
+    cleaned = raw
+    for pattern, replacement in _REDACTORS:
+        cleaned = pattern.sub(replacement, cleaned)
+
+    # Cap length — Oracle stack traces can be huge; keep first 800 chars
+    if len(cleaned) > 800:
+        cleaned = cleaned[:800] + '… [truncated]'
+
+    return f'{label}: {cleaned}' if label else cleaned
+
+
+def safe_call(label, fn, *args, **kwargs):
+    '''Call *fn* and return (result, None) or (None, error_string).
+
+    Used by composite tools to gather partial results gracefully.
+    Errors are funnelled through `safe_err` to strip credentials.
+    '''
+    try:
+        return fn(*args, **kwargs), None
+    except Exception as e:
+        return None, safe_err(e, label=label)
+
+
+def build_response(data, errors=None):
+    '''Build a JSON response string with optional collected errors.'''
+    if errors:
+        data['_errors'] = errors
+    return json.dumps(data, indent=2, default=str)
+
+
+def err(msg):
+    '''Return a JSON error string.
+
+    The message is funnelled through `safe_err` to strip credentials,
+    OCIDs, paths, and bearer tokens. Pass either a plain string or an
+    Exception — both are sanitised.
+    '''
+    return json.dumps({'error': safe_err(msg)})
+
+
+def fmt(result):
+    '''Standard JSON formatting for SDK results.'''
+    if result is None:
+        return json.dumps({'status': 'success'})
+    if isinstance(result, (dict, list)):
+        return json.dumps(result, indent=2, default=str)
+    return str(result)

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/_helpers.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/_helpers.py
@@ -7,6 +7,7 @@
 import json
 import logging
 import re
+from typing import Optional
 
 logger = logging.getLogger('oracle-data-studio-mcp')
 
@@ -402,3 +403,254 @@ def bound_rows(rows, max_rows=None) -> dict:
                 'original_row_count': total, 'max_rows': cap}
     return {'rows': rows[:cap], 'truncated': True,
             'original_row_count': total, 'max_rows': cap}
+
+
+# ────────────────────────────────────────────────────────────────────
+#  Connection / metadata redaction by profile (LLM02)
+# ────────────────────────────────────────────────────────────────────
+# Connection-shaped SDK responses routinely embed sensitive platform
+# details — JDBC URLs (sometimes with credentials), wallet paths,
+# hostnames, usernames, OCI tenancy/compartment OCIDs. Returning those
+# verbatim to the LLM is an info-disclosure path (LLM02 in the OWASP
+# GenAI Top 10).
+#
+# `redact_connection_metadata` keeps only fields explicitly listed in
+# the per-profile allow-set; everything else is dropped. This is
+# deny-by-default — new SDK fields don't accidentally leak. Admin
+# sees the raw response so operators can still debug.
+#
+# Profile rules (least-privilege ↑):
+#   viewer   — name, type, status, description only
+#   analyst  — + host, port, schema, serviceName, database (no auth)
+#   admin    — raw
+
+# Common identifier and type fields safe to surface even to viewer.
+_REDACT_VIEWER_ALLOW = frozenset({
+    'name', 'connectionName', 'connection_name',
+    'type', 'connectionType', 'connection_type',
+    'status', 'state', 'enabled',
+    'description', 'globalId', 'global_id', 'id',
+    'createdAt', 'created_at', 'updatedAt', 'updated_at',
+})
+
+# Analyst additionally sees the "where" of a connection (host, db,
+# schema) but never the "how" (auth material). Hosts may still
+# disclose internal network topology — that's the trade-off analysts
+# accept when they pick this profile over viewer.
+_REDACT_ANALYST_EXTRA = frozenset({
+    'host', 'port', 'serviceName', 'service_name',
+    'schema', 'schemaName', 'schema_name',
+    'database', 'databaseName', 'database_name',
+    'dataServerName', 'data_server_name',
+})
+
+
+def redact_connection_metadata(payload, profile: str = 'viewer'):
+    '''Recursively keep only profile-safe fields from a connection-shaped payload.
+
+    Accepts a dict (single connection), a list (collection), or any
+    other shape (returned unchanged). Nested dicts/lists are walked.
+
+    @param payload: SDK response object.
+    @param profile: 'viewer', 'analyst', 'admin', or any other string
+        (treated as 'viewer' — fail closed on unknown profiles).
+    @return: A pruned copy of the payload safe for the given profile.
+    '''
+    if profile == 'admin':
+        return payload
+    if profile == 'analyst':
+        allow = _REDACT_VIEWER_ALLOW | _REDACT_ANALYST_EXTRA
+    else:
+        # Treat unknown profile as viewer — least privilege.
+        allow = _REDACT_VIEWER_ALLOW
+    return _redact_walk(payload, allow)
+
+
+def _redact_walk(node, allow):
+    if isinstance(node, dict):
+        out = {}
+        for k, v in node.items():
+            if k in allow:
+                out[k] = _redact_walk(v, allow)
+        # Add a marker so the caller / LLM can see the response was
+        # filtered. Skip if the dict is empty after filtering (avoid
+        # noise on already-empty objects).
+        if out:
+            out['_redacted'] = True
+        return out
+    if isinstance(node, list):
+        return [_redact_walk(item, allow) for item in node]
+    # Scalars (or any other shape) pass through unchanged.
+    return node
+
+
+def get_profile(ctx) -> str:
+    '''Return the active server profile from the lifespan context.
+
+    Tools that need profile-aware behaviour call this rather than
+    threading the profile through every signature. Defaults to
+    'viewer' (least privilege) when missing — fail closed.
+    '''
+    try:
+        return ctx.request_context.lifespan_context.get(
+            '_profile', 'viewer')
+    except AttributeError:
+        return 'viewer'
+
+
+# ────────────────────────────────────────────────────────────────────
+#  adp_ai_chat table allow / deny policy (LLM01 / LLM06)
+# ────────────────────────────────────────────────────────────────────
+# `adp_ai_chat` is an NL→SQL surface backed by the database. Without
+# operator-configured constraints, a prompt-injected LLM could pivot
+# to sensitive tables (DBA_USERS, audit logs, application secrets).
+# The policy is enforced before the SDK call so a denied table never
+# reaches Select AI.
+
+def _normalize_table_key(t: str) -> str:
+    '''Strip whitespace + quotes; uppercase. Returns "" for empties.'''
+    if not t:
+        return ''
+    return t.strip().strip('"').strip("'").upper()
+
+
+def check_ai_chat_tables(tables_csv: Optional[str],
+                          allowed: Optional[frozenset] = None,
+                          denied: Optional[frozenset] = None) -> Optional[str]:
+    '''Validate a comma-separated table list against allow / deny policy.
+
+    Returns None if the call should proceed, otherwise a human-readable
+    error message describing the policy violation. Both bare table
+    names ("ORDERS") and qualified names ("SALES.ORDERS") are matched
+    case-insensitively against both forms.
+
+    @param tables_csv: The `tables` kwarg as supplied to the tool.
+        May be None or empty for chat-mode requests with no table list.
+    @param allowed: Optional allow-list. When set, every requested
+        table must be in it. None = no allow-list constraint.
+    @param denied: Optional deny-list. When set, no requested table
+        may be in it. None = no deny-list constraint.
+    '''
+    # No constraints configured → nothing to check.
+    if allowed is None and denied is None:
+        return None
+
+    # Parse requested tables.
+    requested = []
+    if tables_csv:
+        for raw in tables_csv.split(','):
+            key = _normalize_table_key(raw)
+            if key:
+                requested.append(key)
+
+    # Allow-list set but no tables requested: caller must declare
+    # tables explicitly so policy can be evaluated. This blocks the
+    # "no tables = chat mode = unconstrained Select AI" hole.
+    if allowed is not None and not requested:
+        return ('adp_ai_chat: MCP_AI_CHAT_ALLOWED_TABLES is set but '
+                'no `tables` were specified. List the tables your '
+                'question targets so the table policy can be applied.')
+
+    def _matches(name, policy):
+        '''Return True if `name` is in `policy` either as-is or as
+        its bare-name part / fully-qualified counterpart.'''
+        if name in policy:
+            return True
+        # Compare bare name component
+        bare = name.rsplit('.', 1)[-1]
+        return bare in policy
+
+    # Deny wins, always.
+    if denied is not None:
+        for t in requested:
+            if _matches(t, denied):
+                return ('adp_ai_chat: table {!r} is on the deny list '
+                        '(MCP_AI_CHAT_DENIED_TABLES). Refusing the '
+                        'request.'.format(t))
+
+    # Allow-list mode: every requested table must match.
+    if allowed is not None:
+        for t in requested:
+            if not _matches(t, allowed):
+                return ('adp_ai_chat: table {!r} is not in the '
+                        'allow list (MCP_AI_CHAT_ALLOWED_TABLES). '
+                        'Refusing the request.'.format(t))
+    return None
+
+
+# ────────────────────────────────────────────────────────────────────
+#  Destructive-action confirmation tokens (LLM06)
+# ────────────────────────────────────────────────────────────────────
+# Profile filtering and audit logging are necessary but not
+# sufficient — an admin (or a prompt-injected LLM running as admin)
+# can still issue "delete that application" against a real cube.
+# `require_confirm` makes destructive actions require an explicit
+# confirm token matching the target resource name. The token never
+# travels server→LLM, so the LLM has to be told the resource name
+# by the operator. This is OWASP LLM06 (excessive agency) mitigation.
+
+def require_confirm(resource_name: str,
+                    confirm: Optional[str],
+                    *, action_label: str = 'this destructive action') -> Optional[str]:
+    '''Validate a `confirm` token against a resource name.
+
+    Returns None when the call may proceed, otherwise a human-readable
+    error message describing what the caller must pass. Comparison is
+    case-sensitive and exact — typos block the call. The error message
+    is deliberately specific so the operator can tell the LLM the
+    right token; the audit log will record both the attempt and the
+    `outcome=error`.
+
+    @param resource_name: The thing being mutated (app name, user id,
+        session id, project name, …).
+    @param confirm: The token the caller supplied. None / '' / wrong
+        value → block.
+    @param action_label: Human-readable phrase used in the error
+        message — e.g. "delete application", "kill session".
+    '''
+    if confirm and confirm == resource_name:
+        return None
+    return (
+        'Refusing {0}: pass confirm={1!r} to acknowledge. '
+        'Confirmation tokens are required for irreversible actions.'
+        .format(action_label, resource_name))
+
+
+def ai_chat_envelope(result, *, mode: str, max_rows=None) -> dict:
+    '''Wrap Select AI output in an "untrusted-output" envelope.
+
+    Select AI responses interleave LLM-generated text with database
+    query results. Neither piece is trustworthy from the perspective
+    of downstream tool execution — the LLM can prompt-inject the
+    next call, and the DB content can carry stale or attacker-
+    controlled values. Tag the envelope so the calling client knows
+    not to feed it back into another tool unchecked (OWASP LLM05).
+
+    Rows are bounded if the result includes a list payload.
+    '''
+    envelope = {
+        'source': 'select_ai',
+        'mode': mode,
+        'untrusted': True,
+    }
+    # If result is a list, bound it. If a dict carrying a list, bound
+    # the inner list. Otherwise pass through.
+    if isinstance(result, list):
+        envelope.update(bound_rows(result, max_rows=max_rows))
+        return envelope
+    if isinstance(result, dict):
+        # Common shapes: {'rows': [...], ...} or {'data': [...], ...}
+        for key in ('rows', 'data', 'items'):
+            if isinstance(result.get(key), list):
+                bounded = bound_rows(result[key], max_rows=max_rows)
+                new = dict(result)
+                new[key] = bounded.get('rows', new[key])
+                for k in ('truncated', 'original_row_count', 'max_rows'):
+                    if k in bounded:
+                        new[k] = bounded[k]
+                envelope['result'] = new
+                return envelope
+        envelope['result'] = result
+        return envelope
+    envelope['result'] = result
+    return envelope

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/_helpers.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/_helpers.py
@@ -120,3 +120,285 @@ def fmt(result):
     if isinstance(result, (dict, list)):
         return json.dumps(result, indent=2, default=str)
     return str(result)
+
+
+# ────────────────────────────────────────────────────────────────────
+#  Audit logging for mutating / destructive tools
+# ────────────────────────────────────────────────────────────────────
+# Every tool that creates, modifies, or deletes server state should
+# call `audit(...)` once it has decided what to do. We emit a single
+# structured INFO line so operators can answer "who/what/when" without
+# enabling DEBUG on every component. The line is also useful for
+# correlation when investigating an incident.
+#
+# Format (single line, key=value, value-quoted-if-spaces):
+#   audit tool=<tool_name> action=<sub_action> target=<resource>
+#         profile=<server profile> outcome=<ok|error>
+#
+# The values are funnelled through `safe_err` to strip any credential
+# fragments before they hit the log stream.
+
+_audit_logger = logging.getLogger('oracle-data-studio-mcp.audit')
+
+
+def _audit_value(v) -> str:
+    '''Stringify, redact, and shell-quote a single audit value.'''
+    s = safe_err(v) if v is not None else ''
+    # Cap each field at 200 chars so a long ORA-error doesn't blow up
+    # the line.
+    if len(s) > 200:
+        s = s[:200] + '…'
+    if ' ' in s or '"' in s or '=' in s:
+        s = '"{0}"'.format(s.replace('"', '\\"'))
+    return s
+
+
+def audit(tool: str, *, action: str = None, target: str = None,
+          profile: str = None, outcome: str = 'ok',
+          **extra) -> None:
+    '''Emit a single-line INFO audit record for a mutating tool call.
+
+    Call this from inside any tool that creates / modifies / deletes
+    state, right after the SDK call resolves (success or failure). The
+    `outcome` defaults to 'ok'; pass 'error' from an except branch.
+
+    Examples:
+        audit('essbase_manage_application',
+              action='delete', target=app_name, outcome='ok')
+
+        audit('dt_run_pipeline',
+              action='dataflow', target=name, outcome='error')
+
+    Args are intentionally string-typed and small; do not pass entire
+    response payloads here — emit a separate DEBUG log for those if
+    you need the details.
+    '''
+    parts = ['audit', 'tool=' + tool]
+    if action is not None:
+        parts.append('action=' + _audit_value(action))
+    if target is not None:
+        parts.append('target=' + _audit_value(target))
+    if profile is not None:
+        parts.append('profile=' + _audit_value(profile))
+    parts.append('outcome=' + _audit_value(outcome))
+    for k, v in extra.items():
+        parts.append('{0}={1}'.format(k, _audit_value(v)))
+    _audit_logger.info(' '.join(parts))
+
+
+# Tool-name prefixes that indicate a mutating / executing tool. Used by
+# `wrap_mutating_tools_with_audit` to wire `audit()` calls in a single
+# pass rather than touching ~40 individual tool function bodies. Add
+# new mutating tool prefixes here; the wrapper picks them up.
+_MUTATING_PREFIXES = (
+    'essbase_manage_',
+    'essbase_run_calculation',
+    'essbase_load_data',
+    'essbase_deploy_workbook',
+    'essbase_edit_outline',
+    'essbase_query',           # executes MDX
+    'essbase_export_data',     # executes MDX via grid
+    'adp_manage_',
+    'adp_load_from_cloud',
+    'adp_build_analytic_view',
+    'adp_generate_insights',
+    'adp_ai_chat',
+    'dt_manage_',
+    'dt_create_pipeline',
+    'dt_run_pipeline',
+)
+
+# Argument-name candidates for the "target" field on the audit line.
+# We pick the FIRST string kwarg in this order; the goal is a useful
+# resource label, not a perfect identification.
+_TARGET_KEYS = (
+    'app_name', 'application', 'db_name', 'database',
+    'name', 'username', 'user_id', 'group_name', 'group_id',
+    'script_name', 'filter_name', 'connection_name', 'datasource_name',
+    'project_name', 'dataflow_name', 'workflow_name', 'dataload_name',
+    'schedule_name', 'variable_name', 'fact_table', 'object_name',
+    'storage_link', 'credential_name', 'av_name', 'catalog_name',
+    'report_name', 'session_id', 'recipient_name', 'share_name',
+    'provider_name', 'table_name', 'view_name',
+)
+
+
+def is_mutating_tool(tool_name: str) -> bool:
+    '''True if `tool_name` is in the mutating/executing set we audit.'''
+    return any(tool_name.startswith(p) for p in _MUTATING_PREFIXES)
+
+
+def wrap_mutating_tools_with_audit(mcp_server, profile: str = None) -> int:
+    '''Wrap mutating/executing tools so they emit an `audit` log line.
+
+    Idempotent: re-running on an already-wrapped server is a no-op
+    (we set `__audited__ = True` on the wrapper).
+
+    Order rule: call this AFTER `register_tools()` and EITHER before
+    or after `apply_profile()` (profile filtering only deletes
+    entries; wrapping survives).
+
+    @param mcp_server: FastMCP server instance.
+    @param profile: The active profile name; included in every emitted
+        audit line. Pass `None` if unknown.
+    @return: number of tools wrapped.
+    '''
+    tools = mcp_server._tool_manager._tools
+    wrapped = 0
+    for name, tool in list(tools.items()):
+        if not is_mutating_tool(name):
+            continue
+        orig = tool.fn
+        if getattr(orig, '__audited__', False):
+            continue
+
+        def _make_wrapper(orig_fn, tool_name):
+            def _wrapped(*args, **kwargs):
+                action = kwargs.get('action')
+                target = None
+                for key in _TARGET_KEYS:
+                    val = kwargs.get(key)
+                    if isinstance(val, str) and val:
+                        target = val
+                        break
+                try:
+                    result = orig_fn(*args, **kwargs)
+                except Exception:
+                    audit(tool_name, action=action, target=target,
+                          profile=profile, outcome='error')
+                    raise
+                # Tools return JSON strings; treat {'error': ...} as failure
+                outcome = 'ok'
+                if isinstance(result, str):
+                    try:
+                        parsed = json.loads(result)
+                        if isinstance(parsed, dict) and 'error' in parsed:
+                            outcome = 'error'
+                    except ValueError:
+                        pass
+                audit(tool_name, action=action, target=target,
+                      profile=profile, outcome=outcome)
+                return result
+            _wrapped.__audited__ = True
+            _wrapped.__wrapped__ = orig_fn
+            _wrapped.__name__ = getattr(orig_fn, '__name__', tool_name)
+            return _wrapped
+
+        tool.fn = _make_wrapper(orig, name)
+        wrapped += 1
+    return wrapped
+
+
+# ────────────────────────────────────────────────────────────────────
+#  Output bounding for query-style tools
+# ────────────────────────────────────────────────────────────────────
+# MDX queries and AV reads can return arbitrarily large payloads.
+# Returning all of them to the LLM is expensive (token cost, latency,
+# context window), creates an info-disclosure surface (the LLM may
+# repeat sensitive cell values in chat), and lets a single bad query
+# DoS the conversation. Bound the result and surface a `truncated`
+# flag the model can act on.
+
+DEFAULT_MAX_ROWS = 1000
+
+
+def _coerce_int_max_rows(max_rows, default: int = DEFAULT_MAX_ROWS) -> int:
+    '''Normalise a user-supplied max_rows to a sane positive int.'''
+    if max_rows is None:
+        return default
+    try:
+        n = int(max_rows)
+    except (TypeError, ValueError):
+        return default
+    if n <= 0:
+        return default
+    return n
+
+
+def bound_mdx_result(result, max_rows=None) -> dict:
+    '''Apply a row cap to an Essbase MDX response.
+
+    The Essbase REST surface returns either an "axes + cells" shape
+    or a "slice + ranges" shape; for both, we trim the row-axis tuples
+    and corresponding cells/values so the returned payload is no
+    larger than `max_rows`. A `truncated: true` flag is set on the
+    response when the cap fires, along with the original row count
+    so the LLM (and the operator) can see what was dropped.
+
+    Returns a (possibly mutated) dict. Non-dict inputs (or shapes we
+    don't recognise) pass through unchanged.
+    '''
+    cap = _coerce_int_max_rows(max_rows)
+    if not isinstance(result, dict):
+        return result
+
+    # axes + cells shape
+    axes = result.get('axes')
+    if isinstance(axes, list) and len(axes) >= 2:
+        row_axis = axes[1] if isinstance(axes[1], dict) else None
+        if row_axis is None:
+            return result
+        tuples = row_axis.get('tuples')
+        if not isinstance(tuples, list) or len(tuples) <= cap:
+            return result
+        total = len(tuples)
+        n_cols = 0
+        col_axis = axes[0] if isinstance(axes[0], dict) else None
+        if col_axis and isinstance(col_axis.get('tuples'), list):
+            n_cols = len(col_axis['tuples'])
+        row_axis['tuples'] = tuples[:cap]
+        # Trim the flat cell array. Cells are row-major: r*n_cols + c.
+        cells = result.get('cells') or result.get('data')
+        if isinstance(cells, list) and n_cols > 0:
+            keep = cap * n_cols
+            if 'cells' in result:
+                result['cells'] = cells[:keep]
+            else:
+                result['data'] = cells[:keep]
+        result['truncated'] = True
+        result['original_row_count'] = total
+        result['max_rows'] = cap
+        return result
+
+    # slice + ranges shape
+    sl = result.get('slice')
+    if isinstance(sl, dict):
+        rows = sl.get('rows')
+        if isinstance(rows, list) and len(rows) > cap:
+            total = len(rows)
+            n_cols = len(sl.get('columns', []) or [])
+            sl['rows'] = rows[:cap]
+            ranges = (sl.get('data') or {}).get('ranges')
+            if isinstance(ranges, list) and ranges and n_cols > 0:
+                values = ranges[0].get('values')
+                if isinstance(values, list):
+                    ranges[0]['values'] = values[:cap * n_cols]
+            result['truncated'] = True
+            result['original_row_count'] = total
+            result['max_rows'] = cap
+        return result
+
+    return result
+
+
+def bound_rows(rows, max_rows=None) -> dict:
+    '''Apply a row cap to a list-of-dicts (or list-of-anything) result.
+
+    Returns an envelope::
+
+        {'rows': [...], 'truncated': bool,
+         'original_row_count': N, 'max_rows': cap}
+
+    Useful for SDK calls that return a bare list (ADP analytic-view
+    reads, search results, ...).
+    '''
+    cap = _coerce_int_max_rows(max_rows)
+    if not isinstance(rows, list):
+        # Unknown shape — return unchanged in an envelope without truncation.
+        return {'rows': rows, 'truncated': False, 'max_rows': cap}
+    total = len(rows)
+    if total <= cap:
+        return {'rows': rows, 'truncated': False,
+                'original_row_count': total, 'max_rows': cap}
+    return {'rows': rows[:cap], 'truncated': True,
+            'original_row_count': total, 'max_rows': cap}

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/adp_tools.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/adp_tools.py
@@ -440,6 +440,7 @@ def register_tools(mcp: FastMCP):
     # ── 24b. adp_manage_catalog ──────────────────────────────────────
     @mcp.tool()
     def adp_manage_catalog(action: str, catalog_name: str = None,
+                            confirm: str = None,
                             ctx: Context = None) -> str:
         """Manage data catalogs (admin-only): enable, disable, or unmount catalogs.
 
@@ -447,6 +448,7 @@ def register_tools(mcp: FastMCP):
             action: One of 'enable', 'disable', 'unmount'.
             catalog_name: Catalog name (required).
         """
+        from ._helpers import require_confirm
         client = get_adp(ctx)
         if not client:
             return err(_NO_CONN_MSG)
@@ -462,6 +464,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(json.loads(result) if isinstance(
                     result, str) else result)
             elif action == 'unmount':
+                msg = require_confirm(catalog_name, confirm,
+                                       action_label='unmount catalog')
+                if msg:
+                    return err(msg)
                 result = client.Catalog.unmount_catalog(catalog_name)
                 return fmt(json.loads(result) if isinstance(
                     result, str) else result)
@@ -478,6 +484,7 @@ def register_tools(mcp: FastMCP):
                             recipient_name: str = None,
                             email: str = None,
                             new_name: str = None,
+                            confirm: str = None,
                             ctx: Context = None) -> str:
         """Manage data sharing: list shares, create share, publish, delete, manage recipients, providers, and more.
 
@@ -501,6 +508,7 @@ def register_tools(mcp: FastMCP):
         recipient. To grant a published share to a specific recipient,
         call action='grant_recipient' with recipient_name + tables.
         """
+        from ._helpers import require_confirm
         client = get_adp(ctx)
         if not client:
             return err(_NO_CONN_MSG)
@@ -549,6 +557,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(json.loads(result) if isinstance(
                     result, str) else result)
             elif action == 'delete':
+                msg = require_confirm(share_name, confirm,
+                                       action_label='delete share')
+                if msg:
+                    return err(msg)
                 if not share_name:
                     return err('share_name required for delete.')
                 result = client.Share.delete_share(share_name)
@@ -572,6 +584,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(json.loads(result) if isinstance(
                     result, str) else result)
             elif action == 'delete_recipient':
+                msg = require_confirm(recipient_name, confirm,
+                                       action_label='delete recipient')
+                if msg:
+                    return err(msg)
                 if not recipient_name:
                     return err('recipient_name required for delete_recipient.')
                 result = client.Share.delete_recipient(recipient_name)
@@ -601,6 +617,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(json.loads(result) if isinstance(
                     result, str) else result)
             elif action == 'delete_provider':
+                msg = require_confirm(recipient_name, confirm,
+                                       action_label='delete provider')
+                if msg:
+                    return err(msg)
                 if not recipient_name:
                     return err('recipient_name required for delete_provider.')
                 result = client.Share.delete_provider(recipient_name)
@@ -673,6 +693,7 @@ def register_tools(mcp: FastMCP):
                                  storage_link_name: str = None,
                                  uri: str = None,
                                  description: str = None,
+                                 confirm: str = None,
                                  ctx: Context = None) -> str:
         """Manage cloud credentials and storage links for data loading.
 
@@ -689,6 +710,7 @@ def register_tools(mcp: FastMCP):
             uri: URI for cloud storage (for create_storage_link).
             description: Description (optional, for create_storage_link).
         """
+        from ._helpers import require_confirm
         client = get_adp(ctx)
         if not client:
             return err(_NO_CONN_MSG)
@@ -717,6 +739,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(json.loads(result) if isinstance(
                     result, str) else result)
             elif action == 'drop':
+                msg = require_confirm(credential_name, confirm,
+                                       action_label='drop credential')
+                if msg:
+                    return err(msg)
                 if not credential_name:
                     return err('credential_name required for drop.')
                 result = client.Ingest.drop_credential(credential_name)
@@ -736,6 +762,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(json.loads(result) if isinstance(
                     result, str) else result)
             elif action == 'drop_storage_link':
+                msg = require_confirm(storage_link_name, confirm,
+                                       action_label='drop storage link')
+                if msg:
+                    return err(msg)
                 if not storage_link_name:
                     return err('storage_link_name required for '
                                'drop_storage_link.')
@@ -845,6 +875,7 @@ def register_tools(mcp: FastMCP):
                               request_name: str = None,
                               insight_name: str = None,
                               viz_id: int = None,
+                              confirm: str = None,
                               ctx: Context = None) -> str:
         """Manage AI-generated insights: list requests, view results, check status.
 
@@ -854,6 +885,7 @@ def register_tools(mcp: FastMCP):
             insight_name: Insight name (for get_graph).
             viz_id: Visualization ID (for get_graph).
         """
+        from ._helpers import require_confirm
         client = get_adp(ctx)
         if not client:
             return err(_NO_CONN_MSG)
@@ -883,6 +915,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(json.loads(result) if isinstance(
                     result, str) else result)
             elif action == 'drop':
+                msg = require_confirm(request_name, confirm,
+                                       action_label='drop insight')
+                if msg:
+                    return err(msg)
                 if not request_name:
                     return err('request_name required for drop.')
                 result = client.Insight.drop(request_name)
@@ -901,6 +937,7 @@ def register_tools(mcp: FastMCP):
                               db_link_name: str = None,
                               tables: str = None,
                               consumer_group: str = 'LOW',
+                              confirm: str = None,
                               ctx: Context = None) -> str:
         """Manage database links and copy/link tables from remote databases.
 
@@ -910,6 +947,7 @@ def register_tools(mcp: FastMCP):
             tables: Comma-separated table names for copy_tables/link_tables.
             consumer_group: Resource consumer group: 'LOW' (default), 'MEDIUM', 'HIGH'.
         """
+        from ._helpers import require_confirm
         client = get_adp(ctx)
         if not client:
             return err(_NO_CONN_MSG)
@@ -955,6 +993,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(json.loads(result) if isinstance(
                     result, str) else result)
             elif action == 'drop':
+                msg = require_confirm(db_link_name, confirm,
+                                       action_label='drop database link')
+                if msg:
+                    return err(msg)
                 if not db_link_name:
                     return err('db_link_name required for drop.')
                 result = client.Catalog.drop_database_link(

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/adp_tools.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/adp_tools.py
@@ -108,14 +108,23 @@ def register_tools(mcp: FastMCP):
     def adp_query_analytic_view(av_name: str,
                                  show_sql: bool = False,
                                  owner: str = None,
+                                 max_rows: int = 1000,
                                  ctx: Context = None) -> str:
         """Query data from an Analytic View with auto-discovered dimensions and measures.
+
+        Results are row-capped at `max_rows` (default 1000). When the
+        cap fires, the response is wrapped in
+        ``{"rows": [...], "truncated": true, "original_row_count": N,
+        "max_rows": M}`` so the caller can decide whether to re-query
+        with a tighter filter.
 
         Args:
             av_name: Analytic View name.
             show_sql: If true, return the generated SQL instead of data.
             owner: Schema owner (defaults to current user).
+            max_rows: Maximum rows to return (default 1000).
         """
+        from ._helpers import bound_rows
         client = get_adp(ctx)
         if not client:
             return err(_NO_CONN_MSG)
@@ -125,12 +134,24 @@ def register_tools(mcp: FastMCP):
 
             if show_sql:
                 result = client.Analytics.get_sql_simple(av_name, owner)
-            else:
-                result = client.Analytics.get_data_simple(av_name, owner)
+                if isinstance(result, str):
+                    return result
+                return json.dumps(result, indent=2, default=str)
 
-            if isinstance(result, str):
-                return result
-            return json.dumps(result, indent=2, default=str)
+            # Data path: apply the row cap and surface truncation flag.
+            rows = client.Analytics.get_data_simple(av_name, owner)
+            # SDK may return a list, a JSON-string list, or an envelope dict.
+            if isinstance(rows, str):
+                try:
+                    rows = json.loads(rows)
+                except ValueError:
+                    return rows
+            if isinstance(rows, dict):
+                inner = rows.get('items') or rows.get('rows')
+                if isinstance(inner, list):
+                    rows = inner
+            bounded = bound_rows(rows, max_rows=max_rows)
+            return json.dumps(bounded, indent=2, default=str)
         except Exception as exc:
             return err(str(exc))
 

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/adp_tools.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/adp_tools.py
@@ -1,0 +1,1070 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''Upleveled ADP (Autonomous Database) MCP tools.
+
+Each tool combines multiple SDK calls into a single task-oriented
+operation that returns an LLM-friendly result.  See TOOLS_DESIGN.md.
+'''
+
+import json
+import logging
+
+from mcp.server.fastmcp import FastMCP, Context
+
+from ._adp_connect import get_adp, run_adp, _err, _NO_CONN_MSG
+from ._helpers import safe_call, build_response, err, fmt
+
+logger = logging.getLogger('oracle-data-studio-mcp')
+
+
+def register_tools(mcp: FastMCP):
+
+    # NOTE: Pure SQL tools (execute_sql, discover_schema, explain_table,
+    # modify_data) are intentionally omitted — use Oracle SQLcl MCP
+    # server for direct SQL operations.  The tools below focus on ADP
+    # data-platform features: Analytic Views, Select AI, Insights,
+    # cloud loading, catalogs, and data sharing.
+
+    # ── adp_build_analytic_view ─────────────────────────────────────
+    @mcp.tool()
+    def adp_build_analytic_view(fact_table: str,
+                                 av_name: str = None,
+                                 ctx: Context = None) -> str:
+        """Create an Analytic View from a fact table, compile it, and return metadata with a data preview.
+
+        Args:
+            fact_table: Name of the fact table.
+            av_name: Optional — currently informational only.
+                The SDK's auto-creation derives the AV name from the
+                fact table; if a different name is required, use
+                `client.Analytics.create()` directly with explicit
+                dimensions and measures.
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            errors = []
+            data = {'fact_table': fact_table}
+            if av_name:
+                data['av_name_requested'] = av_name
+                errors.append(
+                    'av_name parameter is informational only — the auto '
+                    'creator derives the AV name from the fact table. '
+                    'Use Analytics.create() with explicit dims/measures '
+                    'to specify a custom name.')
+
+            # Create — Analytics.create_auto signature is
+            # (fact_table, skip_dimensions: bool = False, owner: str = None).
+            # Do NOT pass av_name here — it would be coerced to a truthy
+            # `skip_dimensions` and silently dropped.
+            create_result = client.Analytics.create_auto(fact_table)
+            data['create'] = json.loads(create_result) if isinstance(
+                create_result, str) else create_result
+
+            # Determine actual AV name from the create result
+            actual_name = fact_table
+            if isinstance(data['create'], dict):
+                actual_name = data['create'].get('name', actual_name)
+
+            # Compile
+            compile_result, e = safe_call('compile',
+                                          client.Analytics.compile,
+                                          actual_name)
+            if compile_result:
+                data['compile'] = json.loads(compile_result) if isinstance(
+                    compile_result, str) else compile_result
+            if e:
+                errors.append(e)
+
+            # Metadata
+            meta, e = safe_call('metadata',
+                                client.Analytics.get_metadata,
+                                actual_name)
+            if meta:
+                data['metadata'] = json.loads(meta) if isinstance(
+                    meta, str) else meta
+            if e:
+                errors.append(e)
+
+            # Preview
+            preview, e = safe_call('preview',
+                                   client.Analytics.get_data_preview,
+                                   actual_name)
+            if preview:
+                data['data_preview'] = json.loads(preview) if isinstance(
+                    preview, str) else preview
+            if e:
+                errors.append(e)
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 18. adp_query_analytic_view ───────────────────────────────────
+    @mcp.tool()
+    def adp_query_analytic_view(av_name: str,
+                                 show_sql: bool = False,
+                                 owner: str = None,
+                                 ctx: Context = None) -> str:
+        """Query data from an Analytic View with auto-discovered dimensions and measures.
+
+        Args:
+            av_name: Analytic View name.
+            show_sql: If true, return the generated SQL instead of data.
+            owner: Schema owner (defaults to current user).
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            if not client.Analytics.is_exist(av_name, owner):
+                return err(f'Analytic view "{av_name}" does not exist.')
+
+            if show_sql:
+                result = client.Analytics.get_sql_simple(av_name, owner)
+            else:
+                result = client.Analytics.get_data_simple(av_name, owner)
+
+            if isinstance(result, str):
+                return result
+            return json.dumps(result, indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 19. adp_analyze_analytic_view ─────────────────────────────────
+    @mcp.tool()
+    def adp_analyze_analytic_view(av_name: str, owner: str = None,
+                                   ctx: Context = None) -> str:
+        """Get a full health report for an Analytic View: metadata, measures, dimensions, quality issues, errors.
+
+        Args:
+            av_name: Analytic View name.
+            owner: Schema owner (defaults to current user).
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            if not client.Analytics.is_exist(av_name, owner):
+                return err(f'Analytic view "{av_name}" does not exist.')
+
+            errors = []
+            data = {'av_name': av_name}
+
+            meta, e = safe_call('metadata',
+                                client.Analytics.get_metadata,
+                                av_name, owner)
+            if meta:
+                data['metadata'] = json.loads(meta) if isinstance(
+                    meta, str) else meta
+            if e:
+                errors.append(e)
+
+            measures, e = safe_call('measures',
+                                    client.Analytics.get_measures_list,
+                                    av_name, owner)
+            if measures:
+                data['measures'] = json.loads(measures) if isinstance(
+                    measures, str) else measures
+            if e:
+                errors.append(e)
+
+            dims, e = safe_call('dimensions',
+                                client.Analytics.get_dimension_names,
+                                av_name)
+            if dims:
+                data['dimensions'] = json.loads(dims) if isinstance(
+                    dims, str) else dims
+            if e:
+                errors.append(e)
+
+            quality, e = safe_call('quality',
+                                   client.Analytics.quality_report,
+                                   av_name)
+            if quality:
+                data['quality_report'] = json.loads(quality) if isinstance(
+                    quality, str) else quality
+            if e:
+                errors.append(e)
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 20. adp_generate_insights ─────────────────────────────────────
+    @mcp.tool()
+    def adp_generate_insights(object_name: str, measure: str,
+                               ctx: Context = None) -> str:
+        """Generate AI-powered insights for an Analytic View or table.
+
+        Starts insight generation and returns the request details.
+
+        Args:
+            object_name: Analytic View or table name.
+            measure: Measure column to analyze.
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            result = client.Insight.generate(object_name, measure)
+            if isinstance(result, str):
+                return result
+            return json.dumps(result, indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 21. (removed: adp_ai_query) ──────────────────────────────────
+    # adp_ai_query was intentionally removed from the composite MCP.
+    # Reasoning:
+    #   1. Select AI is a separate LLM that does NOT reliably honor
+    #      Oracle 23ai annotations (verified empirically). The MCP
+    #      client's own LLM, given annotations via adp_get_annotations
+    #      and the adp_sql_with_annotations prompt, produces strictly
+    #      better SQL.
+    #   2. Auto-executing LLM-generated SQL is a security surface
+    #      even with safeguards. Pure SQL execution is delegated to
+    #      the Oracle SQLcl MCP server by design.
+    # If Select-AI-generated SQL is needed, call SQLcl + the AI
+    # generator from the client side.
+
+    # ── 22. adp_search ────────────────────────────────────────────────
+    @mcp.tool()
+    def adp_search(search_term: str, include_ddl: bool = False,
+                    ctx: Context = None) -> str:
+        """Search for database objects by name and optionally return their DDL.
+
+        Args:
+            search_term: Search term.
+            include_ddl: Whether to fetch DDL for top matches (default false).
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            errors = []
+            result_str = client.Misc.global_search(
+                search_term, 1, 50)
+            data = {'search_term': search_term}
+            results = json.loads(result_str) if isinstance(
+                result_str, str) else result_str
+            data['results'] = results
+
+            if include_ddl:
+                names = _extract_entity_names(results)
+                ddl_list = []
+                for entry in names[:10]:
+                    ddl, e = safe_call(
+                        f'ddl/{entry}',
+                        client.Misc.get_entity_ddl,
+                        entry, 'TABLE')
+                    if ddl:
+                        ddl_list.append({
+                            'name': entry,
+                            'ddl': json.loads(ddl) if isinstance(
+                                ddl, str) else ddl
+                        })
+                    if e:
+                        errors.append(e)
+                if ddl_list:
+                    data['ddl'] = ddl_list
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 23. adp_load_from_cloud ───────────────────────────────────────
+    @mcp.tool()
+    def adp_load_from_cloud(storage_link: str = None,
+                             object_name: str = None,
+                             target_table: str = None,
+                             consumer_group: str = 'LOW',
+                             request_id: str = None,
+                             ctx: Context = None) -> str:
+        """Load a cloud storage object into the database as a table.
+
+        Pass request_id (without other params) to check load progress.
+        Pass storage_link + object_name to start a new load.
+
+        Requires an existing Cloud Storage link and credential (create
+        them via SQLcl or the ADP console if you haven't already).
+
+        Args:
+            storage_link: Name of an existing Cloud Storage link (created via DBMS_CLOUD.CREATE_CLOUD_STORAGE_LINK or the ADP UI).
+            object_name: Object name (file) in the cloud storage link (e.g. 'sales_2024.csv', 'data/orders.parquet').
+            target_table: Table name to create in the database. Defaults to a name derived from the object.
+            consumer_group: Resource consumer group for the load job: 'LOW' (default), 'MEDIUM', or 'HIGH'.
+            request_id: Request ID from a previous load to check progress.
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            # Progress check mode
+            if request_id:
+                progress, e = safe_call('progress',
+                                         client.Ingest.cloud_progress_status,
+                                         request_id)
+                data = {'request_id': request_id}
+                if progress:
+                    data['progress'] = json.loads(progress) if isinstance(
+                        progress, str) else progress
+                errors = [e] if e else []
+                return build_response(data, errors or None)
+
+            if not storage_link or not object_name:
+                return err('storage_link and object_name required to start a load, '
+                           'or provide request_id to check progress.')
+
+            errors = []
+            data = {'storage_link': storage_link,
+                    'object_name': object_name}
+
+            # Verify credentials exist
+            creds, e = safe_call('credentials',
+                                 client.Ingest.get_credential_list)
+            if creds:
+                data['available_credentials'] = json.loads(
+                    creds) if isinstance(creds, str) else creds
+            if e:
+                errors.append(e)
+
+            # List consumer groups
+            groups, e = safe_call('consumer_groups',
+                                   client.Ingest.get_consumer_groups)
+            if groups:
+                data['consumer_groups'] = json.loads(
+                    groups) if isinstance(groups, str) else groups
+            if e:
+                errors.append(e)
+
+            # Build the objects list expected by the SDK
+            obj_spec = {
+                'storageLink': storage_link,
+                'objectName': object_name,
+            }
+            if target_table:
+                obj_spec['targetTableName'] = target_table
+                data['target_table'] = target_table
+
+            # Copy from cloud
+            result = client.Ingest.copy_cloud_objects(
+                [obj_spec], consumer_group)
+            if isinstance(result, str):
+                data['result'] = json.loads(result)
+            else:
+                data['result'] = result
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 24. adp_browse_catalog ──────────────────────────────────────────
+    @mcp.tool()
+    def adp_browse_catalog(action: str, catalog_name: str = None,
+                            ctx: Context = None) -> str:
+        """Browse data catalogs (read-only): list catalogs, get entities, preview data, list database links, list databases, or check a database link.
+
+        Args:
+            action: One of 'list', 'entities', 'preview', 'db_links', 'list_databases', 'check_db_link'.
+            catalog_name: Catalog or entity name (required for all actions except list/list_databases). Used as db_link_name for check_db_link.
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            if action == 'list':
+                result = client.Catalog.get_catalogs()
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'entities':
+                if not catalog_name:
+                    return err('catalog_name required for entities action.')
+                result = client.Catalog.get_catalog_entities(catalog_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'preview':
+                if not catalog_name:
+                    return err('catalog_name required for preview action.')
+                result = client.Catalog.preview_catalog_table(
+                    catalog_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'db_links':
+                if not catalog_name:
+                    return err('catalog_name required for db_links action.')
+                result = client.Catalog.get_database_links(catalog_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'list_databases':
+                result = client.Catalog.get_autonomous_databases()
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'check_db_link':
+                if not catalog_name:
+                    return err('catalog_name required for check_db_link action (used as db_link_name).')
+                result = client.Catalog.check_database_link(catalog_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/entities/preview/'
+                           f'db_links/list_databases/check_db_link.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 24b. adp_manage_catalog ──────────────────────────────────────
+    @mcp.tool()
+    def adp_manage_catalog(action: str, catalog_name: str = None,
+                            ctx: Context = None) -> str:
+        """Manage data catalogs (admin-only): enable, disable, or unmount catalogs.
+
+        Args:
+            action: One of 'enable', 'disable', 'unmount'.
+            catalog_name: Catalog name (required).
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            if not catalog_name:
+                return err('catalog_name required.')
+            if action == 'enable':
+                result = client.Catalog.enable_catalog(catalog_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'disable':
+                result = client.Catalog.disable_catalog(catalog_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'unmount':
+                result = client.Catalog.unmount_catalog(catalog_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use enable/disable/unmount.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 25. adp_manage_sharing ────────────────────────────────────────
+    @mcp.tool()
+    def adp_manage_sharing(action: str, share_name: str = None,
+                            tables: str = None,
+                            recipient_name: str = None,
+                            email: str = None,
+                            new_name: str = None,
+                            ctx: Context = None) -> str:
+        """Manage data sharing: list shares, create share, publish, delete, manage recipients, providers, and more.
+
+        Args:
+            action: One of 'list', 'get', 'create', 'publish',
+                'grant_recipient', 'delete', 'unpublish',
+                'create_recipient', 'list_recipients', 'delete_recipient',
+                'get_objects', 'rename', 'list_providers',
+                'create_provider', 'delete_provider'.
+            share_name: Share name (for create/publish/get/delete/
+                unpublish/get_objects/rename/grant_recipient).
+            tables: Comma-separated table names (for create or
+                grant_recipient — the shares granted to the recipient).
+            recipient_name: Recipient name (for create_recipient/
+                delete_recipient/create_provider/delete_provider/
+                grant_recipient).
+            email: Email address (optional, for create_recipient/create_provider).
+            new_name: New name for renaming a share (for rename action).
+
+        NOTE: `publish` activates the share globally; it does NOT take a
+        recipient. To grant a published share to a specific recipient,
+        call action='grant_recipient' with recipient_name + tables.
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            if action == 'list':
+                result = client.Share.get_shares()
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'get':
+                if not share_name:
+                    return err('share_name required.')
+                result = client.Share.get_share(share_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'create':
+                if not share_name:
+                    return err('share_name required for create.')
+                result = client.Share.create_share(share_name)
+                data = {'create': json.loads(result) if isinstance(
+                    result, str) else result}
+                if tables:
+                    table_list = [t.strip() for t in tables.split(',')]
+                    upd, e = safe_call(
+                        'update_objects',
+                        client.Share.update_share_objects,
+                        share_name, table_list)
+                    if upd:
+                        data['objects'] = json.loads(upd) if isinstance(
+                            upd, str) else upd
+                return json.dumps(data, indent=2, default=str)
+            elif action == 'publish':
+                if not share_name:
+                    return err('share_name required for publish.')
+                # publish_share(name, owner=None) — does NOT take a
+                # recipient. Recipients are granted separately via
+                # action='grant_recipient'.
+                result = client.Share.publish_share(share_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'grant_recipient':
+                if not recipient_name or not tables:
+                    return err('recipient_name and tables (comma-separated '
+                               'share names) required for grant_recipient.')
+                result = client.Share.update_recipient_shares(
+                    recipient_name, tables)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'delete':
+                if not share_name:
+                    return err('share_name required for delete.')
+                result = client.Share.delete_share(share_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'unpublish':
+                if not share_name:
+                    return err('share_name required for unpublish.')
+                result = client.Share.unpublish_share(share_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'create_recipient':
+                if not recipient_name:
+                    return err('recipient_name required for create_recipient.')
+                result = client.Share.create_recipient(
+                    recipient_name, email=email)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'list_recipients':
+                result = client.Share.get_recipients()
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'delete_recipient':
+                if not recipient_name:
+                    return err('recipient_name required for delete_recipient.')
+                result = client.Share.delete_recipient(recipient_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'get_objects':
+                if not share_name:
+                    return err('share_name required for get_objects.')
+                result = client.Share.get_share_objects(share_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'rename':
+                if not share_name or not new_name:
+                    return err('share_name and new_name required for rename.')
+                result = client.Share.rename_share(share_name, new_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'list_providers':
+                result = client.Share.get_providers()
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'create_provider':
+                if not recipient_name:
+                    return err('recipient_name required for create_provider.')
+                result = client.Share.create_provider(
+                    recipient_name, email=email or '')
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'delete_provider':
+                if not recipient_name:
+                    return err('recipient_name required for delete_provider.')
+                result = client.Share.delete_provider(recipient_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/get/create/publish/grant_recipient/'
+                           f'delete/unpublish/create_recipient/'
+                           f'list_recipients/delete_recipient/'
+                           f'get_objects/rename/list_providers/'
+                           f'create_provider/delete_provider.')
+        except Exception as exc:
+            return err(str(exc))
+
+
+    # ── 26. adp_manage_analytic_views ────────────────────────────────
+    @mcp.tool()
+    def adp_manage_analytic_views(action: str,
+                                    av_name: str = None,
+                                    owner: str = None,
+                                    ctx: Context = None) -> str:
+        """Manage Analytic Views: list all AVs or drop one.
+
+        Args:
+            action: One of 'list', 'drop'.
+            av_name: Analytic View name (required for drop).
+            owner: Schema owner (optional, for list).
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            if action == 'list':
+                result = client.Analytics.get_list(owner)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'drop':
+                if not av_name:
+                    return err('av_name required for drop action.')
+                result = client.Analytics.drop(av_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/drop.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 27. adp_manage_credentials ───────────────────────────────────
+    @mcp.tool()
+    def adp_manage_credentials(action: str,
+                                 credential_name: str = None,
+                                 username: str = None,
+                                 password: str = None,
+                                 user_ocid: str = None,
+                                 tenancy_ocid: str = None,
+                                 private_key: str = None,
+                                 fingerprint: str = None,
+                                 storage_link_name: str = None,
+                                 uri: str = None,
+                                 description: str = None,
+                                 ctx: Context = None) -> str:
+        """Manage cloud credentials and storage links for data loading.
+
+        Args:
+            action: One of 'list', 'create', 'create_ocid', 'drop', 'list_storage_links', 'create_storage_link', 'drop_storage_link', 'list_cloud_objects'.
+            credential_name: Credential name (for create/create_ocid/drop/create_storage_link).
+            username: Username (for create).
+            password: Password (for create).
+            user_ocid: User OCID (for create_ocid).
+            tenancy_ocid: Tenancy OCID (for create_ocid).
+            private_key: Private key (for create_ocid).
+            fingerprint: Key fingerprint (for create_ocid).
+            storage_link_name: Storage link name (for create_storage_link/drop_storage_link/list_cloud_objects).
+            uri: URI for cloud storage (for create_storage_link).
+            description: Description (optional, for create_storage_link).
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            if action == 'list':
+                result = client.Ingest.get_credential_list()
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'create':
+                if not credential_name or not username or not password:
+                    return err('credential_name, username, and password '
+                               'required for create.')
+                result = client.Ingest.create_credential(
+                    credential_name, username, password)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'create_ocid':
+                if not all([credential_name, user_ocid, tenancy_ocid,
+                            private_key, fingerprint]):
+                    return err('credential_name, user_ocid, tenancy_ocid, '
+                               'private_key, and fingerprint required '
+                               'for create_ocid.')
+                result = client.Ingest.create_ocid_credential(
+                    credential_name, user_ocid, tenancy_ocid,
+                    private_key, fingerprint)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'drop':
+                if not credential_name:
+                    return err('credential_name required for drop.')
+                result = client.Ingest.drop_credential(credential_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'list_storage_links':
+                result = client.Ingest.get_cloud_storage_link_list()
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'create_storage_link':
+                if not storage_link_name or not uri or not credential_name:
+                    return err('storage_link_name, uri, and credential_name '
+                               'required for create_storage_link.')
+                result = client.Ingest.create_cloud_storage_link(
+                    storage_link_name, uri, credential_name,
+                    description or '')
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'drop_storage_link':
+                if not storage_link_name:
+                    return err('storage_link_name required for '
+                               'drop_storage_link.')
+                result = client.Ingest.drop_cloud_storage_link(
+                    storage_link_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'list_cloud_objects':
+                if not storage_link_name:
+                    return err('storage_link_name required for '
+                               'list_cloud_objects.')
+                result = client.Ingest.get_cloud_objects(
+                    storage_link_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/create/create_ocid/drop/'
+                           f'list_storage_links/create_storage_link/'
+                           f'drop_storage_link/list_cloud_objects.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 28. adp_ai_chat ──────────────────────────────────────────────
+    @mcp.tool()
+    def adp_ai_chat(question: str,
+                      mode: str = 'chat',
+                      tables: str = None,
+                      profile_name: str = None,
+                      ctx: Context = None) -> str:
+        """Chat with the database using Oracle Select AI in different modes.
+
+        Args:
+            question: Natural language question or prompt.
+            mode: One of 'chat', 'chat_with_db', 'generate_insight'.
+            tables: Comma-separated table names (for chat_with_db/generate_insight).
+            profile_name: Select AI profile name (optional).
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            table_list = None
+            if tables:
+                owner = client.rest.username if hasattr(
+                    client, 'rest') else None
+                table_list = [(owner, t.strip())
+                              for t in tables.split(',')]
+
+            if mode == 'chat':
+                result = client.AI.chat(question, profile_name)
+            elif mode == 'chat_with_db':
+                result = client.AI.chat_with_db(
+                    question, table_list, profile_name)
+            elif mode == 'generate_insight':
+                result = client.AI.generate_insight(
+                    question, table_list, profile_name)
+            else:
+                return err(f'Unknown mode: {mode}. '
+                           f'Use chat/chat_with_db/generate_insight.')
+
+            if isinstance(result, str):
+                try:
+                    return fmt(json.loads(result))
+                except (json.JSONDecodeError, TypeError):
+                    return result
+            return json.dumps(result, indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 29. adp_manage_insights ──────────────────────────────────────
+    @mcp.tool()
+    def adp_manage_insights(action: str,
+                              request_name: str = None,
+                              insight_name: str = None,
+                              viz_id: int = None,
+                              ctx: Context = None) -> str:
+        """Manage AI-generated insights: list requests, view results, check status.
+
+        Args:
+            action: One of 'list_requests', 'list_insights', 'get_graph', 'status', 'drop'.
+            request_name: Insight request name (for list_insights/get_graph/status/drop).
+            insight_name: Insight name (for get_graph).
+            viz_id: Visualization ID (for get_graph).
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            if action == 'list_requests':
+                result = client.Insight.get_request_list()
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'list_insights':
+                if not request_name:
+                    return err('request_name required for list_insights.')
+                result = client.Insight.get_insights_list(request_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'get_graph':
+                name = insight_name or request_name
+                if not name or viz_id is None:
+                    return err('insight_name (or request_name) and viz_id '
+                               'required for get_graph.')
+                result = client.Insight.get_graph_details(name, viz_id)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'status':
+                if not request_name:
+                    return err('request_name required for status.')
+                result = client.Insight.get_job_status(request_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'drop':
+                if not request_name:
+                    return err('request_name required for drop.')
+                result = client.Insight.drop(request_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list_requests/list_insights/get_graph/'
+                           f'status/drop.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 30. adp_manage_db_links ────────────────────────────────────────
+    @mcp.tool()
+    def adp_manage_db_links(action: str,
+                              db_link_name: str = None,
+                              tables: str = None,
+                              consumer_group: str = 'LOW',
+                              ctx: Context = None) -> str:
+        """Manage database links and copy/link tables from remote databases.
+
+        Args:
+            action: One of 'list', 'list_tables', 'copy_tables', 'link_tables', 'check', 'drop'.
+            db_link_name: Database link name (required for list_tables/copy_tables/link_tables/check/drop).
+            tables: Comma-separated table names for copy_tables/link_tables.
+            consumer_group: Resource consumer group: 'LOW' (default), 'MEDIUM', 'HIGH'.
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            if action == 'list':
+                result = client.Ingest.get_database_links()
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'list_tables':
+                if not db_link_name:
+                    return err('db_link_name required for list_tables.')
+                result = client.Ingest.get_db_link_owner_tables(
+                    db_link_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'copy_tables':
+                if not db_link_name or not tables:
+                    return err('db_link_name and tables required for '
+                               'copy_tables.')
+                table_descs = [{'tableName': t.strip(),
+                                'dbLink': db_link_name}
+                               for t in tables.split(',')]
+                result = client.Ingest.copy_tables_from_db_link(
+                    table_descs, consumer_group)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'link_tables':
+                if not db_link_name or not tables:
+                    return err('db_link_name and tables required for '
+                               'link_tables.')
+                table_descs = [{'tableName': t.strip(),
+                                'dbLink': db_link_name}
+                               for t in tables.split(',')]
+                result = client.Ingest.link_tables_from_db_link(
+                    table_descs, consumer_group)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'check':
+                if not db_link_name:
+                    return err('db_link_name required for check.')
+                result = client.Catalog.check_database_link(
+                    db_link_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            elif action == 'drop':
+                if not db_link_name:
+                    return err('db_link_name required for drop.')
+                result = client.Catalog.drop_database_link(
+                    db_link_name)
+                return fmt(json.loads(result) if isinstance(
+                    result, str) else result)
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/list_tables/copy_tables/'
+                           f'link_tables/check/drop.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── adp_get_annotations ─────────────────────────────────────────
+    @mcp.tool()
+    def adp_get_annotations(object_name: str,
+                              object_type: str = 'TABLE',
+                              annotation_owner: str = None,
+                              column_name: str = None,
+                              ctx: Context = None) -> str:
+        """Fetch Oracle 23ai annotations on a table/view and its columns — useful for NL→SQL.
+
+        Annotations carry semantic metadata (description, display_name,
+        data_class, join_hint, unit, aggregate, etc.) that helps an LLM
+        generate correct SQL without guessing from column names.
+
+        Reads from ALL_ANNOTATIONS_USAGE. Annotation names come back
+        UPPERCASE (Oracle stores them that way). Returns a tidy structure:
+            {
+              "object": "SALES",
+              "annotations": {
+                "table":   {"DESCRIPTION": "...", "DATA_DOMAIN": "..."},
+                "columns": {
+                  "CUST_ID":   {"DISPLAY_NAME": "Customer", ...},
+                  "AMOUNT":    {"UNIT": "USD", "AGGREGATE": "SUM"},
+                  ...
+                }
+              }
+            }
+
+        Args:
+            object_name: Table/view name (case-insensitive).
+            object_type: TABLE | VIEW | MATERIALIZED VIEW (default TABLE).
+            annotation_owner: Optional — filter by the user who defined the
+                annotation (ALL_ANNOTATIONS_USAGE.ANNOTATION_OWNER). The
+                annotations view itself is implicitly scoped to objects
+                visible to the current user, so there is no object-owner
+                filter to apply.
+            column_name: Optional — fetch annotations for a single column only.
+        """
+        client = get_adp(ctx)
+        if not client:
+            return err(_NO_CONN_MSG)
+        try:
+            # Build the query — quote the identifier literals properly
+            where = ["UPPER(object_name) = UPPER('{0}')".format(
+                object_name.replace("'", "''"))]
+            if object_type:
+                where.append("UPPER(object_type) = UPPER('{0}')".format(
+                    object_type.replace("'", "''")))
+            if annotation_owner:
+                where.append(
+                    "UPPER(annotation_owner) = UPPER('{0}')".format(
+                        annotation_owner.replace("'", "''")))
+            if column_name:
+                where.append("UPPER(column_name) = UPPER('{0}')".format(
+                    column_name.replace("'", "''")))
+
+            sql = (
+                "SELECT object_name, object_type, column_name, "
+                "annotation_owner, annotation_name, annotation_value "
+                "FROM all_annotations_usage "
+                "WHERE " + " AND ".join(where) + " "
+                "ORDER BY column_name NULLS FIRST, annotation_name"
+            )
+
+            raw = client.Misc.run_query(sql)
+            rows = json.loads(raw) if isinstance(raw, str) else raw
+
+            # Normalize — run_query can return either a bare list of row
+            # dicts OR an ORDS envelope {'items': [...]}. Handle both.
+            if isinstance(rows, dict):
+                rows = rows.get('items', rows.get('rows', []))
+
+            data = {
+                'object': object_name.upper(),
+                'object_type': object_type.upper() if object_type else None,
+                'annotation_owner_filter':
+                    annotation_owner.upper() if annotation_owner else None,
+                'annotations': {'table': {}, 'columns': {}},
+                'annotation_count': 0,
+            }
+            for row in rows or []:
+                # Rows may come back with lowercase or uppercase keys.
+                if isinstance(row, dict):
+                    col = row.get('column_name') or row.get('COLUMN_NAME')
+                    nm = (row.get('annotation_name')
+                          or row.get('ANNOTATION_NAME'))
+                    val = (row.get('annotation_value')
+                           or row.get('ANNOTATION_VALUE'))
+                elif isinstance(row, list) and len(row) >= 6:
+                    # obj, obj_type, col, ann_owner, ann_name, ann_value
+                    col, nm, val = row[2], row[4], row[5]
+                else:
+                    continue
+                if not nm:
+                    continue
+                data['annotation_count'] += 1
+                if col:
+                    data['annotations']['columns'].setdefault(col, {})[nm] = val
+                else:
+                    data['annotations']['table'][nm] = val
+
+            if data['annotation_count'] == 0:
+                data['note'] = (
+                    'No annotations found. Requires Oracle 23ai and '
+                    'annotations defined via CREATE/ALTER ... ANNOTATIONS(...). '
+                    'Check that ALL_ANNOTATIONS_USAGE is accessible.')
+
+            return fmt(data)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── Prompt: adp_sql_with_annotations ────────────────────────────
+    @mcp.prompt(
+        description='Generate SQL for Oracle ADB using column/table '
+                    'annotations as semantic hints. Instructs the '
+                    'assistant to call adp_get_annotations first.')
+    def adp_sql_with_annotations(question: str, tables: str) -> str:
+        """Prompt template — annotation-aware SQL generation.
+
+        Args:
+            question: The natural-language question to answer with SQL.
+            tables: Comma-separated list of candidate tables/views.
+        """
+        return (
+            "You are writing SQL for an Oracle Autonomous Database (23ai).\n\n"
+            "Task: answer the question below with a single SQL statement.\n\n"
+            f"QUESTION:\n{question}\n\n"
+            f"CANDIDATE TABLES: {tables}\n\n"
+            "Process:\n"
+            "1. For each candidate table, call `adp_get_annotations` to "
+            "fetch its table- and column-level annotations.\n"
+            "2. Use the annotations as semantic hints:\n"
+            "   - `description` / `display_name` — confirm table/column meaning\n"
+            "   - `data_class` / `pii` — avoid PII unless explicitly requested\n"
+            "   - `join_hint` — prefer these keys when joining\n"
+            "   - `unit` — keep unit-consistency in arithmetic/filters\n"
+            "   - `aggregate` — use the suggested aggregation function\n"
+            "   - `role` / `grain` — honor time granularity (DAY/MONTH/YEAR)\n"
+            "3. If annotations conflict with the question, ask before guessing.\n"
+            "4. If no annotations exist, fall back to column names + "
+            "`adp_search` (include_ddl=true) to inspect DDL.\n"
+            "5. Return the final SQL in a fenced ```sql block, followed by a "
+            "one-sentence rationale citing which annotations drove the choice."
+        )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+def _extract_entity_names(search_result):
+    '''Extract entity names from an ADP global_search result.'''
+    names = []
+    if isinstance(search_result, dict):
+        nodes = search_result.get('nodes', [])
+        for node in nodes:
+            d = node.get('data', {})
+            name = d.get('name', d.get('entity_name', ''))
+            if name:
+                names.append(name)
+    elif isinstance(search_result, list):
+        for item in search_result:
+            if isinstance(item, dict):
+                name = item.get('name', item.get('entity_name', ''))
+                if name:
+                    names.append(name)
+    return names

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/adp_tools.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/adp_tools.py
@@ -622,14 +622,20 @@ def register_tools(mcp: FastMCP):
     def adp_manage_analytic_views(action: str,
                                     av_name: str = None,
                                     owner: str = None,
+                                    confirm: str = None,
                                     ctx: Context = None) -> str:
         """Manage Analytic Views: list all AVs or drop one.
+
+        Destructive actions (`drop`) require `confirm` to match
+        `av_name` exactly — guards against prompt-injected deletions.
 
         Args:
             action: One of 'list', 'drop'.
             av_name: Analytic View name (required for drop).
             owner: Schema owner (optional, for list).
+            confirm: For drop: must equal `av_name`.
         """
+        from ._helpers import require_confirm
         client = get_adp(ctx)
         if not client:
             return err(_NO_CONN_MSG)
@@ -641,6 +647,10 @@ def register_tools(mcp: FastMCP):
             elif action == 'drop':
                 if not av_name:
                     return err('av_name required for drop action.')
+                msg = require_confirm(av_name, confirm,
+                                       action_label='drop analytic view')
+                if msg:
+                    return err(msg)
                 result = client.Analytics.drop(av_name)
                 return fmt(json.loads(result) if isinstance(
                     result, str) else result)
@@ -755,18 +765,46 @@ def register_tools(mcp: FastMCP):
                       mode: str = 'chat',
                       tables: str = None,
                       profile_name: str = None,
+                      max_rows: int = 1000,
                       ctx: Context = None) -> str:
         """Chat with the database using Oracle Select AI in different modes.
+
+        The returned payload is wrapped in an "untrusted-output"
+        envelope (`{"source": "select_ai", "untrusted": true, ...}`)
+        because the response interleaves LLM-generated text with DB
+        query results — callers must not feed it back into another
+        tool unchecked. Row results are capped at `max_rows`.
+
+        When `MCP_AI_CHAT_ALLOWED_TABLES` is set, every requested table
+        must match the allowlist. When `MCP_AI_CHAT_DENIED_TABLES` is
+        set, no requested table may match it. Both can coexist;
+        deny wins.
 
         Args:
             question: Natural language question or prompt.
             mode: One of 'chat', 'chat_with_db', 'generate_insight'.
-            tables: Comma-separated table names (for chat_with_db/generate_insight).
+            tables: Comma-separated table names (for chat_with_db /
+                generate_insight). Required if
+                MCP_AI_CHAT_ALLOWED_TABLES is set.
             profile_name: Select AI profile name (optional).
+            max_rows: Max rows from any DB-backed response. Default 1000.
         """
+        from ._helpers import check_ai_chat_tables, ai_chat_envelope
         client = get_adp(ctx)
         if not client:
             return err(_NO_CONN_MSG)
+
+        # Table-policy gate. Pulled from the lifespan context which is
+        # populated from env at startup.
+        lc = (ctx.request_context.lifespan_context
+              if ctx is not None else {})
+        policy_err = check_ai_chat_tables(
+            tables,
+            allowed=lc.get('_ai_chat_allowed_tables'),
+            denied=lc.get('_ai_chat_denied_tables'))
+        if policy_err:
+            return err(policy_err)
+
         try:
             table_list = None
             if tables:
@@ -787,12 +825,17 @@ def register_tools(mcp: FastMCP):
                 return err(f'Unknown mode: {mode}. '
                            f'Use chat/chat_with_db/generate_insight.')
 
+            # Normalise: some SDK paths return a JSON string instead of
+            # a dict / list. Parse so the envelope sees structured data.
             if isinstance(result, str):
                 try:
-                    return fmt(json.loads(result))
+                    result = json.loads(result)
                 except (json.JSONDecodeError, TypeError):
-                    return result
-            return json.dumps(result, indent=2, default=str)
+                    pass
+
+            envelope = ai_chat_envelope(result, mode=mode,
+                                         max_rows=max_rows)
+            return json.dumps(envelope, indent=2, default=str)
         except Exception as exc:
             return err(str(exc))
 

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/dt_tools.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/dt_tools.py
@@ -460,6 +460,7 @@ def register_tools(mcp: FastMCP):
                             time: str = None,
                             days: str = None,
                             status: str = 'INACTIVE',
+                            confirm: str = None,
                             ctx: Context = None) -> str:
         """Manage Data Transforms schedules: list, create, or delete.
 
@@ -476,6 +477,7 @@ def register_tools(mcp: FastMCP):
             days: Days for weekly schedules, comma-separated (e.g. 'MONDAY,WEDNESDAY,FRIDAY'). Valid values: MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY. Required for weekly.
             status: 'ACTIVE' or 'INACTIVE' (default: INACTIVE). Set to ACTIVE to enable immediately.
         """
+        from ._helpers import require_confirm
         dt = get_dt(ctx)
         if not dt:
             return err(_NO)
@@ -486,6 +488,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(result)
 
             elif action == 'delete':
+                msg = require_confirm(schedule_name, confirm,
+                                       action_label='delete schedule')
+                if msg:
+                    return err(msg)
                 if not schedule_name:
                     return err('schedule_name required for delete.')
                 result = client.delete_schedule(schedule_name)
@@ -656,6 +662,7 @@ def register_tools(mcp: FastMCP):
                                password: str = None,
                                wallet_path: str = None,
                                jdbc_url: str = None,
+                               confirm: str = None,
                                ctx: Context = None) -> str:
         """Manage Data Transforms connections: list, create, delete, or test.
 
@@ -671,6 +678,7 @@ def register_tools(mcp: FastMCP):
             wallet_path: Wallet path for create (alternative to host/port).
             jdbc_url: JDBC URL for create (alternative to host/port).
         """
+        from ._helpers import require_confirm
         dt = get_dt(ctx)
         if not dt:
             return err(_NO)
@@ -714,6 +722,10 @@ def register_tools(mcp: FastMCP):
                     return err('Connection builder not available. Install oracle-data-studio>=1.0.25.')
 
             elif action == 'delete':
+                msg = require_confirm(connection_name, confirm,
+                                       action_label='delete connection')
+                if msg:
+                    return err(msg)
                 if not connection_name:
                     return err('connection_name required for delete.')
                 result = client.delete_connection(connection_name)

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/dt_tools.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/dt_tools.py
@@ -46,11 +46,14 @@ def register_tools(mcp: FastMCP):
             if e:
                 errors.append(e)
 
-            # Connections
+            # Connections — redact host/userinfo/wallet by profile so we
+            # don't leak JDBC URLs and wallet paths to a viewer-level LLM.
+            from ._helpers import redact_connection_metadata, get_profile
             conns, e = safe_call('connections',
                                  client.list_connections)
             if conns:
-                data['connections'] = conns
+                data['connections'] = redact_connection_metadata(
+                    conns, profile=get_profile(ctx))
             if e:
                 errors.append(e)
 
@@ -131,13 +134,20 @@ def register_tools(mcp: FastMCP):
     # ── 28b. dt_manage_project ────────────────────────────────────────
     @mcp.tool()
     def dt_manage_project(action: str, project_name: str,
+                           confirm: str = None,
                            ctx: Context = None) -> str:
         """Manage Data Transforms projects (admin-only).
+
+        Destructive actions (`delete`) require `confirm` to match
+        `project_name` exactly — guards against prompt-injected
+        deletions.
 
         Args:
             action: One of 'delete'.
             project_name: Name of the project.
+            confirm: For delete: must equal `project_name`.
         """
+        from ._helpers import require_confirm
         dt = get_dt(ctx)
         if not dt:
             return err(_NO)
@@ -145,6 +155,10 @@ def register_tools(mcp: FastMCP):
             client = dt['client']
 
             if action == 'delete':
+                msg = require_confirm(project_name, confirm,
+                                       action_label='delete project')
+                if msg:
+                    return err(msg)
                 project_id = client.check_if_project_exists(project_name)
                 if not project_id:
                     return err(f'Project "{project_name}" not found.')
@@ -172,12 +186,16 @@ def register_tools(mcp: FastMCP):
             errors = []
             data = {'connection_name': connection_name}
 
-            # Details
+            # Details — redact JDBC URL, wallet path, host/userinfo for
+            # non-admin profiles. Even `viewer` keeps the connection
+            # name + type so it remains useful for discovery.
+            from ._helpers import redact_connection_metadata, get_profile
             details, e = safe_call('details',
                                    client.get_connection_details,
                                    connection_name)
             if details:
-                data['details'] = details
+                data['details'] = redact_connection_metadata(
+                    details, profile=get_profile(ctx))
             if e:
                 errors.append(e)
 

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/dt_tools.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/dt_tools.py
@@ -1,0 +1,955 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''Upleveled Data Transforms MCP tools.
+
+Each tool combines multiple SDK calls into a single task-oriented
+operation that returns an LLM-friendly result.  See TOOLS_DESIGN.md.
+'''
+
+import json
+import logging
+
+from mcp.server.fastmcp import FastMCP, Context
+
+from ._dt_connect import get_dt
+from ._helpers import safe_call, build_response, err, fmt
+
+logger = logging.getLogger('oracle-data-studio-mcp')
+
+_NO = 'Data Transforms not connected. Set DT_URL, DT_USER, DT_PASSWORD.'
+
+
+def register_tools(mcp: FastMCP):
+
+    # ── 27. dt_explore ────────────────────────────────────────────────
+    @mcp.tool()
+    def dt_explore(ctx: Context) -> str:
+        """Get a full Data Transforms environment overview: version, connections, projects, and active schedules.
+
+        This is the starting point for any Data Transforms task.
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+            wb = dt.get('workbench')
+            errors = []
+            data = {}
+
+            # About / version
+            about, e = safe_call('about', client.get_about)
+            if about:
+                data['about'] = about
+            if e:
+                errors.append(e)
+
+            # Connections
+            conns, e = safe_call('connections',
+                                 client.list_connections)
+            if conns:
+                data['connections'] = conns
+            if e:
+                errors.append(e)
+
+            # Projects
+            projects, e = safe_call('projects',
+                                    client.list_projects)
+            if projects:
+                data['projects'] = projects
+            if e:
+                errors.append(e)
+
+            # Schedules
+            schedules, e = safe_call('schedules',
+                                     client.list_schedules)
+            if schedules:
+                data['schedules'] = schedules
+            if e:
+                errors.append(e)
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 28. dt_describe_project ───────────────────────────────────────
+    @mcp.tool()
+    def dt_describe_project(project_name: str,
+                             ctx: Context = None) -> str:
+        """Get a complete inventory of a Data Transforms project (read-only).
+
+        Args:
+            project_name: Name of the project.
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+            errors = []
+            data = {'project_name': project_name}
+
+            # Check project exists
+            project_id = client.check_if_project_exists(project_name)
+            if not project_id:
+                return err(f'Project "{project_name}" not found.')
+            data['project_id'] = project_id
+
+            # Dataflows
+            dfs, e = safe_call('dataflows',
+                               client.list_dataflows_in_project,
+                               project_id)
+            if dfs:
+                data['dataflows'] = dfs
+            if e:
+                errors.append(e)
+
+            # Workflows
+            wfs, e = safe_call('workflows',
+                               client.list_workflows_in_project,
+                               project_id)
+            if wfs:
+                data['workflows'] = wfs
+            if e:
+                errors.append(e)
+
+            # Dataloads
+            dls, e = safe_call('dataloads',
+                               client.list_dataloads_in_project,
+                               project_id)
+            if dls:
+                data['dataloads'] = dls
+            if e:
+                errors.append(e)
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 28b. dt_manage_project ────────────────────────────────────────
+    @mcp.tool()
+    def dt_manage_project(action: str, project_name: str,
+                           ctx: Context = None) -> str:
+        """Manage Data Transforms projects (admin-only).
+
+        Args:
+            action: One of 'delete'.
+            project_name: Name of the project.
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+
+            if action == 'delete':
+                project_id = client.check_if_project_exists(project_name)
+                if not project_id:
+                    return err(f'Project "{project_name}" not found.')
+                client.delete_project(project_name)
+                return json.dumps({'status': 'deleted', 'project': project_name})
+            else:
+                return err(f'Unknown action: {action}. Use delete.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 29. dt_describe_connection ────────────────────────────────────
+    @mcp.tool()
+    def dt_describe_connection(connection_name: str,
+                                ctx: Context) -> str:
+        """Get connection details, test it, and list its available schemas.
+
+        Args:
+            connection_name: Name of the connection.
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+            errors = []
+            data = {'connection_name': connection_name}
+
+            # Details
+            details, e = safe_call('details',
+                                   client.get_connection_details,
+                                   connection_name)
+            if details:
+                data['details'] = details
+            if e:
+                errors.append(e)
+
+            # Test
+            test, e = safe_call('test',
+                                client.test_connection_by_name,
+                                connection_name)
+            if test is not None:
+                data['test_result'] = test
+            if e:
+                errors.append(e)
+
+            # Schemas
+            schemas, e = safe_call('schemas',
+                                   client.get_live_schemas,
+                                   connection_name)
+            if schemas:
+                data['schemas'] = schemas
+            if e:
+                errors.append(e)
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 30. dt_create_pipeline ────────────────────────────────────────
+    @mcp.tool()
+    def dt_create_pipeline(project_name: str,
+                            source_connection: str,
+                            source_schema: str,
+                            source_table: str,
+                            target_connection: str,
+                            target_schema: str,
+                            target_table: str,
+                            dataflow_name: str = None,
+                            integration_type: str = 'CONTROL_APPEND',
+                            ctx: Context = None) -> str:
+        """Create a simple source-to-target dataflow in a Data Transforms project.
+
+        Creates the project if it doesn't exist, then builds a dataflow
+        that maps data from a source table to a target table.
+
+        Args:
+            project_name: Target project name (created if it doesn't exist).
+            source_connection: Name of the source connection (use dt_explore to list available connections).
+            source_schema: Schema in the source connection (use dt_describe_connection to list schemas).
+            source_table: Table name in the source schema.
+            target_connection: Name of the target connection.
+            target_schema: Schema in the target connection.
+            target_table: Table name in the target schema.
+            dataflow_name: Name for the dataflow (defaults to 'DF_{source_table}_to_{target_table}').
+            integration_type: How to load data. One of: 'CONTROL_APPEND' (append rows, default), 'INCREMENTAL_UPDATE' (upsert changed rows), 'INSERT' (simple insert).
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+            wb = dt.get('workbench')
+            data = {'project_name': project_name}
+
+            if not dataflow_name:
+                dataflow_name = f'DF_{source_table}_to_{target_table}'
+            data['dataflow_name'] = dataflow_name
+
+            # Ensure project exists
+            project_id = client.check_if_project_exists(project_name)
+            if not project_id:
+                client.create_project(project_name)
+                project_id = client.check_if_project_exists(project_name)
+            data['project_id'] = project_id
+
+            # Use the SDK's builder classes if workbench is available
+            if wb:
+                try:
+                    from datatransforms.dataflow import (
+                        Project, SourceDataStore, TargetDataStore)
+                    from datatransforms.dataflow import DataFlow
+
+                    project = Project(project_name, project_name)
+                    src = SourceDataStore('SRC', source_table)
+                    tgt = TargetDataStore('TGT', target_table,
+                                          {'integrationType': integration_type})
+                    df = DataFlow(project, dataflow_name)
+                    df.add_source(source_connection, source_schema, src)
+                    df.add_target(target_connection, target_schema, tgt)
+                    df.connect(src, tgt)
+                    df.create()
+                    data['action'] = 'created'
+                    data['success'] = True
+                    return json.dumps(data, indent=2, default=str)
+                except ImportError:
+                    pass  # fall through to raw API
+                except Exception as e:
+                    logger.debug('DataFlow builder failed: %s', e)
+                    # fall through to raw API
+
+            # Fallback: build the JSON payload manually
+            payload = _build_simple_dataflow_payload(
+                project_name, dataflow_name,
+                source_connection, source_schema, source_table,
+                target_connection, target_schema, target_table,
+                integration_type)
+            success, global_id = \
+                client.create_dataflow_from_json_payload(
+                    json.dumps(payload))
+            data['action'] = 'created'
+            data['success'] = success
+            data['global_id'] = global_id
+
+            return json.dumps(data, indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 31. dt_check_health ───────────────────────────────────────────
+    @mcp.tool()
+    def dt_check_health(ctx: Context) -> str:
+        """Check Data Transforms environment health: test all connections and list schedules.
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+            errors = []
+            data = {}
+
+            # List and test all connections
+            conns, e = safe_call('connections',
+                                 client.list_connections)
+            if e:
+                errors.append(e)
+
+            if conns:
+                conn_results = []
+                conn_list = conns if isinstance(conns, list) else \
+                    conns.get('items', [conns])
+                for conn in conn_list:
+                    name = conn.get('name', '') if isinstance(
+                        conn, dict) else str(conn)
+                    if name:
+                        test, e2 = safe_call(
+                            f'test/{name}',
+                            client.test_connection_by_name, name)
+                        conn_results.append({
+                            'name': name,
+                            'status': test if test is not None
+                            else 'unknown'
+                        })
+                        if e2:
+                            errors.append(e2)
+                data['connections'] = conn_results
+
+            # Schedules
+            schedules, e = safe_call('schedules',
+                                     client.list_schedules)
+            if schedules:
+                data['schedules'] = schedules
+            if e:
+                errors.append(e)
+
+            # Deployment time
+            deploy, e = safe_call('deployment',
+                                  client.get_deployment_time)
+            if deploy:
+                data['deployment'] = deploy
+            if e:
+                errors.append(e)
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 32. dt_browse_data ────────────────────────────────────────────
+    @mcp.tool()
+    def dt_browse_data(connection_name: str, schema: str = None,
+                        ctx: Context = None) -> str:
+        """Browse schemas and tables available through a Data Transforms connection.
+
+        Args:
+            connection_name: Connection to browse.
+            schema: Optional schema filter (shows all if omitted).
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+            errors = []
+            data = {'connection_name': connection_name}
+
+            if schema:
+                tables, e = safe_call('tables',
+                                      client.get_live_tables,
+                                      connection_name, schema)
+                if tables:
+                    data['tables'] = tables
+                if e:
+                    errors.append(e)
+            else:
+                schemas, e = safe_call('schemas',
+                                       client.get_live_schemas,
+                                       connection_name)
+                if schemas:
+                    data['schemas'] = schemas
+                if e:
+                    errors.append(e)
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 33. dt_manage_dataflow ────────────────────────────────────────
+    @mcp.tool()
+    def dt_manage_dataflow(project_name: str, dataflow_name: str,
+                            ctx: Context = None) -> str:
+        """Check if a dataflow exists in a project and return its details.
+
+        Use dt_create_pipeline to create new dataflows with explicit
+        source/target parameters.
+
+        Args:
+            project_name: Project name.
+            dataflow_name: Dataflow name to look up.
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+            data = {'project_name': project_name,
+                    'dataflow_name': dataflow_name}
+
+            project_id = client.check_if_project_exists(project_name)
+            if not project_id:
+                return err(f'Project "{project_name}" not found.')
+
+            exists, global_id = client.check_if_df_exists(
+                project_id, dataflow_name)
+            data['exists'] = exists
+            if exists:
+                data['global_id'] = global_id
+                # Try to get dataflow details
+                details, e = safe_call(
+                    'details',
+                    client.get_dataflow_by_id, global_id)
+                if details:
+                    data['details'] = details
+
+            return json.dumps(data, indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 34. dt_manage_schedule ────────────────────────────────────────
+    @mcp.tool()
+    def dt_manage_schedule(action: str,
+                            schedule_name: str = None,
+                            project_name: str = None,
+                            resource_name: str = None,
+                            resource_type: str = 'dataflow',
+                            frequency: str = None,
+                            time: str = None,
+                            days: str = None,
+                            status: str = 'INACTIVE',
+                            ctx: Context = None) -> str:
+        """Manage Data Transforms schedules: list, create, or delete.
+
+        For 'create', builds a schedule from explicit parameters — no raw JSON needed.
+
+        Args:
+            action: One of 'list', 'create', 'delete'.
+            schedule_name: Schedule name (required for create/delete).
+            project_name: Project containing the resource to schedule (required for create).
+            resource_name: Dataflow or workflow name to schedule (required for create).
+            resource_type: 'dataflow' or 'workflow' (default: dataflow).
+            frequency: Schedule frequency. One of: 'immediate' (run once now), 'hourly', 'daily', 'weekly', 'monthly'. Required for create.
+            time: Time for the schedule. Format depends on frequency: for 'hourly' use 'MM:SS' (e.g. '30:00' = at 30 minutes past), for 'daily' use 'HH:MM' (e.g. '14:30'), for 'weekly'/'monthly' use 'HH:MM:SS' (e.g. '06:00:00'). Required for all except 'immediate'.
+            days: Days for weekly schedules, comma-separated (e.g. 'MONDAY,WEDNESDAY,FRIDAY'). Valid values: MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY. Required for weekly.
+            status: 'ACTIVE' or 'INACTIVE' (default: INACTIVE). Set to ACTIVE to enable immediately.
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+            if action == 'list':
+                result = client.list_schedules()
+                return fmt(result)
+
+            elif action == 'delete':
+                if not schedule_name:
+                    return err('schedule_name required for delete.')
+                result = client.delete_schedule(schedule_name)
+                return fmt(result)
+
+            elif action == 'create':
+                if not all([schedule_name, project_name,
+                            resource_name, frequency]):
+                    return err(
+                        'create requires: schedule_name, project_name, '
+                        'resource_name, frequency.')
+
+                # Build schedule using the SDK's Schedule builder
+                try:
+                    from datatransforms.schedule import Schedule
+                    sched = Schedule(schedule_name)
+
+                    # Attach resource
+                    if resource_type == 'workflow':
+                        sched.workflow(project_name, resource_name)
+                    else:
+                        sched.dataflow(project_name, resource_name)
+
+                    # Set frequency
+                    if frequency == 'immediate':
+                        sched.immediate()
+                    elif frequency == 'hourly':
+                        parts = (time or '00:00').split(':')
+                        mins = int(parts[0])
+                        secs = int(parts[1]) if len(parts) > 1 else 0
+                        sched.hourly(mins, secs)
+                    elif frequency == 'daily':
+                        parts = (time or '00:00').split(':')
+                        hh = int(parts[0])
+                        mm = int(parts[1]) if len(parts) > 1 else 0
+                        ss = int(parts[2]) if len(parts) > 2 else 0
+                        sched.daily(hh, mm, ss)
+                    elif frequency == 'weekly':
+                        if not days:
+                            return err('days required for weekly schedule '
+                                       '(e.g. "MONDAY,FRIDAY").')
+                        day_list = [d.strip() for d in days.split(',')]
+                        sched.weekly(day_list, time or '00:00')
+                    elif frequency == 'monthly':
+                        parts = (time or '01 00:00:00').split(' ')
+                        if len(parts) == 2:
+                            date_part = parts[0]
+                            time_part = parts[1]
+                        else:
+                            date_part = '1'
+                            time_part = time or '00:00:00'
+                        sched.monthly(date_part, time_part)
+                    else:
+                        return err(
+                            f'Unknown frequency: {frequency}. '
+                            f'Use immediate/hourly/daily/weekly/monthly.')
+
+                    # Set status
+                    sched.schedule_status(status)
+
+                    # Create it
+                    sched.create()
+
+                    return json.dumps({
+                        'action': 'created',
+                        'schedule_name': schedule_name,
+                        'frequency': frequency,
+                        'status': status,
+                        'resource': resource_name,
+                        'project': project_name,
+                    }, indent=2)
+
+                except ImportError:
+                    return err(
+                        'Schedule builder not available. '
+                        'Install oracle-data-studio>=1.0.25.')
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/create/delete.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 35. dt_manage_variables ───────────────────────────────────────
+    @mcp.tool()
+    def dt_manage_variables(action: str, variable_name: str = None,
+                             value: str = None,
+                             ctx: Context = None) -> str:
+        """Manage Data Transforms variables: list, create, or update.
+
+        Args:
+            action: One of 'list', 'set'.
+            variable_name: Variable name (required for set).
+            value: Variable value (required for set).
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+            if action == 'list':
+                result = client.list_variables()
+                return fmt(result)
+            elif action == 'set':
+                if not variable_name or value is None:
+                    return err('variable_name and value required for set.')
+                # Try update first, create on failure
+                try:
+                    result = client.update_variable(variable_name, value)
+                    return json.dumps({'action': 'updated',
+                                       'variable': variable_name,
+                                       'value': value})
+                except Exception:
+                    result = client.create_variable(variable_name, value)
+                    return json.dumps({'action': 'created',
+                                       'variable': variable_name,
+                                       'value': value})
+            else:
+                return err(f'Unknown action: {action}. Use list/set.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 36. dt_run_pipeline ──────────────────────────────────────────
+    @mcp.tool()
+    def dt_run_pipeline(project_name: str,
+                         resource_name: str,
+                         resource_type: str = 'dataflow',
+                         ctx: Context = None) -> str:
+        """Execute a dataflow, workflow, or dataload in a Data Transforms project. Returns the job session and status.
+
+        Args:
+            project_name: Project containing the resource.
+            resource_name: Name of the dataflow, workflow, or dataload to run.
+            resource_type: One of 'dataflow', 'workflow', 'dataload' (default: dataflow).
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            wb = dt.get('workbench')
+            if not wb:
+                return err('Data Transforms workbench not available. Execution requires a full workbench connection.')
+            runtime = wb.get_runtime_client()
+            data = {'project': project_name, 'resource': resource_name, 'type': resource_type}
+
+            if resource_type == 'dataflow':
+                result = runtime.run_dataflow(project_name, resource_name)
+            elif resource_type == 'workflow':
+                result = runtime.run_workflow(project_name, resource_name)
+            elif resource_type == 'dataload':
+                result = runtime.run_dataload(project_name, resource_name)
+            else:
+                return err(f'Unknown resource_type: {resource_type}. Use dataflow/workflow/dataload.')
+
+            data['job_result'] = result
+            return json.dumps(data, indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 37. dt_manage_connection ─────────────────────────────────────
+    @mcp.tool()
+    def dt_manage_connection(action: str,
+                               connection_name: str = None,
+                               connection_type: str = None,
+                               host: str = None,
+                               port: int = None,
+                               service_name: str = None,
+                               user: str = None,
+                               password: str = None,
+                               wallet_path: str = None,
+                               jdbc_url: str = None,
+                               ctx: Context = None) -> str:
+        """Manage Data Transforms connections: list, create, delete, or test.
+
+        Args:
+            action: One of 'list', 'get_types', 'create', 'delete', 'test'.
+            connection_name: Connection name (required for create/delete/test).
+            connection_type: Connection type for create (e.g. 'Oracle').
+            host: Host for create.
+            port: Port for create.
+            service_name: Service name for create.
+            user: Username for create.
+            password: Password for create.
+            wallet_path: Wallet path for create (alternative to host/port).
+            jdbc_url: JDBC URL for create (alternative to host/port).
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+
+            if action == 'list':
+                result = client.list_connections()
+                return fmt(result)
+
+            elif action == 'get_types':
+                result = client.get_connection_types()
+                return fmt(result)
+
+            elif action == 'create':
+                if not connection_name:
+                    return err('connection_name required for create.')
+                try:
+                    from datatransforms.connection import Connection
+                    conn = Connection(connection_name)
+                    if connection_type:
+                        conn.of_type(connection_type)
+                    if user and password:
+                        conn.with_credentials(user, password)
+                    if wallet_path:
+                        conn.usingWallet(wallet_path)
+                    if jdbc_url:
+                        conn.property('jdbcUrl', jdbc_url)
+                    elif host:
+                        conn.property('host', host)
+                        if port:
+                            conn.property('port', str(port))
+                        if service_name:
+                            conn.property('serviceName', service_name)
+                    wb = dt.get('workbench')
+                    if not wb:
+                        return err('Workbench required for create.')
+                    result = wb.save_connection(conn)
+                    return json.dumps({'action': 'created', 'connection': connection_name, 'result': str(result)}, indent=2)
+                except ImportError:
+                    return err('Connection builder not available. Install oracle-data-studio>=1.0.25.')
+
+            elif action == 'delete':
+                if not connection_name:
+                    return err('connection_name required for delete.')
+                result = client.delete_connection(connection_name)
+                return json.dumps({'action': 'deleted', 'connection': connection_name, 'result': str(result)}, indent=2)
+
+            elif action == 'test':
+                if not connection_name:
+                    return err('connection_name required for test.')
+                result = client.test_connection_by_name(connection_name)
+                return json.dumps({'action': 'tested', 'connection': connection_name, 'result': result}, indent=2, default=str)
+
+            else:
+                return err(f'Unknown action: {action}. Use list/get_types/create/delete/test.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 38. dt_manage_dataload ───────────────────────────────────────
+    @mcp.tool()
+    def dt_manage_dataload(action: str,
+                            project_name: str,
+                            dataload_name: str = None,
+                            source_connection: str = None,
+                            source_schema: str = None,
+                            target_connection: str = None,
+                            target_schema: str = None,
+                            tables: str = None,
+                            load_type: str = 'TRUNCATE',
+                            ctx: Context = None) -> str:
+        """Manage dataloads in a Data Transforms project.
+
+        Args:
+            action: One of 'list', 'get', 'check_exists', 'create'.
+            project_name: Project name.
+            dataload_name: Dataload name (required for get/check_exists/create).
+            source_connection: Source connection name (required for create).
+            source_schema: Source schema name (required for create).
+            target_connection: Target connection name (required for create).
+            target_schema: Target schema name (required for create).
+            tables: Comma-separated list of table names (required for create).
+            load_type: Load type for create: TRUNCATE (default), APPEND, or RECREATE.
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+            data = {'project_name': project_name, 'action': action}
+
+            project_id = client.check_if_project_exists(project_name)
+            if not project_id:
+                return err(f'Project "{project_name}" not found.')
+            data['project_id'] = project_id
+
+            if action == 'list':
+                result = client.list_dataloads_in_project(project_id)
+                data['dataloads'] = result
+                return json.dumps(data, indent=2, default=str)
+
+            elif action == 'get':
+                if not dataload_name:
+                    return err('dataload_name required for get.')
+                exists, global_id = client.check_if_dataload_exists(project_id, dataload_name)
+                data['exists'] = exists
+                if exists:
+                    data['global_id'] = global_id
+                    details = client.get_dataload_by_id(global_id)
+                    data['details'] = details
+                return json.dumps(data, indent=2, default=str)
+
+            elif action == 'check_exists':
+                if not dataload_name:
+                    return err('dataload_name required for check_exists.')
+                exists, global_id = client.check_if_dataload_exists(project_id, dataload_name)
+                data['exists'] = exists
+                if exists:
+                    data['global_id'] = global_id
+                return json.dumps(data, indent=2, default=str)
+
+            elif action == 'create':
+                if not all([dataload_name, source_connection, source_schema,
+                            target_connection, target_schema, tables]):
+                    return err('create requires: dataload_name, source_connection, '
+                               'source_schema, target_connection, target_schema, tables.')
+                try:
+                    from datatransforms.dataload import DataLoad
+                    dl = DataLoad(dataload_name, project_name)
+                    dl.source(f'{source_connection}.{source_schema}')
+                    dl.target(f'{target_connection}.{target_schema}')
+                    table_list = [t.strip() for t in tables.split(',')]
+                    for table_name in table_list:
+                        if load_type == 'TRUNCATE':
+                            dl.truncate(table_name)
+                        elif load_type == 'APPEND':
+                            dl.append(table_name)
+                        elif load_type == 'RECREATE':
+                            dl.recreate(table_name)
+                        else:
+                            dl.truncate(table_name)
+                    dl.create_dataload()
+                    return json.dumps({'action': 'created', 'dataload': dataload_name,
+                                       'tables': table_list, 'load_type': load_type})
+                except ImportError:
+                    return err('DataLoad builder not available. Install oracle-data-studio>=1.0.25.')
+
+            else:
+                return err(f'Unknown action: {action}. Use list/get/check_exists/create.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 39. dt_manage_data_entities ──────────────────────────────────
+    @mcp.tool()
+    def dt_manage_data_entities(action: str,
+                                  connection_name: str = None,
+                                  schema_name: str = None,
+                                  entity_name: str = None,
+                                  entity_id: str = None,
+                                  ctx: Context = None) -> str:
+        """Manage data entities in Data Transforms: list, get details, or import from a connection.
+
+        Args:
+            action: One of 'list', 'get', 'import_entities'.
+            connection_name: Connection name (required for import_entities).
+            schema_name: Schema name (required for import_entities).
+            entity_name: Entity name (for get by name).
+            entity_id: Entity global ID (for get by ID).
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+            data = {'action': action}
+
+            if action == 'list':
+                try:
+                    result = client.list_data_entities()
+                except Exception:
+                    result = client.get_all_datastores()
+                data['entities'] = result
+                return json.dumps(data, indent=2, default=str)
+
+            elif action == 'get':
+                if entity_id:
+                    result = client.get_data_entity_by_id(entity_id)
+                    data['entity'] = result
+                elif entity_name:
+                    result = client.get_data_entity_by_name(entity_name)
+                    data['entity'] = result
+                else:
+                    return err('entity_id or entity_name required for get.')
+                return json.dumps(data, indent=2, default=str)
+
+            elif action == 'import_entities':
+                if not connection_name or not schema_name:
+                    return err('connection_name and schema_name required for import_entities.')
+                wb = dt.get('workbench')
+                if not wb:
+                    return err('Workbench required for import_entities.')
+                result = wb.import_data_entities(connection_name, schema_name)
+                data['connection_name'] = connection_name
+                data['schema_name'] = schema_name
+                data['result'] = result
+                return json.dumps(data, indent=2, default=str)
+
+            else:
+                return err(f'Unknown action: {action}. Use list/get/import_entities.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 40. dt_manage_workflow ──────────────────────────────────────────
+    @mcp.tool()
+    def dt_manage_workflow(action: str,
+                            project_name: str,
+                            workflow_name: str = None,
+                            ctx: Context = None) -> str:
+        """Manage workflows in a Data Transforms project: list, get details, or check existence.
+
+        Args:
+            action: One of 'list', 'get', 'check_exists'.
+            project_name: Project name.
+            workflow_name: Workflow name (required for get/check_exists).
+        """
+        dt = get_dt(ctx)
+        if not dt:
+            return err(_NO)
+        try:
+            client = dt['client']
+            data = {'project_name': project_name, 'action': action}
+
+            project_id = client.check_if_project_exists(project_name)
+            if not project_id:
+                return err(f'Project "{project_name}" not found.')
+            data['project_id'] = project_id
+
+            if action == 'list':
+                result = client.list_workflows_in_project(project_id)
+                return fmt(result)
+
+            elif action == 'get':
+                if not workflow_name:
+                    return err('workflow_name required for get.')
+                exists, global_id = client.check_if_workflow_exists(project_id, workflow_name)
+                data['exists'] = exists
+                if exists:
+                    data['global_id'] = global_id
+                    details, e = safe_call(
+                        'details',
+                        client.get_workflow_by_id, global_id)
+                    if details:
+                        data['details'] = details
+                return json.dumps(data, indent=2, default=str)
+
+            elif action == 'check_exists':
+                if not workflow_name:
+                    return err('workflow_name required for check_exists.')
+                exists, global_id = client.check_if_workflow_exists(project_id, workflow_name)
+                data['exists'] = exists
+                if exists:
+                    data['global_id'] = global_id
+                return json.dumps(data, indent=2, default=str)
+
+            else:
+                return err(f'Unknown action: {action}. Use list/get/check_exists.')
+        except Exception as exc:
+            return err(str(exc))
+
+
+# ── Private helpers ───────────────────────────────────────────────────
+
+def _build_simple_dataflow_payload(project_name, dataflow_name,
+                                    src_conn, src_schema, src_table,
+                                    tgt_conn, tgt_schema, tgt_table,
+                                    integration_type):
+    '''Build a minimal dataflow JSON payload for the REST API.
+
+    This is the fallback when the SDK builder classes are not available.
+    '''
+    return {
+        'name': dataflow_name,
+        'projectName': project_name,
+        'sources': [{
+            'connectionName': src_conn,
+            'schemaName': src_schema,
+            'dataEntityName': src_table,
+            'operatorName': 'SRC',
+        }],
+        'targets': [{
+            'connectionName': tgt_conn,
+            'schemaName': tgt_schema,
+            'dataEntityName': tgt_table,
+            'operatorName': 'TGT',
+            'integrationType': integration_type,
+        }],
+        'connections': [
+            {'from': 'SRC', 'to': 'TGT'}
+        ]
+    }

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/essbase_tools.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/essbase_tools.py
@@ -394,8 +394,13 @@ def register_tools(mcp: FastMCP):
                                   db_name: str = None,
                                   variable_name: str = None,
                                   value: str = None,
+                                  confirm: str = None,
                                   ctx: Context = None) -> str:
         """Manage Essbase substitution variables at any scope.
+
+        Destructive actions (`delete`) require `confirm` to match
+        `variable_name` exactly — guards against prompt-injected
+        deletions.
 
         Args:
             action: One of 'list', 'get', 'set', 'delete'.
@@ -404,7 +409,9 @@ def register_tools(mcp: FastMCP):
             db_name: Database name (required for db scope).
             variable_name: Variable name (required for get/set/delete).
             value: Variable value (required for set).
+            confirm: For delete: must equal `variable_name`.
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -447,6 +454,12 @@ def register_tools(mcp: FastMCP):
                         return fmt(v.create_db_variable(
                             app_name, db_name, payload))
             elif action == 'delete':
+                if not variable_name:
+                    return err('variable_name required for delete.')
+                msg = require_confirm(variable_name, confirm,
+                                       action_label='delete variable')
+                if msg:
+                    return err(msg)
                 if scope == 'server':
                     v.delete_server_variable(variable_name)
                 elif scope == 'application':
@@ -725,6 +738,7 @@ def register_tools(mcp: FastMCP):
                                script_name: str,
                                content: str = None,
                                new_name: str = None,
+                               confirm: str = None,
                                ctx: Context = None) -> str:
         """Manage calc scripts: list, create, update, delete, or validate.
 
@@ -739,6 +753,7 @@ def register_tools(mcp: FastMCP):
             content: Calc script text (required for create/update, e.g. 'CALC ALL;').
             new_name: New name for rename (optional with 'update').
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -791,6 +806,10 @@ def register_tools(mcp: FastMCP):
                                    'new_name': new_name})
 
             elif action == 'delete':
+                msg = require_confirm(script_name, confirm,
+                                       action_label='delete script')
+                if msg:
+                    return err(msg)
                 s.delete_script(app_name, db_name, script_name)
                 return json.dumps({'status': 'deleted',
                                    'script': script_name})
@@ -811,6 +830,7 @@ def register_tools(mcp: FastMCP):
     def essbase_manage_files(action: str, path: str = None,
                               target_path: str = None,
                               content: str = None,
+                              confirm: str = None,
                               ctx: Context = None) -> str:
         """Manage files in the Essbase file catalog: list, upload, download, copy, move, delete, create_folder.
 
@@ -823,6 +843,7 @@ def register_tools(mcp: FastMCP):
             target_path: Destination path (required for copy/move).
             content: Text content to upload (required for upload, e.g. data file contents or rule file).
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -862,6 +883,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(result)
 
             elif action == 'delete':
+                msg = require_confirm(path, confirm,
+                                       action_label='delete file')
+                if msg:
+                    return err(msg)
                 if not path:
                     return err('path required for delete.')
                 f.delete_file(path)
@@ -900,6 +925,7 @@ def register_tools(mcp: FastMCP):
                                     user: str = None,
                                     password: str = None,
                                     db_type: str = 'oracle',
+                                    confirm: str = None,
                                     ctx: Context = None) -> str:
         """Manage Essbase global connections: list, get, create, update, test, or delete.
 
@@ -916,6 +942,7 @@ def register_tools(mcp: FastMCP):
             password: Database password (required for create).
             db_type: Connection type: 'oracle' (default), 'sql_server', 'db2'.
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -984,6 +1011,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(result)
 
             elif action == 'delete':
+                msg = require_confirm(connection_name, confirm,
+                                       action_label='delete connection')
+                if msg:
+                    return err(msg)
                 if not connection_name:
                     return err('connection_name required.')
                 c.delete_connection(connection_name)
@@ -1068,6 +1099,7 @@ def register_tools(mcp: FastMCP):
                                 user_or_group: str = None,
                                 access: str = 'read',
                                 new_name: str = None,
+                                confirm: str = None,
                                 ctx: Context = None) -> str:
         """Manage security filters for row-level access control on an Essbase database.
 
@@ -1084,6 +1116,7 @@ def register_tools(mcp: FastMCP):
             access: Access type for simple filter creation: 'read' (default), 'write', 'none', 'metaread'.
             new_name: New filter name (required for copy/rename).
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -1200,6 +1233,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(result)
 
             elif action == 'delete':
+                msg = require_confirm(filter_name, confirm,
+                                       action_label='delete filter')
+                if msg:
+                    return err(msg)
                 if not filter_name:
                     return err('filter_name required for delete.')
                 fl.delete_filter(app_name, db_name, filter_name)
@@ -1227,6 +1264,7 @@ def register_tools(mcp: FastMCP):
     def essbase_manage_jobs(action: str = 'list',
                              job_id: int = None,
                              limit: int = 50,
+                             confirm: str = None,
                              ctx: Context = None) -> str:
         """Monitor and manage Essbase jobs: list recent jobs, check status, or rerun a failed job.
 
@@ -1237,6 +1275,7 @@ def register_tools(mcp: FastMCP):
             job_id: Job ID (required for status/rerun).
             limit: Maximum jobs to return for list (default 50).
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -1266,6 +1305,10 @@ def register_tools(mcp: FastMCP):
                 return json.dumps(data, indent=2, default=str)
 
             elif action == 'purge':
+                msg = require_confirm('all', confirm,
+                                       action_label='purge jobs')
+                if msg:
+                    return err(msg)
                 j.purge()
                 return json.dumps({'status': 'purged'})
 
@@ -1288,6 +1331,7 @@ def register_tools(mcp: FastMCP):
                               alias_table: str = 'Default',
                               alias_value: str = None,
                               uda_value: str = None,
+                              confirm: str = None,
                               ctx: Context = None) -> str:
         """Edit the cube outline: add, remove, move, or rename members and set properties.
 
@@ -1308,6 +1352,7 @@ def register_tools(mcp: FastMCP):
             alias_value: Alias value (for 'set_alias', or optionally with 'add').
             uda_value: User-Defined Attribute value (for 'set_uda').
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -1340,6 +1385,10 @@ def register_tools(mcp: FastMCP):
                         'alias': alias_value})
 
             elif action == 'remove':
+                msg = require_confirm(member_name, confirm,
+                                       action_label='remove outline member')
+                if msg:
+                    return err(msg)
                 edit_actions.append({
                     'actionType': 'removeMember',
                     'memberName': member_name})
@@ -1406,6 +1455,7 @@ def register_tools(mcp: FastMCP):
                                     connection: str = None,
                                     query: str = None,
                                     columns: str = None,
+                                    confirm: str = None,
                                     ctx: Context = None) -> str:
         """Manage global datasources for data loads and drill-through.
 
@@ -1416,6 +1466,7 @@ def register_tools(mcp: FastMCP):
             query: SQL query for the datasource (for create).
             columns: Comma-separated column names (for create).
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -1462,6 +1513,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(result)
 
             elif action == 'delete':
+                msg = require_confirm(datasource_name, confirm,
+                                       action_label='delete datasource')
+                if msg:
+                    return err(msg)
                 if not datasource_name:
                     return err('datasource_name required for delete.')
                 ds.delete_datasource(datasource_name)
@@ -1484,6 +1539,7 @@ def register_tools(mcp: FastMCP):
                                       sql_query: str = None,
                                       columns: str = None,
                                       drillable_regions: str = None,
+                                      confirm: str = None,
                                       ctx: Context = None) -> str:
         """Manage drill-through reports that link cube cells to detail data.
 
@@ -1497,6 +1553,7 @@ def register_tools(mcp: FastMCP):
             columns: Comma-separated column names to display (for create).
             drillable_regions: Comma-separated member specifications defining where drill-through is available (for create, e.g. '@IDESCENDANTS(East),@IDESCENDANTS(Sales)').
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -1554,6 +1611,10 @@ def register_tools(mcp: FastMCP):
                 return fmt(result)
 
             elif action == 'delete':
+                msg = require_confirm(report_name, confirm,
+                                       action_label='delete drill-through report')
+                if msg:
+                    return err(msg)
                 if not report_name:
                     return err('report_name required for delete.')
                 dt.delete_report(app_name, db_name, report_name)
@@ -1769,6 +1830,7 @@ def register_tools(mcp: FastMCP):
     def essbase_manage_groups(action: str,
                                group_id: str = None,
                                user_ids: str = None,
+                               confirm: str = None,
                                ctx: Context = None) -> str:
         """Manage Essbase groups: list, get details, create, delete, add/remove users, get users, add/remove subgroups.
 
@@ -1777,6 +1839,7 @@ def register_tools(mcp: FastMCP):
             group_id: Group ID (required for get/create/delete/add_users/remove_users/get_users/add_subgroups/remove_subgroups).
             user_ids: Comma-separated user IDs (required for add_users). For add_subgroups, comma-separated subgroup IDs.
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -1818,6 +1881,10 @@ def register_tools(mcp: FastMCP):
                     {'status': 'created', 'group': group_id})
 
             elif action == 'delete':
+                msg = require_confirm(group_id, confirm,
+                                       action_label='delete group')
+                if msg:
+                    return err(msg)
                 if not group_id:
                     return err('group_id required for delete.')
                 g.delete_group(group_id)
@@ -1836,6 +1903,10 @@ def register_tools(mcp: FastMCP):
                      'users': [u['id'] for u in users]})
 
             elif action == 'remove_users':
+                msg = require_confirm(group_id, confirm,
+                                       action_label='remove users from group')
+                if msg:
+                    return err(msg)
                 if not group_id:
                     return err('group_id required for remove_users.')
                 result = g.remove_users(group_id)
@@ -1862,6 +1933,10 @@ def register_tools(mcp: FastMCP):
                      'subgroups': [s['id'] for s in subgroups]})
 
             elif action == 'remove_subgroups':
+                msg = require_confirm(group_id, confirm,
+                                       action_label='remove subgroups from group')
+                if msg:
+                    return err(msg)
                 if not group_id:
                     return err('group_id required for remove_subgroups.')
                 result = g.remove_subgroups(group_id)

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/essbase_tools.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/essbase_tools.py
@@ -649,8 +649,13 @@ def register_tools(mcp: FastMCP):
                                     db_name: str = None,
                                     db_type: str = 'BSO',
                                     new_name: str = None,
+                                    confirm: str = None,
                                     ctx: Context = None) -> str:
         """Create, delete, copy, rename, start, or stop an Essbase application.
+
+        Destructive actions (`delete`, `rename`) require `confirm` to
+        match `app_name` exactly — guards against prompt-injected
+        deletions.
 
         Args:
             action: One of 'create', 'delete', 'copy', 'rename', 'start', 'stop'.
@@ -658,7 +663,9 @@ def register_tools(mcp: FastMCP):
             db_name: Database name (required for create — creates the app with this initial database).
             db_type: Database type for create: 'BSO' (block storage, default) or 'ASO' (aggregate storage).
             new_name: New name for copy or rename actions.
+            confirm: For destructive actions only: must equal `app_name`.
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -674,6 +681,10 @@ def register_tools(mcp: FastMCP):
                 })
                 return fmt(result)
             elif action == 'delete':
+                msg = require_confirm(app_name, confirm,
+                                       action_label='delete application')
+                if msg:
+                    return err(msg)
                 a.delete_application(app_name)
                 return json.dumps({'status': 'deleted',
                                    'application': app_name})
@@ -686,6 +697,10 @@ def register_tools(mcp: FastMCP):
             elif action == 'rename':
                 if not new_name:
                     return err('new_name required for rename.')
+                msg = require_confirm(app_name, confirm,
+                                       action_label='rename application')
+                if msg:
+                    return err(msg)
                 result = a.rename_application({
                     'oldAppName': app_name, 'newAppName': new_name})
                 return fmt(result)
@@ -1565,8 +1580,12 @@ def register_tools(mcp: FastMCP):
                                  new_name: str = None,
                                  target_app: str = None,
                                  target_db: str = None,
+                                 confirm: str = None,
                                  ctx: Context = None) -> str:
         """Manage databases within an Essbase application: delete, copy, or rename.
+
+        Destructive actions (`delete`) require `confirm` to match
+        `db_name` exactly — guards against prompt-injected deletions.
 
         Args:
             action: One of 'delete', 'copy', 'rename', 'update'.
@@ -1575,13 +1594,19 @@ def register_tools(mcp: FastMCP):
             new_name: New database name (required for rename).
             target_app: Target application name (required for copy).
             target_db: Target database name (required for copy).
+            confirm: For delete only: must equal `db_name`.
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
         try:
             a = ess.applications
             if action == 'delete':
+                msg = require_confirm(db_name, confirm,
+                                       action_label='delete database')
+                if msg:
+                    return err(msg)
                 a.delete_database(app_name, db_name)
                 return json.dumps({'status': 'deleted',
                                    'application': app_name,
@@ -1626,8 +1651,12 @@ def register_tools(mcp: FastMCP):
                               password: str = None,
                               role: str = None,
                               app_name: str = None,
+                              confirm: str = None,
                               ctx: Context = None) -> str:
         """Manage Essbase users: list, get details, create, update, delete, provision, deprovision roles, or list roles.
+
+        Destructive actions (`delete`) require `confirm` to match
+        `user_id` exactly — guards against prompt-injected deletions.
 
         Args:
             action: One of 'list', 'get', 'create', 'update', 'delete', 'provision', 'deprovision', 'list_roles', 'list_service_roles', 'list_app_roles'.
@@ -1635,7 +1664,9 @@ def register_tools(mcp: FastMCP):
             password: Password (required for create).
             role: Role name (required for provision, e.g. 'service_administrator', 'power_user').
             app_name: Application name (for app-level provisioning; omit for service-level).
+            confirm: For delete only: must equal `user_id`.
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -1674,6 +1705,10 @@ def register_tools(mcp: FastMCP):
             elif action == 'delete':
                 if not user_id:
                     return err('user_id required for delete.')
+                msg = require_confirm(user_id, confirm,
+                                       action_label='delete user')
+                if msg:
+                    return err(msg)
                 u.delete_user(user_id)
                 return json.dumps({'status': 'deleted',
                                    'user': user_id})
@@ -1846,13 +1881,20 @@ def register_tools(mcp: FastMCP):
     @mcp.tool()
     def essbase_manage_sessions(action: str = 'list',
                                   session_id: str = None,
+                                  confirm: str = None,
                                   ctx: Context = None) -> str:
         """Manage Essbase sessions: list active sessions, get current session, kill a session, or kill all sessions.
+
+        Destructive actions (`kill`, `kill_all`) require `confirm`:
+          - `kill`: must equal `session_id`.
+          - `kill_all`: must equal the literal string 'all'.
 
         Args:
             action: One of 'list' (default), 'current', 'kill', 'kill_all'.
             session_id: Session ID (required for kill).
+            confirm: Confirmation token (required for kill and kill_all).
         """
+        from ._helpers import require_confirm
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -1867,11 +1909,19 @@ def register_tools(mcp: FastMCP):
             elif action == 'kill':
                 if not session_id:
                     return err('session_id required for kill.')
+                msg = require_confirm(session_id, confirm,
+                                       action_label='kill session')
+                if msg:
+                    return err(msg)
                 s.delete_session(session_id)
                 return json.dumps({'status': 'killed',
                                    'session': session_id})
 
             elif action == 'kill_all':
+                msg = require_confirm('all', confirm,
+                                       action_label='kill all sessions')
+                if msg:
+                    return err(msg)
                 s.delete_all_sessions()
                 return json.dumps({'status': 'all_sessions_killed'})
 

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/essbase_tools.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/essbase_tools.py
@@ -144,19 +144,29 @@ def register_tools(mcp: FastMCP):
     # ── 3. essbase_query ──────────────────────────────────────────────
     @mcp.tool()
     def essbase_query(app_name: str, db_name: str, mdx: str,
-                      ctx: Context) -> str:
+                      max_rows: int = 1000,
+                      ctx: Context = None) -> str:
         """Execute an MDX query and return formatted tabular results.
+
+        Results are capped at `max_rows` (default 1000). When the cap
+        fires, `truncated: true`, `original_row_count`, and `max_rows`
+        are added to the response so the caller can decide whether to
+        re-query with a tighter WHERE clause.
 
         Args:
             app_name: Application name.
             db_name: Database (cube) name.
             mdx: MDX query string.
+            max_rows: Maximum row-axis tuples to return. Default 1000.
+                Hard floor 1; values ≤0 fall back to the default.
         """
+        from ._helpers import bound_mdx_result
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
         try:
             result = ess.grid.execute_mdx(app_name, db_name, mdx)
+            result = bound_mdx_result(result, max_rows=max_rows)
             return json.dumps(result, indent=2, default=str)
         except Exception as exc:
             return err(str(exc))
@@ -599,17 +609,23 @@ def register_tools(mcp: FastMCP):
     def essbase_export_data(app_name: str, db_name: str,
                              mdx: str = None,
                              report_name: str = None,
+                             max_rows: int = 1000,
                              ctx: Context = None) -> str:
         """Export data from an Essbase database.
 
-        Provide either an MDX query or a saved report name.
+        Provide either an MDX query or a saved report name. Results
+        are row-capped at `max_rows` (default 1000); when the cap
+        fires, `truncated: true` and `original_row_count` are added
+        to the response.
 
         Args:
             app_name: Application name.
             db_name: Database (cube) name.
             mdx: MDX query string.
             report_name: Name of a saved MDX report.
+            max_rows: Maximum row-axis tuples to return (default 1000).
         """
+        from ._helpers import bound_mdx_result
         ess = get_essbase(ctx)
         if not ess:
             return err(_NO)
@@ -622,6 +638,7 @@ def register_tools(mcp: FastMCP):
             else:
                 # Default: get the default grid
                 result = ess.grid.get_default_grid(app_name, db_name)
+            result = bound_mdx_result(result, max_rows=max_rows)
             return json.dumps(result, indent=2, default=str)
         except Exception as exc:
             return err(str(exc))

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/essbase_tools.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/tools/essbase_tools.py
@@ -1,0 +1,2133 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+'''Upleveled Essbase MCP tools.
+
+Each tool combines multiple SDK calls into a single task-oriented
+operation that returns an LLM-friendly result.  See TOOLS_DESIGN.md.
+'''
+
+import json
+import logging
+
+from mcp.server.fastmcp import FastMCP, Context
+
+from ._essbase_connect import get_essbase
+from ._helpers import safe_call, build_response, err, fmt
+
+logger = logging.getLogger('oracle-data-studio-mcp')
+
+_NO = 'Essbase not connected. Set ESSBASE_URL + credentials.'
+
+
+def register_tools(mcp: FastMCP):
+
+    # ── 1. essbase_explore ────────────────────────────────────────────
+    @mcp.tool()
+    def essbase_explore(ctx: Context) -> str:
+        """Get a full overview of the Essbase server: applications, their databases, status, sizes, and settings.
+
+        Combines list_applications + list_databases + get_statistics + get_settings per app.
+        This is the starting point for any Essbase task.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            apps_data = ess.applications.list_applications()
+            apps = apps_data.get('items', [])
+            errors = []
+            result = []
+            for app in apps:
+                name = app.get('name', '')
+                entry = {'application': app}
+
+                dbs, e = safe_call(f'{name}/databases',
+                                   ess.applications.list_databases, name)
+                if dbs:
+                    entry['databases'] = dbs.get('items', dbs)
+                if e:
+                    errors.append(e)
+
+                stats, e = safe_call(f'{name}/statistics',
+                                     ess.applications.get_statistics, name)
+                if stats:
+                    entry['statistics'] = stats
+                if e:
+                    errors.append(e)
+
+                settings, e = safe_call(f'{name}/settings',
+                                        ess.applications.get_settings, name)
+                if settings:
+                    entry['settings'] = settings
+                if e:
+                    errors.append(e)
+
+                result.append(entry)
+
+            return build_response(
+                {'applications': result, 'count': len(result)},
+                errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 2. essbase_describe_database ──────────────────────────────────
+    @mcp.tool()
+    def essbase_describe_database(app_name: str, db_name: str,
+                                  ctx: Context) -> str:
+        """Get a complete database profile: dimensions with member counts, storage type (BSO/ASO), settings, statistics, and substitution variables.
+
+        Args:
+            app_name: Application name.
+            db_name: Database (cube) name.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            errors = []
+            data = {}
+
+            db, e = safe_call('database',
+                              ess.applications.get_database,
+                              app_name, db_name)
+            if db:
+                data['database'] = db
+            if e:
+                errors.append(e)
+
+            dims, e = safe_call('dimensions',
+                                ess.dimensions.list_dimensions,
+                                app_name, db_name)
+            if dims:
+                data['dimensions'] = dims.get('items', dims)
+            if e:
+                errors.append(e)
+
+            settings, e = safe_call('settings',
+                                    ess.database_settings.get_settings,
+                                    app_name, db_name)
+            if settings:
+                data['settings'] = settings
+            if e:
+                errors.append(e)
+
+            stats, e = safe_call('statistics',
+                                 ess.database_settings.get_statistics,
+                                 app_name, db_name)
+            if stats:
+                data['statistics'] = stats
+            if e:
+                errors.append(e)
+
+            storage, e = safe_call('storage',
+                                   ess.database_settings.get_storage_statistics,
+                                   app_name, db_name)
+            if storage:
+                data['storage'] = storage
+            if e:
+                errors.append(e)
+
+            vars_data, e = safe_call('variables',
+                                     ess.variables.list_db_variables,
+                                     app_name, db_name)
+            if vars_data:
+                data['variables'] = vars_data.get('items', vars_data)
+            if e:
+                errors.append(e)
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 3. essbase_query ──────────────────────────────────────────────
+    @mcp.tool()
+    def essbase_query(app_name: str, db_name: str, mdx: str,
+                      ctx: Context) -> str:
+        """Execute an MDX query and return formatted tabular results.
+
+        Args:
+            app_name: Application name.
+            db_name: Database (cube) name.
+            mdx: MDX query string.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            result = ess.grid.execute_mdx(app_name, db_name, mdx)
+            return json.dumps(result, indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 4. essbase_browse_outline ─────────────────────────────────────
+    @mcp.tool()
+    def essbase_browse_outline(app_name: str, db_name: str,
+                                parent: str = None, depth: int = 2,
+                                ctx: Context = None) -> str:
+        """Browse the cube outline hierarchy.
+
+        Without a parent, returns top-level dimensions.
+        With a parent, returns children recursively up to *depth* levels.
+
+        Args:
+            app_name: Application name.
+            db_name: Database (cube) name.
+            parent: Parent member name (omit for top-level dimensions).
+            depth: How many levels deep to recurse (default 2, max 5).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            depth = min(depth, 5)
+            if parent is None:
+                outline = ess.dimensions.get_outline(app_name, db_name)
+                return json.dumps(outline, indent=2, default=str)
+
+            def _get_tree(par, lvl):
+                if lvl <= 0:
+                    return None
+                children_data = ess.dimensions.get_children(
+                    app_name, db_name, par, limit=200)
+                items = children_data.get('items',
+                            children_data.get('data', []))
+                for item in items:
+                    name = item.get('name', item.get('memberName', ''))
+                    if name and lvl > 1:
+                        sub = _get_tree(name, lvl - 1)
+                        if sub:
+                            item['children'] = sub
+                return items
+
+            tree = _get_tree(parent, depth)
+            return json.dumps({'parent': parent, 'members': tree},
+                              indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 5. essbase_search_members ─────────────────────────────────────
+    @mcp.tool()
+    def essbase_search_members(app_name: str, db_name: str,
+                                pattern: str, ctx: Context) -> str:
+        """Search for members in the cube outline and return matches with their properties and ancestors.
+
+        Args:
+            app_name: Application name.
+            db_name: Database (cube) name.
+            pattern: Search keyword or pattern.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            hits = ess.dimensions.search_members(
+                app_name, db_name, pattern, limit=50)
+            items = hits.get('items', hits.get('data', []))
+            errors = []
+            enriched = []
+            for item in items:
+                name = item.get('name', item.get('memberName', ''))
+                if name:
+                    ancestors, e = safe_call(
+                        f'ancestors/{name}',
+                        ess.dimensions.get_member_ancestors,
+                        app_name, db_name, name)
+                    if ancestors:
+                        item['ancestors'] = ancestors
+                    if e:
+                        errors.append(e)
+                enriched.append(item)
+            return build_response(
+                {'matches': enriched, 'count': len(enriched)},
+                errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 6. essbase_run_calculation ────────────────────────────────────
+    @mcp.tool()
+    def essbase_run_calculation(app_name: str, db_name: str,
+                                 script_name: str = None,
+                                 calc_script: str = None,
+                                 ctx: Context = None) -> str:
+        """Run a calculation on an Essbase database — fire-and-forget with automatic wait.
+
+        Provide either a saved script name OR inline calc script text.
+        Automatically waits for completion and returns the final status.
+        On failure, includes the relevant log excerpt.
+
+        Args:
+            app_name: Application name.
+            db_name: Database (cube) name.
+            script_name: Name of a saved calc script (e.g. 'CalcAll').
+            calc_script: Inline calc script text (e.g. 'CALC ALL;').
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        if not script_name and not calc_script:
+            return err('Provide either script_name or calc_script.')
+        try:
+            payload = {
+                'jobtype': 'calc',
+                'application': app_name,
+                'db': db_name,
+                'parameters': {}
+            }
+            if script_name:
+                payload['parameters']['file'] = script_name
+            else:
+                payload['parameters']['script'] = calc_script
+
+            job = ess.jobs.execute(payload)
+            job_id = job.get('id', job.get('jobID'))
+            result = ess.jobs.wait_for_completion(job_id)
+
+            # On failure, try to get the log
+            if result.get('statusCode') == 400:
+                log, _ = safe_call('log',
+                                   ess.applications.get_latest_log,
+                                   app_name)
+                if log:
+                    if isinstance(log, bytes):
+                        log = log.decode('utf-8', errors='replace')
+                    # Return last 2000 chars of log
+                    result['log_excerpt'] = log[-2000:]
+
+            return json.dumps(result, indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 7. essbase_load_data ──────────────────────────────────────────
+    @mcp.tool()
+    def essbase_load_data(app_name: str, db_name: str,
+                           rule_file: str = None,
+                           data_file: str = None,
+                           ctx: Context = None) -> str:
+        """Load data into an Essbase database.
+
+        Executes a dataload job and waits for completion.
+
+        Args:
+            app_name: Application name.
+            db_name: Database (cube) name.
+            rule_file: Rules file name (optional).
+            data_file: Data file name (optional).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            payload = {
+                'jobtype': 'dataload',
+                'application': app_name,
+                'db': db_name,
+                'parameters': {}
+            }
+            if rule_file:
+                payload['parameters']['rule'] = rule_file
+            if data_file:
+                payload['parameters']['file'] = data_file
+
+            job = ess.jobs.execute(payload)
+            job_id = job.get('id', job.get('jobID'))
+            result = ess.jobs.wait_for_completion(job_id)
+            return json.dumps(result, indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 8. essbase_deploy_workbook ────────────────────────────────────
+    @mcp.tool()
+    def essbase_deploy_workbook(app_name: str, file_path: str,
+                                 ctx: Context) -> str:
+        """Import an Excel workbook to create or update an Essbase cube.
+
+        Uploads the file if needed, then runs an importExcel job and
+        waits for completion.  Returns the created application/database info.
+
+        Args:
+            app_name: Application name to create or update.
+            file_path: Server-side file path to the Excel workbook.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            payload = {
+                'jobtype': 'importExcel',
+                'application': app_name,
+                'parameters': {
+                    'file': file_path
+                }
+            }
+            job = ess.jobs.execute(payload)
+            job_id = job.get('id', job.get('jobID'))
+            result = ess.jobs.wait_for_completion(job_id)
+
+            # If success, get the created app info
+            if result.get('statusCode') in (200, 300):
+                app_info, _ = safe_call('app_info',
+                                        ess.applications.get_application,
+                                        app_name)
+                if app_info:
+                    result['application'] = app_info
+
+            return json.dumps(result, indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 9. essbase_manage_variables ───────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_variables(action: str, scope: str,
+                                  app_name: str = None,
+                                  db_name: str = None,
+                                  variable_name: str = None,
+                                  value: str = None,
+                                  ctx: Context = None) -> str:
+        """Manage Essbase substitution variables at any scope.
+
+        Args:
+            action: One of 'list', 'get', 'set', 'delete'.
+            scope: One of 'server', 'application', 'database'.
+            app_name: Application name (required for app/db scope).
+            db_name: Database name (required for db scope).
+            variable_name: Variable name (required for get/set/delete).
+            value: Variable value (required for set).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            v = ess.variables
+            if action == 'list':
+                if scope == 'server':
+                    return fmt(v.list_server_variables())
+                elif scope == 'application':
+                    return fmt(v.list_app_variables(app_name))
+                else:
+                    return fmt(v.list_db_variables(app_name, db_name))
+            elif action == 'get':
+                if scope == 'server':
+                    return fmt(v.get_server_variable(variable_name))
+                elif scope == 'application':
+                    return fmt(v.get_app_variable(app_name, variable_name))
+                else:
+                    return fmt(v.get_db_variable(
+                        app_name, db_name, variable_name))
+            elif action == 'set':
+                payload = {'name': variable_name, 'value': value}
+                # Try update first, create on failure
+                try:
+                    if scope == 'server':
+                        return fmt(v.update_server_variable(
+                            variable_name, payload))
+                    elif scope == 'application':
+                        return fmt(v.update_app_variable(
+                            app_name, variable_name, payload))
+                    else:
+                        return fmt(v.update_db_variable(
+                            app_name, db_name, variable_name, payload))
+                except Exception:
+                    if scope == 'server':
+                        return fmt(v.create_server_variable(payload))
+                    elif scope == 'application':
+                        return fmt(v.create_app_variable(app_name, payload))
+                    else:
+                        return fmt(v.create_db_variable(
+                            app_name, db_name, payload))
+            elif action == 'delete':
+                if scope == 'server':
+                    v.delete_server_variable(variable_name)
+                elif scope == 'application':
+                    v.delete_app_variable(app_name, variable_name)
+                else:
+                    v.delete_db_variable(app_name, db_name, variable_name)
+                return json.dumps({'status': 'deleted',
+                                   'variable': variable_name})
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/get/set/delete.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 10. essbase_get_script ────────────────────────────────────────
+    @mcp.tool()
+    def essbase_get_script(app_name: str, db_name: str,
+                            script_name: str, ctx: Context) -> str:
+        """Get a script's content along with its validation status.
+
+        Args:
+            app_name: Application name.
+            db_name: Database (cube) name.
+            script_name: Script name.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            errors = []
+            data = {}
+            content, e = safe_call('content',
+                                   ess.scripts.get_script_content,
+                                   app_name, db_name, script_name)
+            if content is not None:
+                data['content'] = content
+            if e:
+                errors.append(e)
+
+            validation, e = safe_call(
+                'validate',
+                ess.scripts.validate_script,
+                app_name, db_name,
+                {'name': script_name})
+            if validation:
+                data['validation'] = validation
+            if e:
+                errors.append(e)
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 11. essbase_manage_security ───────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_security(username: str = None,
+                                 group_name: str = None,
+                                 ctx: Context = None) -> str:
+        """Get the complete security profile for a user or group.
+
+        Returns service roles, application roles, filters, and group memberships.
+        Provide either username OR group_name.
+
+        Args:
+            username: User to look up (provide this or group_name).
+            group_name: Group to look up (provide this or username).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        if not username and not group_name:
+            return err('Provide either username or group_name.')
+        try:
+            errors = []
+            data = {}
+            if username:
+                user, e = safe_call('user', ess.users.get_user, username)
+                if user:
+                    data['user'] = user
+                if e:
+                    errors.append(e)
+
+                prov, e = safe_call(
+                    'provisioning',
+                    ess.users.get_user_provisioning_report, username)
+                if prov:
+                    data['provisioning'] = prov
+                if e:
+                    errors.append(e)
+            else:
+                group, e = safe_call('group', ess.groups.get_group,
+                                     group_name)
+                if group:
+                    data['group'] = group
+                if e:
+                    errors.append(e)
+
+                prov, e = safe_call(
+                    'provisioning',
+                    ess.groups.get_group_provisioning_report,
+                    group_name)
+                if prov:
+                    data['provisioning'] = prov
+                if e:
+                    errors.append(e)
+
+                members, e = safe_call(
+                    'members',
+                    ess.groups.get_group_members, group_name)
+                if members:
+                    data['members'] = members
+                if e:
+                    errors.append(e)
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 12. essbase_server_health ─────────────────────────────────────
+    @mcp.tool()
+    def essbase_server_health(ctx: Context) -> str:
+        """Quick Essbase server health check: version, instance config, active sessions, locked objects.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            errors = []
+            data = {}
+
+            about, e = safe_call('about', ess.about.get)
+            if about:
+                data['about'] = about
+            if e:
+                errors.append(e)
+
+            instance, e = safe_call('instance', ess.about.get_instance)
+            if instance:
+                data['instance'] = instance
+            if e:
+                errors.append(e)
+
+            sessions, e = safe_call('sessions',
+                                    ess.sessions.list_sessions)
+            if sessions:
+                if isinstance(sessions, list):
+                    data['active_sessions'] = len(sessions)
+                    data['sessions'] = sessions
+                else:
+                    data['sessions'] = sessions
+            if e:
+                errors.append(e)
+
+            return build_response(data, errors or None)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 13. essbase_export_data ───────────────────────────────────────
+    @mcp.tool()
+    def essbase_export_data(app_name: str, db_name: str,
+                             mdx: str = None,
+                             report_name: str = None,
+                             ctx: Context = None) -> str:
+        """Export data from an Essbase database.
+
+        Provide either an MDX query or a saved report name.
+
+        Args:
+            app_name: Application name.
+            db_name: Database (cube) name.
+            mdx: MDX query string.
+            report_name: Name of a saved MDX report.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            if mdx:
+                result = ess.grid.execute_mdx(app_name, db_name, mdx)
+            elif report_name:
+                result = ess.grid.execute_mdx_report(
+                    app_name, db_name, report_name)
+            else:
+                # Default: get the default grid
+                result = ess.grid.get_default_grid(app_name, db_name)
+            return json.dumps(result, indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 14. essbase_manage_application ─────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_application(action: str, app_name: str,
+                                    db_name: str = None,
+                                    db_type: str = 'BSO',
+                                    new_name: str = None,
+                                    ctx: Context = None) -> str:
+        """Create, delete, copy, rename, start, or stop an Essbase application.
+
+        Args:
+            action: One of 'create', 'delete', 'copy', 'rename', 'start', 'stop'.
+            app_name: Application name (for all actions).
+            db_name: Database name (required for create — creates the app with this initial database).
+            db_type: Database type for create: 'BSO' (block storage, default) or 'ASO' (aggregate storage).
+            new_name: New name for copy or rename actions.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            a = ess.applications
+            if action == 'create':
+                if not db_name:
+                    return err('db_name required for create.')
+                result = a.create_application({
+                    'applicationName': app_name,
+                    'databaseName': db_name,
+                    'databaseType': db_type,
+                })
+                return fmt(result)
+            elif action == 'delete':
+                a.delete_application(app_name)
+                return json.dumps({'status': 'deleted',
+                                   'application': app_name})
+            elif action == 'copy':
+                if not new_name:
+                    return err('new_name required for copy.')
+                result = a.copy_application({
+                    'from': app_name, 'to': new_name})
+                return fmt(result)
+            elif action == 'rename':
+                if not new_name:
+                    return err('new_name required for rename.')
+                result = a.rename_application({
+                    'oldAppName': app_name, 'newAppName': new_name})
+                return fmt(result)
+            elif action == 'start':
+                a.update_application(app_name, {'status': 1})
+                return json.dumps({'status': 'started',
+                                   'application': app_name})
+            elif action == 'stop':
+                a.update_application(app_name, {'status': 0})
+                return json.dumps({'status': 'stopped',
+                                   'application': app_name})
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use create/delete/copy/rename/start/stop.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 15. essbase_manage_script ──────────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_script(action: str, app_name: str,
+                               db_name: str,
+                               script_name: str,
+                               content: str = None,
+                               new_name: str = None,
+                               ctx: Context = None) -> str:
+        """Manage calc scripts: list, create, update, delete, or validate.
+
+        Use 'create' to have the LLM write new calc scripts. Automatically
+        validates after create/update.
+
+        Args:
+            action: One of 'list', 'create', 'update', 'delete', 'validate'.
+            app_name: Application name.
+            db_name: Database (cube) name.
+            script_name: Script name (ignored for 'list').
+            content: Calc script text (required for create/update, e.g. 'CALC ALL;').
+            new_name: New name for rename (optional with 'update').
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            s = ess.scripts
+            if action == 'list':
+                result = s.list_scripts(app_name, db_name)
+                return fmt(result)
+
+            elif action == 'create':
+                if not content:
+                    return err('content required for create.')
+                result = s.create_script(app_name, db_name, {
+                    'name': script_name, 'content': content})
+                errors = []
+                data = {'action': 'created', 'script': result}
+                # Auto-validate
+                val, e = safe_call('validate', s.validate_script,
+                                   app_name, db_name,
+                                   {'name': script_name})
+                if val:
+                    data['validation'] = val
+                if e:
+                    errors.append(e)
+                return build_response(data, errors or None)
+
+            elif action == 'update':
+                payload = {'name': script_name, 'content': content}
+                if new_name:
+                    # Rename first, then update content
+                    s.rename_script(app_name, db_name, {
+                        'oldName': script_name, 'newName': new_name})
+                    script_name = new_name
+                    payload['name'] = new_name
+                if content:
+                    result = s.update_script(app_name, db_name,
+                                             script_name, payload)
+                    errors = []
+                    data = {'action': 'updated', 'script': result}
+                    val, e = safe_call('validate', s.validate_script,
+                                       app_name, db_name,
+                                       {'name': script_name})
+                    if val:
+                        data['validation'] = val
+                    if e:
+                        errors.append(e)
+                    return build_response(data, errors or None)
+                return json.dumps({'action': 'renamed',
+                                   'old_name': script_name,
+                                   'new_name': new_name})
+
+            elif action == 'delete':
+                s.delete_script(app_name, db_name, script_name)
+                return json.dumps({'status': 'deleted',
+                                   'script': script_name})
+
+            elif action == 'validate':
+                result = s.validate_script(app_name, db_name,
+                                           {'name': script_name})
+                return fmt(result)
+
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/create/update/delete/validate.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 16. essbase_manage_files ───────────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_files(action: str, path: str = None,
+                              target_path: str = None,
+                              content: str = None,
+                              ctx: Context = None) -> str:
+        """Manage files in the Essbase file catalog: list, upload, download, copy, move, delete, create_folder.
+
+        Paths use the catalog format: 'applications/Sample/Basic/data.csv',
+        'shared/uploads/', etc.
+
+        Args:
+            action: One of 'list', 'download', 'upload', 'copy', 'move', 'delete', 'create_folder'.
+            path: File or folder path in the catalog (e.g. 'applications/Sample').
+            target_path: Destination path (required for copy/move).
+            content: Text content to upload (required for upload, e.g. data file contents or rule file).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            f = ess.files
+            if action == 'list':
+                if path:
+                    result = f.list_files(path)
+                else:
+                    result = f.list_root()
+                return fmt(result)
+
+            elif action == 'download':
+                if not path:
+                    return err('path required for download.')
+                data = f.download(path)
+                if isinstance(data, bytes):
+                    # Return metadata about the download
+                    return json.dumps({
+                        'path': path,
+                        'size_bytes': len(data),
+                        'preview': data[:500].decode(
+                            'utf-8', errors='replace')
+                    })
+                return fmt(data)
+
+            elif action == 'copy':
+                if not path or not target_path:
+                    return err('path and target_path required for copy.')
+                result = f.copy(path, target_path)
+                return fmt(result)
+
+            elif action == 'move':
+                if not path or not target_path:
+                    return err('path and target_path required for move.')
+                result = f.move(path, target_path)
+                return fmt(result)
+
+            elif action == 'delete':
+                if not path:
+                    return err('path required for delete.')
+                f.delete_file(path)
+                return json.dumps({'status': 'deleted', 'path': path})
+
+            elif action == 'upload':
+                if not path:
+                    return err('path required for upload.')
+                if not content:
+                    return err('content required for upload.')
+                result = f.upload(path, content.encode('utf-8'))
+                return fmt(result) if result else json.dumps(
+                    {'status': 'uploaded', 'path': path})
+
+            elif action == 'create_folder':
+                if not path:
+                    return err('path required for create_folder.')
+                result = f.create_folder(path)
+                return fmt(result) if result else json.dumps(
+                    {'status': 'created', 'path': path})
+
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/download/upload/copy/move/delete/'
+                           f'create_folder.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 17. essbase_manage_connections ──────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_connections(action: str,
+                                    connection_name: str = None,
+                                    host: str = None,
+                                    port: int = None,
+                                    service_name: str = None,
+                                    user: str = None,
+                                    password: str = None,
+                                    db_type: str = 'oracle',
+                                    ctx: Context = None) -> str:
+        """Manage Essbase global connections: list, get, create, update, test, or delete.
+
+        Connections define data sources for data loads, drill-through,
+        and datasource operations.
+
+        Args:
+            action: One of 'list', 'get', 'create', 'update', 'test', 'delete'.
+            connection_name: Connection name (required for get/create/update/test/delete).
+            host: Database hostname (required for create).
+            port: Database port (required for create, e.g. 1521).
+            service_name: Database service name (required for create).
+            user: Database username (required for create).
+            password: Database password (required for create).
+            db_type: Connection type: 'oracle' (default), 'sql_server', 'db2'.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            c = ess.connections
+            if action == 'list':
+                result = c.list_connections()
+                return fmt(result)
+
+            elif action == 'get':
+                if not connection_name:
+                    return err('connection_name required.')
+                result = c.get_connection(connection_name)
+                return fmt(result)
+
+            elif action == 'create':
+                if not all([connection_name, host, port, service_name,
+                            user, password]):
+                    return err('create requires: connection_name, host, '
+                               'port, service_name, user, password.')
+                payload = {
+                    'name': connection_name,
+                    'type': db_type,
+                    'host': host,
+                    'port': port,
+                    'serviceName': service_name,
+                    'user': user,
+                    'password': password,
+                }
+                result = c.create_connection(payload)
+                # Auto-test after create
+                errors = []
+                data = {'action': 'created', 'connection': result}
+                test, e = safe_call('test', c.test_saved_connection,
+                                    connection_name)
+                if test:
+                    data['test_result'] = test
+                if e:
+                    errors.append(e)
+                return build_response(data, errors or None)
+
+            elif action == 'test':
+                if not connection_name:
+                    return err('connection_name required.')
+                result = c.test_saved_connection(connection_name)
+                return fmt(result)
+
+            elif action == 'update':
+                if not connection_name:
+                    return err('connection_name required for update.')
+                if not any([host, port, service_name, user, password]):
+                    return err('update requires at least one of: host, '
+                               'port, service_name, user, password.')
+                payload = {}
+                if host:
+                    payload['host'] = host
+                if port:
+                    payload['port'] = port
+                if service_name:
+                    payload['serviceName'] = service_name
+                if user:
+                    payload['user'] = user
+                if password:
+                    payload['password'] = password
+                result = c.update_connection(connection_name, payload)
+                return fmt(result)
+
+            elif action == 'delete':
+                if not connection_name:
+                    return err('connection_name required.')
+                c.delete_connection(connection_name)
+                return json.dumps({'status': 'deleted',
+                                   'connection': connection_name})
+
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/get/create/update/test/delete.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 18. essbase_manage_locks ───────────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_locks(app_name: str, db_name: str,
+                              action: str = 'list',
+                              object_name: str = None,
+                              ctx: Context = None) -> str:
+        """View and manage locks on an Essbase database.
+
+        Lists all locks, locked objects, and locked data blocks.
+        Can unlock a specific object to resolve blocked operations.
+
+        Args:
+            action: One of 'list' (default), 'unlock'.
+            app_name: Application name.
+            db_name: Database (cube) name.
+            object_name: Object name to unlock (required for unlock).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            lk = ess.locks
+            if action == 'list':
+                errors = []
+                data = {}
+
+                locks, e = safe_call('locks', lk.list_locks,
+                                     app_name, db_name)
+                if locks:
+                    data['locks'] = locks
+                if e:
+                    errors.append(e)
+
+                objects, e = safe_call('locked_objects',
+                                       lk.list_locked_objects,
+                                       app_name, db_name)
+                if objects:
+                    data['locked_objects'] = objects
+                if e:
+                    errors.append(e)
+
+                blocks, e = safe_call('locked_blocks',
+                                      lk.list_locked_blocks,
+                                      app_name, db_name)
+                if blocks:
+                    data['locked_blocks'] = blocks
+                if e:
+                    errors.append(e)
+
+                return build_response(data, errors or None)
+
+            elif action == 'unlock':
+                if not object_name:
+                    return err('object_name required for unlock.')
+                result = lk.unlock_object(app_name, db_name,
+                                          {'name': object_name})
+                return fmt(result)
+
+            else:
+                return err(f'Unknown action: {action}. Use list/unlock.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 19. essbase_manage_filters ─────────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_filters(action: str, app_name: str,
+                                db_name: str,
+                                filter_name: str = None,
+                                filter_rows: str = None,
+                                user_or_group: str = None,
+                                access: str = 'read',
+                                new_name: str = None,
+                                ctx: Context = None) -> str:
+        """Manage security filters for row-level access control on an Essbase database.
+
+        Filters define which data intersections specific users or groups
+        can read or write.
+
+        Args:
+            action: One of 'list', 'get', 'create', 'update', 'copy', 'rename', 'delete', 'assign'.
+            app_name: Application name.
+            db_name: Database (cube) name.
+            filter_name: Filter name (required for get/create/update/copy/rename/delete/assign).
+            filter_rows: Comma-separated filter row definitions for create/update. Each row is 'access_type, member_spec' (e.g. 'READ, @IDESCENDANTS(East); WRITE, @IDESCENDANTS(West)').
+            user_or_group: User or group name to assign the filter to (required for assign).
+            access: Access type for simple filter creation: 'read' (default), 'write', 'none', 'metaread'.
+            new_name: New filter name (required for copy/rename).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            fl = ess.filters
+            if action == 'list':
+                result = fl.list_filters(app_name, db_name)
+                return fmt(result)
+
+            elif action == 'get':
+                if not filter_name:
+                    return err('filter_name required.')
+                errors = []
+                data = {}
+                filt, e = safe_call('filter', fl.get_filter,
+                                    app_name, db_name, filter_name)
+                if filt:
+                    data['filter'] = filt
+                if e:
+                    errors.append(e)
+                rows, e = safe_call('rows', fl.get_filter_rows,
+                                    app_name, db_name, filter_name)
+                if rows:
+                    data['rows'] = rows
+                if e:
+                    errors.append(e)
+                perms, e = safe_call('permissions',
+                                     fl.get_permissions,
+                                     app_name, db_name, filter_name)
+                if perms:
+                    data['permissions'] = perms
+                if e:
+                    errors.append(e)
+                return build_response(data, errors or None)
+
+            elif action == 'create':
+                if not filter_name:
+                    return err('filter_name required for create.')
+                # Build filter rows from the string
+                rows = []
+                if filter_rows:
+                    for row_def in filter_rows.split(';'):
+                        row_def = row_def.strip()
+                        if ',' in row_def:
+                            acc, member = row_def.split(',', 1)
+                            rows.append({
+                                'access': acc.strip().upper(),
+                                'member': member.strip()
+                            })
+                if not rows:
+                    rows = [{'access': access.upper(),
+                             'member': '@ALL'}]
+                payload = {'name': filter_name, 'rows': rows}
+                result = fl.create_filter(app_name, db_name, payload)
+                # Auto-validate
+                errors = []
+                data = {'action': 'created', 'filter': result}
+                val, e = safe_call('validate', fl.validate_filter,
+                                   app_name, db_name, payload)
+                if val:
+                    data['validation'] = val
+                if e:
+                    errors.append(e)
+                return build_response(data, errors or None)
+
+            elif action == 'update':
+                if not filter_name:
+                    return err('filter_name required for update.')
+                if not filter_rows:
+                    return err('filter_rows required for update.')
+                rows_list = []
+                for row_def in filter_rows.split(';'):
+                    row_def = row_def.strip()
+                    if ',' in row_def:
+                        acc, member = row_def.split(',', 1)
+                        rows_list.append({
+                            'access': acc.strip().upper(),
+                            'member': member.strip()
+                        })
+                result = fl.update_filter(
+                    app_name, db_name, filter_name,
+                    {'rows': rows_list})
+                # Auto-validate after update
+                errors = []
+                data = {'action': 'updated', 'filter': result}
+                val, e = safe_call('validate', fl.validate_filter,
+                                   app_name, db_name,
+                                   {'name': filter_name,
+                                    'rows': rows_list})
+                if val:
+                    data['validation'] = val
+                if e:
+                    errors.append(e)
+                return build_response(data, errors or None)
+
+            elif action == 'copy':
+                if not filter_name:
+                    return err('filter_name required for copy.')
+                if not new_name:
+                    return err('new_name required for copy.')
+                result = fl.copy_filter(
+                    app_name, db_name,
+                    {'from': filter_name, 'to': new_name})
+                return fmt(result)
+
+            elif action == 'rename':
+                if not filter_name:
+                    return err('filter_name required for rename.')
+                if not new_name:
+                    return err('new_name required for rename.')
+                result = fl.rename_filter(
+                    app_name, db_name,
+                    {'oldName': filter_name, 'newName': new_name})
+                return fmt(result)
+
+            elif action == 'delete':
+                if not filter_name:
+                    return err('filter_name required for delete.')
+                fl.delete_filter(app_name, db_name, filter_name)
+                return json.dumps({'status': 'deleted',
+                                   'filter': filter_name})
+
+            elif action == 'assign':
+                if not filter_name or not user_or_group:
+                    return err('filter_name and user_or_group required '
+                               'for assign.')
+                result = fl.add_permissions(
+                    app_name, db_name, filter_name,
+                    {'userOrGroup': user_or_group})
+                return fmt(result)
+
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/get/create/update/copy/rename/'
+                           f'delete/assign.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 20. essbase_manage_jobs ────────────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_jobs(action: str = 'list',
+                             job_id: int = None,
+                             limit: int = 50,
+                             ctx: Context = None) -> str:
+        """Monitor and manage Essbase jobs: list recent jobs, check status, or rerun a failed job.
+
+        Status codes: 100=in progress, 200=completed, 300=completed with warnings, 400=failed.
+
+        Args:
+            action: One of 'list' (default), 'status', 'rerun', 'purge'.
+            job_id: Job ID (required for status/rerun).
+            limit: Maximum jobs to return for list (default 50).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            j = ess.jobs
+            if action == 'list':
+                result = j.list_jobs(limit=limit)
+                return fmt(result)
+
+            elif action == 'status':
+                if not job_id:
+                    return err('job_id required for status.')
+                result = j.get_status(job_id)
+                return fmt(result)
+
+            elif action == 'rerun':
+                if not job_id:
+                    return err('job_id required for rerun.')
+                result = j.rerun(job_id)
+                new_id = result.get('id', result.get('jobID'))
+                data = {'action': 'rerun', 'original_job': job_id,
+                        'new_job': result}
+                # Wait for the new job
+                if new_id:
+                    final = j.wait_for_completion(new_id)
+                    data['final_status'] = final
+                return json.dumps(data, indent=2, default=str)
+
+            elif action == 'purge':
+                j.purge()
+                return json.dumps({'status': 'purged'})
+
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/status/rerun/purge.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── essbase_edit_outline ──────────────────────────────────────────
+    @mcp.tool()
+    def essbase_edit_outline(app_name: str, db_name: str,
+                              action: str,
+                              member_name: str,
+                              parent_name: str = None,
+                              new_name: str = None,
+                              formula: str = None,
+                              consolidation: str = None,
+                              data_storage: str = None,
+                              alias_table: str = 'Default',
+                              alias_value: str = None,
+                              uda_value: str = None,
+                              ctx: Context = None) -> str:
+        """Edit the cube outline: add, remove, move, or rename members and set properties.
+
+        Wraps Essbase Batch Outline Edit (BOE) into explicit parameters.
+        Multiple edits can be chained by calling this tool repeatedly.
+
+        Args:
+            app_name: Application name.
+            db_name: Database (cube) name.
+            action: One of 'add', 'remove', 'move', 'rename', 'set_formula', 'set_alias', 'set_uda'.
+            member_name: Member to act on (or new member name for 'add').
+            parent_name: Parent member (required for 'add' and 'move').
+            new_name: New name (required for 'rename').
+            formula: Member formula (for 'set_formula', or optionally with 'add').
+            consolidation: Consolidation operator: '+', '-', '*', '/', '~' (optional for 'add').
+            data_storage: Storage type: 'storeData', 'dynamicCalc', 'dynamicCalcAndStore', 'neverShare', 'labelOnly', 'sharedMember' (optional for 'add').
+            alias_table: Alias table name (default 'Default', used with 'set_alias' or 'add').
+            alias_value: Alias value (for 'set_alias', or optionally with 'add').
+            uda_value: User-Defined Attribute value (for 'set_uda').
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            edit_actions = []
+
+            if action == 'add':
+                if not parent_name:
+                    return err('parent_name required for add.')
+                entry = {'actionType': 'addMember',
+                         'parentName': parent_name,
+                         'memberName': member_name}
+                if consolidation:
+                    entry['consolidation'] = consolidation
+                if data_storage:
+                    entry['dataStorage'] = data_storage
+                edit_actions.append(entry)
+                # Optionally set formula
+                if formula:
+                    edit_actions.append({
+                        'actionType': 'setFormula',
+                        'memberName': member_name,
+                        'formula': formula})
+                # Optionally set alias
+                if alias_value:
+                    edit_actions.append({
+                        'actionType': 'setAlias',
+                        'memberName': member_name,
+                        'aliasTable': alias_table,
+                        'alias': alias_value})
+
+            elif action == 'remove':
+                edit_actions.append({
+                    'actionType': 'removeMember',
+                    'memberName': member_name})
+
+            elif action == 'move':
+                if not parent_name:
+                    return err('parent_name required for move.')
+                edit_actions.append({
+                    'actionType': 'moveMember',
+                    'memberName': member_name,
+                    'parentName': parent_name})
+
+            elif action == 'rename':
+                if not new_name:
+                    return err('new_name required for rename.')
+                edit_actions.append({
+                    'actionType': 'renameMember',
+                    'memberName': member_name,
+                    'newName': new_name})
+
+            elif action == 'set_formula':
+                if formula is None:
+                    return err('formula required for set_formula.')
+                edit_actions.append({
+                    'actionType': 'setFormula',
+                    'memberName': member_name,
+                    'formula': formula})
+
+            elif action == 'set_alias':
+                if not alias_value:
+                    return err('alias_value required for set_alias.')
+                edit_actions.append({
+                    'actionType': 'setAlias',
+                    'memberName': member_name,
+                    'aliasTable': alias_table,
+                    'alias': alias_value})
+
+            elif action == 'set_uda':
+                if not uda_value:
+                    return err('uda_value required for set_uda.')
+                edit_actions.append({
+                    'actionType': 'setUDA',
+                    'memberName': member_name,
+                    'uda': uda_value})
+
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use add/remove/move/rename/'
+                           f'set_formula/set_alias/set_uda.')
+
+            payload = {'editActions': edit_actions}
+            result = ess.dimensions.batch_outline_edit(
+                app_name, db_name, payload)
+            data = {'action': action, 'member': member_name,
+                    'result': result}
+            return json.dumps(data, indent=2, default=str)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── essbase_manage_datasources ────────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_datasources(action: str,
+                                    datasource_name: str = None,
+                                    connection: str = None,
+                                    query: str = None,
+                                    columns: str = None,
+                                    ctx: Context = None) -> str:
+        """Manage global datasources for data loads and drill-through.
+
+        Args:
+            action: One of 'list', 'get', 'create', 'update', 'delete'.
+            datasource_name: Datasource name (required for get/create/update/delete).
+            connection: Connection name to use (for create).
+            query: SQL query for the datasource (for create).
+            columns: Comma-separated column names (for create).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            ds = ess.datasources
+
+            if action == 'list':
+                return fmt(ds.list_datasources())
+
+            elif action == 'get':
+                if not datasource_name:
+                    return err('datasource_name required for get.')
+                return fmt(ds.get_datasource(datasource_name))
+
+            elif action == 'create':
+                if not datasource_name:
+                    return err('datasource_name required for create.')
+                if not connection:
+                    return err('connection required for create.')
+                payload = {
+                    'name': datasource_name,
+                    'connection': connection,
+                }
+                if query:
+                    payload['query'] = query
+                if columns:
+                    payload['columns'] = [c.strip()
+                                          for c in columns.split(',')]
+                result = ds.create_datasource(payload)
+                return fmt(result)
+
+            elif action == 'update':
+                if not datasource_name:
+                    return err('datasource_name required for update.')
+                payload = {}
+                if connection:
+                    payload['connection'] = connection
+                if query:
+                    payload['query'] = query
+                if columns:
+                    payload['columns'] = [c.strip()
+                                          for c in columns.split(',')]
+                result = ds.update_datasource(datasource_name, payload)
+                return fmt(result)
+
+            elif action == 'delete':
+                if not datasource_name:
+                    return err('datasource_name required for delete.')
+                ds.delete_datasource(datasource_name)
+                return json.dumps({'status': 'deleted',
+                                   'datasource': datasource_name})
+
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/get/create/update/delete.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── essbase_manage_drill_through ──────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_drill_through(action: str,
+                                      app_name: str,
+                                      db_name: str,
+                                      report_name: str = None,
+                                      connection: str = None,
+                                      sql_query: str = None,
+                                      columns: str = None,
+                                      drillable_regions: str = None,
+                                      ctx: Context = None) -> str:
+        """Manage drill-through reports that link cube cells to detail data.
+
+        Args:
+            action: One of 'list', 'get', 'create', 'update', 'delete', 'execute'.
+            app_name: Application name.
+            db_name: Database name.
+            report_name: Report name (required for get/create/delete/execute).
+            connection: Connection name for external data (for create).
+            sql_query: SQL query to run on drill-through (for create).
+            columns: Comma-separated column names to display (for create).
+            drillable_regions: Comma-separated member specifications defining where drill-through is available (for create, e.g. '@IDESCENDANTS(East),@IDESCENDANTS(Sales)').
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            dt = ess.drill_through
+
+            if action == 'list':
+                return fmt(dt.list_reports(app_name, db_name))
+
+            elif action == 'get':
+                if not report_name:
+                    return err('report_name required for get.')
+                return fmt(dt.get_report(
+                    app_name, db_name, report_name))
+
+            elif action == 'create':
+                if not report_name:
+                    return err('report_name required for create.')
+                if not connection:
+                    return err('connection required for create.')
+                payload = {
+                    'name': report_name,
+                    'connection': connection,
+                }
+                if sql_query:
+                    payload['query'] = sql_query
+                if columns:
+                    payload['columns'] = [c.strip()
+                                          for c in columns.split(',')]
+                if drillable_regions:
+                    payload['drillableRegions'] = [
+                        r.strip()
+                        for r in drillable_regions.split(',')]
+                result = dt.create_report(
+                    app_name, db_name, payload)
+                return fmt(result)
+
+            elif action == 'update':
+                if not report_name:
+                    return err('report_name required for update.')
+                payload = {}
+                if connection:
+                    payload['connection'] = connection
+                if sql_query:
+                    payload['query'] = sql_query
+                if columns:
+                    payload['columns'] = [c.strip()
+                                          for c in columns.split(',')]
+                if drillable_regions:
+                    payload['drillableRegions'] = [
+                        r.strip()
+                        for r in drillable_regions.split(',')]
+                result = dt.update_report(
+                    app_name, db_name, report_name, payload)
+                return fmt(result)
+
+            elif action == 'delete':
+                if not report_name:
+                    return err('report_name required for delete.')
+                dt.delete_report(app_name, db_name, report_name)
+                return json.dumps({'status': 'deleted',
+                                   'report': report_name})
+
+            elif action == 'execute':
+                if not report_name:
+                    return err('report_name required for execute.')
+                result = dt.execute_report(
+                    app_name, db_name, report_name)
+                return fmt(result)
+
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/get/create/update/delete/execute.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 24. essbase_manage_database ────────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_database(action: str, app_name: str,
+                                 db_name: str,
+                                 new_name: str = None,
+                                 target_app: str = None,
+                                 target_db: str = None,
+                                 ctx: Context = None) -> str:
+        """Manage databases within an Essbase application: delete, copy, or rename.
+
+        Args:
+            action: One of 'delete', 'copy', 'rename', 'update'.
+            app_name: Application name.
+            db_name: Database (cube) name.
+            new_name: New database name (required for rename).
+            target_app: Target application name (required for copy).
+            target_db: Target database name (required for copy).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            a = ess.applications
+            if action == 'delete':
+                a.delete_database(app_name, db_name)
+                return json.dumps({'status': 'deleted',
+                                   'application': app_name,
+                                   'database': db_name})
+
+            elif action == 'copy':
+                if not target_app or not target_db:
+                    return err('target_app and target_db required for copy.')
+                result = a.copy_database(app_name,
+                                         {'from': db_name,
+                                          'to': target_db})
+                return fmt(result) if result else json.dumps(
+                    {'status': 'copied', 'from': db_name,
+                     'to': target_db})
+
+            elif action == 'rename':
+                if not new_name:
+                    return err('new_name required for rename.')
+                result = a.rename_database(app_name,
+                                           {'oldDbName': db_name,
+                                            'newDbName': new_name})
+                return fmt(result) if result else json.dumps(
+                    {'status': 'renamed', 'old_name': db_name,
+                     'new_name': new_name})
+
+            elif action == 'update':
+                result = a.update_database(app_name, db_name, {})
+                return fmt(result) if result else json.dumps(
+                    {'status': 'updated', 'application': app_name,
+                     'database': db_name})
+
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use delete/copy/rename/update.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 25. essbase_manage_users ───────────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_users(action: str,
+                              user_id: str = None,
+                              password: str = None,
+                              role: str = None,
+                              app_name: str = None,
+                              ctx: Context = None) -> str:
+        """Manage Essbase users: list, get details, create, update, delete, provision, deprovision roles, or list roles.
+
+        Args:
+            action: One of 'list', 'get', 'create', 'update', 'delete', 'provision', 'deprovision', 'list_roles', 'list_service_roles', 'list_app_roles'.
+            user_id: User ID (required for get/create/update/delete/provision/deprovision).
+            password: Password (required for create).
+            role: Role name (required for provision, e.g. 'service_administrator', 'power_user').
+            app_name: Application name (for app-level provisioning; omit for service-level).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            u = ess.users
+            if action == 'list':
+                return fmt(u.list_users())
+
+            elif action == 'get':
+                if not user_id:
+                    return err('user_id required for get.')
+                errors = []
+                data = {}
+                user, e = safe_call('user', u.get_user, user_id)
+                if user:
+                    data['user'] = user
+                if e:
+                    errors.append(e)
+                prov, e = safe_call('provisioning',
+                                    u.get_user_provisioning_report,
+                                    user_id)
+                if prov:
+                    data['provisioning'] = prov
+                if e:
+                    errors.append(e)
+                return build_response(data, errors or None)
+
+            elif action == 'create':
+                if not user_id or not password:
+                    return err('user_id and password required for create.')
+                result = u.create_user(
+                    {'id': user_id, 'password': password})
+                return fmt(result) if result else json.dumps(
+                    {'status': 'created', 'user': user_id})
+
+            elif action == 'delete':
+                if not user_id:
+                    return err('user_id required for delete.')
+                u.delete_user(user_id)
+                return json.dumps({'status': 'deleted',
+                                   'user': user_id})
+
+            elif action == 'provision':
+                if not user_id or not role:
+                    return err('user_id and role required for provision.')
+                if app_name:
+                    result = u.provision_app_role(
+                        app_name, user_id, {'role': role})
+                else:
+                    result = u.provision_service_role(
+                        user_id, {'role': role})
+                return fmt(result) if result else json.dumps(
+                    {'status': 'provisioned', 'user': user_id,
+                     'role': role})
+
+            elif action == 'update':
+                if not user_id:
+                    return err('user_id required for update.')
+                payload = {}
+                if password:
+                    payload['password'] = password
+                result = u.update_user(user_id, payload)
+                return fmt(result)
+
+            elif action == 'deprovision':
+                if not user_id:
+                    return err('user_id required for deprovision.')
+                if app_name:
+                    result = u.deprovision_app_role(app_name, user_id)
+                else:
+                    result = u.deprovision_service_role(user_id)
+                return fmt(result) if result else json.dumps(
+                    {'status': 'deprovisioned', 'user': user_id})
+
+            elif action == 'list_roles':
+                return fmt(u.list_roles())
+
+            elif action == 'list_service_roles':
+                return fmt(u.list_service_roles())
+
+            elif action == 'list_app_roles':
+                if not app_name:
+                    return err('app_name required for list_app_roles.')
+                return fmt(u.list_app_roles(app_name))
+
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/get/create/update/delete/provision/'
+                           f'deprovision/list_roles/list_service_roles/'
+                           f'list_app_roles.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 26. essbase_manage_groups ──────────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_groups(action: str,
+                               group_id: str = None,
+                               user_ids: str = None,
+                               ctx: Context = None) -> str:
+        """Manage Essbase groups: list, get details, create, delete, add/remove users, get users, add/remove subgroups.
+
+        Args:
+            action: One of 'list', 'get', 'create', 'delete', 'add_users', 'remove_users', 'get_users', 'add_subgroups', 'remove_subgroups'.
+            group_id: Group ID (required for get/create/delete/add_users/remove_users/get_users/add_subgroups/remove_subgroups).
+            user_ids: Comma-separated user IDs (required for add_users). For add_subgroups, comma-separated subgroup IDs.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            g = ess.groups
+            if action == 'list':
+                return fmt(g.list_groups())
+
+            elif action == 'get':
+                if not group_id:
+                    return err('group_id required for get.')
+                errors = []
+                data = {}
+                group, e = safe_call('group', g.get_group, group_id)
+                if group:
+                    data['group'] = group
+                if e:
+                    errors.append(e)
+                members, e = safe_call('members',
+                                       g.get_members, group_id)
+                if members:
+                    data['members'] = members
+                if e:
+                    errors.append(e)
+                prov, e = safe_call('provisioning',
+                                    g.get_provisioning_report,
+                                    group_id)
+                if prov:
+                    data['provisioning'] = prov
+                if e:
+                    errors.append(e)
+                return build_response(data, errors or None)
+
+            elif action == 'create':
+                if not group_id:
+                    return err('group_id required for create.')
+                result = g.create_group({'id': group_id})
+                return fmt(result) if result else json.dumps(
+                    {'status': 'created', 'group': group_id})
+
+            elif action == 'delete':
+                if not group_id:
+                    return err('group_id required for delete.')
+                g.delete_group(group_id)
+                return json.dumps({'status': 'deleted',
+                                   'group': group_id})
+
+            elif action == 'add_users':
+                if not group_id or not user_ids:
+                    return err('group_id and user_ids required '
+                               'for add_users.')
+                users = [{'id': u.strip()}
+                         for u in user_ids.split(',')]
+                result = g.add_users(group_id, users)
+                return fmt(result) if result else json.dumps(
+                    {'status': 'users_added', 'group': group_id,
+                     'users': [u['id'] for u in users]})
+
+            elif action == 'remove_users':
+                if not group_id:
+                    return err('group_id required for remove_users.')
+                result = g.remove_users(group_id)
+                return fmt(result) if result else json.dumps(
+                    {'status': 'users_removed',
+                     'group': group_id})
+
+            elif action == 'get_users':
+                if not group_id:
+                    return err('group_id required for get_users.')
+                result = g.get_users(group_id)
+                return fmt(result)
+
+            elif action == 'add_subgroups':
+                if not group_id or not user_ids:
+                    return err('group_id and user_ids (subgroup IDs) '
+                               'required for add_subgroups.')
+                subgroups = [{'id': s.strip()}
+                             for s in user_ids.split(',')]
+                result = g.add_subgroups(group_id, subgroups)
+                return fmt(result) if result else json.dumps(
+                    {'status': 'subgroups_added',
+                     'group': group_id,
+                     'subgroups': [s['id'] for s in subgroups]})
+
+            elif action == 'remove_subgroups':
+                if not group_id:
+                    return err('group_id required for remove_subgroups.')
+                result = g.remove_subgroups(group_id)
+                return fmt(result) if result else json.dumps(
+                    {'status': 'subgroups_removed',
+                     'group': group_id})
+
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/get/create/delete/add_users/'
+                           f'remove_users/get_users/add_subgroups/'
+                           f'remove_subgroups.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 27. essbase_manage_sessions ────────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_sessions(action: str = 'list',
+                                  session_id: str = None,
+                                  ctx: Context = None) -> str:
+        """Manage Essbase sessions: list active sessions, get current session, kill a session, or kill all sessions.
+
+        Args:
+            action: One of 'list' (default), 'current', 'kill', 'kill_all'.
+            session_id: Session ID (required for kill).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            s = ess.sessions
+            if action == 'list':
+                return fmt(s.list_sessions())
+
+            elif action == 'current':
+                return fmt(s.get_current_session())
+
+            elif action == 'kill':
+                if not session_id:
+                    return err('session_id required for kill.')
+                s.delete_session(session_id)
+                return json.dumps({'status': 'killed',
+                                   'session': session_id})
+
+            elif action == 'kill_all':
+                s.delete_all_sessions()
+                return json.dumps({'status': 'all_sessions_killed'})
+
+            else:
+                return err(f'Unknown action: {action}. '
+                           f'Use list/current/kill/kill_all.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 28. essbase_manage_db_settings ─────────────────────────────────
+    @mcp.tool()
+    def essbase_manage_db_settings(app_name: str, db_name: str,
+                                     category: str = 'all',
+                                     settings_json: str = None,
+                                     ctx: Context = None) -> str:
+        """Get or update detailed database settings and tuning information for performance analysis.
+
+        Retrieves configuration across multiple categories: startup, calculation,
+        cache, compression, transactions, runtime statistics, and storage statistics.
+        Use category='all' for a full snapshot or specify a single category.
+        Provide settings_json to update database settings.
+
+        Args:
+            app_name: Application name.
+            db_name: Database (cube) name.
+            category: One of 'all' (default), 'startup', 'calculation', 'cache', 'compression', 'transactions', 'runtime', 'storage'.
+            settings_json: JSON string of settings to update (when provided, performs an update instead of a read).
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            if settings_json:
+                import json as json_mod
+                settings = json_mod.loads(settings_json)
+                result = ess.database_settings.update_settings(
+                    app_name, db_name, settings)
+                return json.dumps({'action': 'updated',
+                                   'result': str(result)})
+
+            ds = ess.database_settings
+            if category == 'all':
+                errors = []
+                data = {}
+
+                settings, e = safe_call(
+                    'settings', ds.get_settings,
+                    app_name, db_name)
+                if settings:
+                    data['settings'] = settings
+                if e:
+                    errors.append(e)
+
+                startup, e = safe_call(
+                    'startup', ds.get_startup_settings,
+                    app_name, db_name)
+                if startup:
+                    data['startup'] = startup
+                if e:
+                    errors.append(e)
+
+                calc, e = safe_call(
+                    'calculation', ds.get_calculation_settings,
+                    app_name, db_name)
+                if calc:
+                    data['calculation'] = calc
+                if e:
+                    errors.append(e)
+
+                cache, e = safe_call(
+                    'cache', ds.get_cache_settings,
+                    app_name, db_name)
+                if cache:
+                    data['cache'] = cache
+                if e:
+                    errors.append(e)
+
+                buf, e = safe_call(
+                    'buffer', ds.get_buffer_settings,
+                    app_name, db_name)
+                if buf:
+                    data['buffer'] = buf
+                if e:
+                    errors.append(e)
+
+                comp, e = safe_call(
+                    'compression', ds.get_compression_settings,
+                    app_name, db_name)
+                if comp:
+                    data['compression'] = comp
+                if e:
+                    errors.append(e)
+
+                txn, e = safe_call(
+                    'transactions', ds.get_transaction_settings,
+                    app_name, db_name)
+                if txn:
+                    data['transactions'] = txn
+                if e:
+                    errors.append(e)
+
+                return build_response(data, errors or None)
+
+            elif category == 'startup':
+                return fmt(ds.get_startup_settings(app_name, db_name))
+            elif category == 'calculation':
+                return fmt(ds.get_calculation_settings(
+                    app_name, db_name))
+            elif category == 'cache':
+                return fmt(ds.get_cache_settings(app_name, db_name))
+            elif category == 'compression':
+                return fmt(ds.get_compression_settings(
+                    app_name, db_name))
+            elif category == 'transactions':
+                return fmt(ds.get_transaction_settings(
+                    app_name, db_name))
+            elif category == 'runtime':
+                return fmt(ds.get_runtime_statistics(
+                    app_name, db_name))
+            elif category == 'storage':
+                return fmt(ds.get_storage_statistics(
+                    app_name, db_name))
+            else:
+                return err(f'Unknown category: {category}. '
+                           f'Use all/startup/calculation/cache/'
+                           f'compression/transactions/runtime/storage.')
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 29. essbase_get_logs ───────────────────────────────────────────
+    @mcp.tool()
+    def essbase_get_logs(app_name: str,
+                          latest_only: bool = True,
+                          ctx: Context = None) -> str:
+        """Retrieve application logs from Essbase.
+
+        Returns the latest log entry by default, or all available logs.
+
+        Args:
+            app_name: Application name.
+            latest_only: If True (default), return only the latest log. If False, return all logs.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            if latest_only:
+                result = ess.applications.get_latest_log(app_name)
+            else:
+                result = ess.applications.get_logs(app_name)
+            if isinstance(result, bytes):
+                result = result.decode('utf-8', errors='replace')
+            if isinstance(result, str):
+                return json.dumps({'application': app_name,
+                                   'log': result}, default=str)
+            return fmt(result)
+        except Exception as exc:
+            return err(str(exc))
+
+    # ── 30. essbase_outline_metadata ──────────────────────────────────
+    @mcp.tool()
+    def essbase_outline_metadata(app_name: str, db_name: str,
+                                   category: str = 'all',
+                                   dimension_name: str = None,
+                                   ctx: Context = None) -> str:
+        """Get detailed outline metadata: dimensions, generations, levels, smart lists, and outline settings.
+
+        Args:
+            app_name: Application name.
+            db_name: Database name.
+            category: One of 'all', 'generations', 'levels', 'smart_lists', 'outline_settings', 'export_xml', 'member'.
+            dimension_name: Dimension name (required for generations/levels). For 'member' category, this is the member unique name.
+        """
+        ess = get_essbase(ctx)
+        if not ess:
+            return err(_NO)
+        try:
+            if category == 'all':
+                errors = []
+                data = {}
+
+                dims, e = safe_call(
+                    'dimensions',
+                    ess.dimensions.list_dimensions,
+                    app_name, db_name)
+                if dims:
+                    data['dimensions'] = dims
+                if e:
+                    errors.append(e)
+
+                smart, e = safe_call(
+                    'smart_lists',
+                    ess.dimensions.get_smart_lists,
+                    app_name, db_name)
+                if smart:
+                    data['smart_lists'] = smart
+                if e:
+                    errors.append(e)
+
+                outline_settings, e = safe_call(
+                    'outline_settings',
+                    ess.dimensions.get_outline_settings,
+                    app_name, db_name)
+                if outline_settings:
+                    data['outline_settings'] = outline_settings
+                if e:
+                    errors.append(e)
+
+                attr_settings, e = safe_call(
+                    'attribute_settings',
+                    ess.dimensions.get_attribute_settings,
+                    app_name, db_name)
+                if attr_settings:
+                    data['attribute_settings'] = attr_settings
+                if e:
+                    errors.append(e)
+
+                return build_response(data, errors or None)
+
+            elif category == 'generations':
+                if not dimension_name:
+                    return err('dimension_name required for generations.')
+                return fmt(ess.dimensions.list_generations(
+                    app_name, db_name, dimension_name))
+
+            elif category == 'levels':
+                if not dimension_name:
+                    return err('dimension_name required for levels.')
+                return fmt(ess.dimensions.list_levels(
+                    app_name, db_name, dimension_name))
+
+            elif category == 'smart_lists':
+                return fmt(ess.dimensions.get_smart_lists(
+                    app_name, db_name))
+
+            elif category == 'outline_settings':
+                return fmt(ess.dimensions.get_outline_settings(
+                    app_name, db_name))
+
+            elif category == 'export_xml':
+                return fmt(ess.dimensions.export_outline_xml(
+                    app_name, db_name))
+
+            elif category == 'member':
+                if not dimension_name:
+                    return err('dimension_name (member unique name) '
+                               'required for member.')
+                errors = []
+                data = {}
+
+                member, e = safe_call(
+                    'member',
+                    ess.dimensions.get_member,
+                    app_name, db_name, dimension_name)
+                if member:
+                    data['member'] = member
+                if e:
+                    errors.append(e)
+
+                count, e = safe_call(
+                    'descendants_count',
+                    ess.dimensions.get_descendants_count,
+                    app_name, db_name, dimension_name)
+                if count is not None:
+                    data['descendants_count'] = count
+                if e:
+                    errors.append(e)
+
+                return build_response(data, errors or None)
+
+            else:
+                return err(f'Unknown category: {category}. '
+                           f'Use all/generations/levels/smart_lists/'
+                           f'outline_settings/export_xml/member.')
+        except Exception as exc:
+            return err(str(exc))

--- a/src/oracle-data-studio-mcp-server/pyproject.toml
+++ b/src/oracle-data-studio-mcp-server/pyproject.toml
@@ -1,0 +1,53 @@
+[project]
+name = "oracle.data-studio-mcp-server"
+version = "1.0.0"
+description = "Oracle Data Studio MCP server — Essbase, ADP (Autonomous Database Data Platform), and Data Transforms with Oracle 23ai annotation-aware query routing"
+readme = "README.md"
+requires-python = ">=3.13"
+license = "UPL-1.0"
+license-files = ["LICENSE.txt"]
+authors = [
+    {name = "Oracle Data Studio", email = "essbase_grp_ww@oracle.com"},
+]
+dependencies = [
+    "fastmcp==3.2.4",
+    "oracle-data-studio>=1.0.26",
+    "pydantic==2.12.3",
+    "keyring>=25.0.0",
+]
+classifiers = [
+    "License :: OSI Approved :: Universal Permissive License (UPL)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.13",
+]
+
+[project.scripts]
+"oracle.data-studio-mcp-server" = "oracle.data_studio_mcp_server.server:main"
+"oracle.data-studio-config" = "oracle.data_studio_mcp_server.cli_config:main"
+
+[project.urls]
+Changelog = "https://github.com/oracle/mcp/blob/main/src/oracle-data-studio-mcp-server/CHANGELOG.md"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["oracle"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.2.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["oracle/data_studio_mcp_server/tests"]
+
+[tool.coverage.run]
+source = ["oracle/data_studio_mcp_server"]
+omit = ["*/tests/*", "*/__init__.py"]
+
+[tool.coverage.report]
+fail_under = 80

--- a/src/oracle-data-studio-mcp-server/pyproject.toml
+++ b/src/oracle-data-studio-mcp-server/pyproject.toml
@@ -60,11 +60,8 @@ omit = [
     "**/tests/*",
 ]
 precision = 2
-# Coverage threshold intentionally not enforced in this initial
-# contribution. Today's suite covers helpers, profiles, config,
-# credential store, error sanitisation, reconnect rate-limit/locking,
-# tool registration, and key dispatch paths (~24% line coverage).
-# The remaining gap is the per-action handlers in the composite
-# tool files — they rely on the live SDK and are easier to verify
-# end-to-end than via per-action mocks. Will be raised incrementally
-# in follow-up PRs once a stable mock pattern is established.
+# Regression gate just below current line coverage (70.52%).
+# Raise this in follow-up PRs as more error-path branches and
+# rarely-used SDK passthroughs get coverage. Keeping a real gate
+# here (not 0) means a future PR cannot silently lower coverage.
+fail_under = 75

--- a/src/oracle-data-studio-mcp-server/pyproject.toml
+++ b/src/oracle-data-studio-mcp-server/pyproject.toml
@@ -40,14 +40,31 @@ packages = ["oracle"]
 dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.2.0",
+    "pytest-cov>=7.0.0",
 ]
 
 [tool.pytest.ini_options]
 testpaths = ["oracle/data_studio_mcp_server/tests"]
 
 [tool.coverage.run]
-source = ["oracle/data_studio_mcp_server"]
-omit = ["*/tests/*", "*/__init__.py"]
+omit = [
+    "**/__init__.py",
+    "**/tests/*",
+    "dist/*",
+    ".venv/*",
+]
 
 [tool.coverage.report]
-fail_under = 80
+omit = [
+    "**/__init__.py",
+    "**/tests/*",
+]
+precision = 2
+# Coverage threshold intentionally not enforced in this initial
+# contribution. Today's suite covers helpers, profiles, config,
+# credential store, error sanitisation, reconnect rate-limit/locking,
+# tool registration, and key dispatch paths (~24% line coverage).
+# The remaining gap is the per-action handlers in the composite
+# tool files — they rely on the live SDK and are easier to verify
+# end-to-end than via per-action mocks. Will be raised incrementally
+# in follow-up PRs once a stable mock pattern is established.

--- a/src/oracle-data-studio-mcp-server/uv.lock
+++ b/src/oracle-data-studio-mcp-server/uv.lock
@@ -233,6 +233,75 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -746,6 +815,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -760,6 +830,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
 
 [[package]]
@@ -1020,6 +1091,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1232,8 +1317,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/src/oracle-data-studio-mcp-server/uv.lock
+++ b/src/oracle-data-studio-mcp-server/uv.lock
@@ -1,0 +1,1438 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/e2/85f227594656000ff4d8adadae91a21f536d4a84c6c716a86bd6685874be/cachetools-7.1.1.tar.gz", hash = "sha256:27bdf856d68fd3c71c26c01b5edc312124ed427524d1ddb31aa2b7746fe20d4b", size = 40202, upload-time = "2026-05-03T20:00:29.391Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/0f/f897abe4ea0a8c408ae65c8c83bffab4936ad65d6032d4fb4cd35bbdc3ee/cachetools-7.1.1-py3-none-any.whl", hash = "sha256:0335cd7a0952d2b22327441fb0628139e234c565559eeb91a8a4ac7551c5353d", size = 16775, upload-time = "2026-05-03T20:00:27.857Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
+name = "cyclopts"
+version = "4.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/f7/3ee212c1bc314551094fc8fda7b4b63c647ac5c32d06daa285d04d33edfc/cyclopts-4.11.2.tar.gz", hash = "sha256:8c9b77921660fa1ee52c150e2217ced672323efb3434e9b338077de1bc551ff4", size = 175935, upload-time = "2026-05-04T00:11:57.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl", hash = "sha256:838020120b939549ff7c8423aca29c86764b5dd1d8a5d7f3753a6327861f537b", size = 213537, upload-time = "2026-05-04T00:11:56.103Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "3.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pyperclip" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/dc/5f768c2e391e9afabe5d18e3221346deb5fb6338565f1ccc9e7c6d7befdd/joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48", size = 231881, upload-time = "2026-05-06T04:58:13.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/3b/ad1cb22e75c963b1f07c8a2329bf47227ce7e4361df5eb2fb101b2ce33ef/joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e", size = 70464, upload-time = "2026-05-06T04:58:11.668Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/86/cfee6dd25843bec0760f456599a4f7e7e40221a934b9229fda0662c859bc/jsonschema_path-0.4.6.tar.gz", hash = "sha256:c89eb635f4d497c9ac328eeff359c489755838806a7d033510a692e9576f5c4b", size = 15302, upload-time = "2026-04-27T18:57:08.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/43/3d3065c05a04bb550c143bfbb8e4fd7022cd327e1082bf257bac74923783/jsonschema_path-0.4.6-py3-none-any.whl", hash = "sha256:451354b5311fa955c3144e6e4e255388c751c0121c5570ec5bb9291dd42d08c9", size = 19565, upload-time = "2026-04-27T18:57:06.792Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5c/f3aedc83549aae71cd52b9e9687fe896e3dc6e966ba20eba04718605d198/markdown_it_py-4.1.0.tar.gz", hash = "sha256:760e3f87b2787c044c5138a5ba107b7c2be26c03b13cc7f8fe42756b65b1df6c", size = 81613, upload-time = "2026-05-06T16:32:13.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/88/802c82060c54bc7dde21eb0033e337838b8181a1323254aa9ec41cbfc3d1/markdown_it_py-4.1.0-py3-none-any.whl", hash = "sha256:d4939a62a2dd0cd9cb80a191a711ba1d39bac8ed5ef9e9966895b0171c01c46d", size = 90955, upload-time = "2026-05-06T16:32:12.184Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
+]
+
+[[package]]
+name = "oracle-data-studio"
+version = "1.0.26"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pandas" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d2/8085fafc05330c5ccabd6e4db7edf049e46acfc7245bdf996a9f680c39af/oracle_data_studio-1.0.26.tar.gz", hash = "sha256:7e508e0b26a00d95bff3e65ed7d9b02fd1e46dfa15092cde0c941276e1beee92", size = 197241, upload-time = "2026-04-24T00:29:42.992Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/3f/adde1979efc5d59f9c7444b007cd574e81c3ebca292581c3b53a511ae342/oracle_data_studio-1.0.26-py3-none-any.whl", hash = "sha256:aee0185ee918200fc555e03d7bdc2eeaff00ca7ab6372c74a78e04fdf5075a4c", size = 251373, upload-time = "2026-04-24T00:29:41.754Z" },
+]
+
+[[package]]
+name = "oracle-data-studio-mcp-server"
+version = "1.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "keyring" },
+    { name = "oracle-data-studio" },
+    { name = "pydantic" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", specifier = "==3.2.4" },
+    { name = "keyring", specifier = ">=25.0.0" },
+    { name = "oracle-data-studio", specifier = ">=1.0.26" },
+    { name = "pydantic", specifier = "==2.12.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
+    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
+    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
+    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "py-key-value-aio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/1e/4f0a3233767010308f2fd6bd0814597e3f63f1dc98304a9112b8759df4ff/pydantic-2.12.3.tar.gz", hash = "sha256:1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74", size = 819383, upload-time = "2025-10-17T15:04:21.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/6b/83661fa77dcefa195ad5f8cd9af3d1a7450fd57cc883ad04d65446ac2029/pydantic-2.12.3-py3-none-any.whl", hash = "sha256:6986454a854bc3bc6e5443e1369e06a3a456af9d339eda45510f517d9ea5c6bf", size = 462431, upload-time = "2025-10-17T15:04:19.346Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/18/d0944e8eaaa3efd0a91b0f1fc537d3be55ad35091b6a87638211ba691964/pydantic_core-2.41.4.tar.gz", hash = "sha256:70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5", size = 457557, upload-time = "2025-10-14T10:23:47.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/d0/c20adabd181a029a970738dfe23710b52a31f1258f591874fcdec7359845/pydantic_core-2.41.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:85e050ad9e5f6fe1004eec65c914332e52f429bc0ae12d6fa2092407a462c746", size = 2105688, upload-time = "2025-10-14T10:20:54.448Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b6/0ce5c03cec5ae94cca220dfecddc453c077d71363b98a4bbdb3c0b22c783/pydantic_core-2.41.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7393f1d64792763a48924ba31d1e44c2cfbc05e3b1c2c9abb4ceeadd912cced", size = 1910807, upload-time = "2025-10-14T10:20:56.115Z" },
+    { url = "https://files.pythonhosted.org/packages/68/3e/800d3d02c8beb0b5c069c870cbb83799d085debf43499c897bb4b4aaff0d/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94dab0940b0d1fb28bcab847adf887c66a27a40291eedf0b473be58761c9799a", size = 1956669, upload-time = "2025-10-14T10:20:57.874Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a4/24271cc71a17f64589be49ab8bd0751f6a0a03046c690df60989f2f95c2c/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de7c42f897e689ee6f9e93c4bec72b99ae3b32a2ade1c7e4798e690ff5246e02", size = 2051629, upload-time = "2025-10-14T10:21:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/68/de/45af3ca2f175d91b96bfb62e1f2d2f1f9f3b14a734afe0bfeff079f78181/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:664b3199193262277b8b3cd1e754fb07f2c6023289c815a1e1e8fb415cb247b1", size = 2224049, upload-time = "2025-10-14T10:21:01.801Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/ae4e1ff84672bf869d0a77af24fd78387850e9497753c432875066b5d622/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d95b253b88f7d308b1c0b417c4624f44553ba4762816f94e6986819b9c273fb2", size = 2342409, upload-time = "2025-10-14T10:21:03.556Z" },
+    { url = "https://files.pythonhosted.org/packages/18/62/273dd70b0026a085c7b74b000394e1ef95719ea579c76ea2f0cc8893736d/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1351f5bbdbbabc689727cb91649a00cb9ee7203e0a6e54e9f5ba9e22e384b84", size = 2069635, upload-time = "2025-10-14T10:21:05.385Z" },
+    { url = "https://files.pythonhosted.org/packages/30/03/cf485fff699b4cdaea469bc481719d3e49f023241b4abb656f8d422189fc/pydantic_core-2.41.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1affa4798520b148d7182da0615d648e752de4ab1a9566b7471bc803d88a062d", size = 2194284, upload-time = "2025-10-14T10:21:07.122Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/7e/c8e713db32405dfd97211f2fc0a15d6bf8adb7640f3d18544c1f39526619/pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7b74e18052fea4aa8dea2fb7dbc23d15439695da6cbe6cfc1b694af1115df09d", size = 2137566, upload-time = "2025-10-14T10:21:08.981Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f7/db71fd4cdccc8b75990f79ccafbbd66757e19f6d5ee724a6252414483fb4/pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:285b643d75c0e30abda9dc1077395624f314a37e3c09ca402d4015ef5979f1a2", size = 2316809, upload-time = "2025-10-14T10:21:10.805Z" },
+    { url = "https://files.pythonhosted.org/packages/76/63/a54973ddb945f1bca56742b48b144d85c9fc22f819ddeb9f861c249d5464/pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f52679ff4218d713b3b33f88c89ccbf3a5c2c12ba665fb80ccc4192b4608dbab", size = 2311119, upload-time = "2025-10-14T10:21:12.583Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/03/5d12891e93c19218af74843a27e32b94922195ded2386f7b55382f904d2f/pydantic_core-2.41.4-cp313-cp313-win32.whl", hash = "sha256:ecde6dedd6fff127c273c76821bb754d793be1024bc33314a120f83a3c69460c", size = 1981398, upload-time = "2025-10-14T10:21:14.584Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d8/fd0de71f39db91135b7a26996160de71c073d8635edfce8b3c3681be0d6d/pydantic_core-2.41.4-cp313-cp313-win_amd64.whl", hash = "sha256:d081a1f3800f05409ed868ebb2d74ac39dd0c1ff6c035b5162356d76030736d4", size = 2030735, upload-time = "2025-10-14T10:21:16.432Z" },
+    { url = "https://files.pythonhosted.org/packages/72/86/c99921c1cf6650023c08bfab6fe2d7057a5142628ef7ccfa9921f2dda1d5/pydantic_core-2.41.4-cp313-cp313-win_arm64.whl", hash = "sha256:f8e49c9c364a7edcbe2a310f12733aad95b022495ef2a8d653f645e5d20c1564", size = 1973209, upload-time = "2025-10-14T10:21:18.213Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0d/b5706cacb70a8414396efdda3d72ae0542e050b591119e458e2490baf035/pydantic_core-2.41.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ed97fd56a561f5eb5706cebe94f1ad7c13b84d98312a05546f2ad036bafe87f4", size = 1877324, upload-time = "2025-10-14T10:21:20.363Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2d/cba1fa02cfdea72dfb3a9babb067c83b9dff0bbcb198368e000a6b756ea7/pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a870c307bf1ee91fc58a9a61338ff780d01bfae45922624816878dce784095d2", size = 1884515, upload-time = "2025-10-14T10:21:22.339Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ea/3df927c4384ed9b503c9cc2d076cf983b4f2adb0c754578dfb1245c51e46/pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d25e97bc1f5f8f7985bdc2335ef9e73843bb561eb1fa6831fdfc295c1c2061cf", size = 2042819, upload-time = "2025-10-14T10:21:26.683Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ee/df8e871f07074250270a3b1b82aad4cd0026b588acd5d7d3eb2fcb1471a3/pydantic_core-2.41.4-cp313-cp313t-win_amd64.whl", hash = "sha256:d405d14bea042f166512add3091c1af40437c2e7f86988f3915fabd27b1e9cd2", size = 1995866, upload-time = "2025-10-14T10:21:28.951Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/de/b20f4ab954d6d399499c33ec4fafc46d9551e11dc1858fb7f5dca0748ceb/pydantic_core-2.41.4-cp313-cp313t-win_arm64.whl", hash = "sha256:19f3684868309db5263a11bace3c45d93f6f24afa2ffe75a647583df22a2ff89", size = 1970034, upload-time = "2025-10-14T10:21:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/54/28/d3325da57d413b9819365546eb9a6e8b7cbd9373d9380efd5f74326143e6/pydantic_core-2.41.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:e9205d97ed08a82ebb9a307e92914bb30e18cdf6f6b12ca4bedadb1588a0bfe1", size = 2102022, upload-time = "2025-10-14T10:21:32.809Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/24/b58a1bc0d834bf1acc4361e61233ee217169a42efbdc15a60296e13ce438/pydantic_core-2.41.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:82df1f432b37d832709fbcc0e24394bba04a01b6ecf1ee87578145c19cde12ac", size = 1905495, upload-time = "2025-10-14T10:21:34.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a4/71f759cc41b7043e8ecdaab81b985a9b6cad7cec077e0b92cff8b71ecf6b/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3b4cc4539e055cfa39a3763c939f9d409eb40e85813257dcd761985a108554", size = 1956131, upload-time = "2025-10-14T10:21:36.924Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/64/1e79ac7aa51f1eec7c4cda8cbe456d5d09f05fdd68b32776d72168d54275/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b1eb1754fce47c63d2ff57fdb88c351a6c0150995890088b33767a10218eaa4e", size = 2052236, upload-time = "2025-10-14T10:21:38.927Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e3/a3ffc363bd4287b80f1d43dc1c28ba64831f8dfc237d6fec8f2661138d48/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6ab5ab30ef325b443f379ddb575a34969c333004fca5a1daa0133a6ffaad616", size = 2223573, upload-time = "2025-10-14T10:21:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/28/27/78814089b4d2e684a9088ede3790763c64693c3d1408ddc0a248bc789126/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:31a41030b1d9ca497634092b46481b937ff9397a86f9f51bd41c4767b6fc04af", size = 2342467, upload-time = "2025-10-14T10:21:44.018Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/4de0e2a1159cb85ad737e03306717637842c88c7fd6d97973172fb183149/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a44ac1738591472c3d020f61c6df1e4015180d6262ebd39bf2aeb52571b60f12", size = 2063754, upload-time = "2025-10-14T10:21:46.466Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/50/8cb90ce4b9efcf7ae78130afeb99fd1c86125ccdf9906ef64b9d42f37c25/pydantic_core-2.41.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d72f2b5e6e82ab8f94ea7d0d42f83c487dc159c5240d8f83beae684472864e2d", size = 2196754, upload-time = "2025-10-14T10:21:48.486Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3b/ccdc77af9cd5082723574a1cc1bcae7a6acacc829d7c0a06201f7886a109/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c4d1e854aaf044487d31143f541f7aafe7b482ae72a022c664b2de2e466ed0ad", size = 2137115, upload-time = "2025-10-14T10:21:50.63Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ba/e7c7a02651a8f7c52dc2cff2b64a30c313e3b57c7d93703cecea76c09b71/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b568af94267729d76e6ee5ececda4e283d07bbb28e8148bb17adad93d025d25a", size = 2317400, upload-time = "2025-10-14T10:21:52.959Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ba/6c533a4ee8aec6b812c643c49bb3bd88d3f01e3cebe451bb85512d37f00f/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6d55fb8b1e8929b341cc313a81a26e0d48aa3b519c1dbaadec3a6a2b4fcad025", size = 2312070, upload-time = "2025-10-14T10:21:55.419Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ae/f10524fcc0ab8d7f96cf9a74c880243576fd3e72bd8ce4f81e43d22bcab7/pydantic_core-2.41.4-cp314-cp314-win32.whl", hash = "sha256:5b66584e549e2e32a1398df11da2e0a7eff45d5c2d9db9d5667c5e6ac764d77e", size = 1982277, upload-time = "2025-10-14T10:21:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/dc/e5aa27aea1ad4638f0c3fb41132f7eb583bd7420ee63204e2d4333a3bbf9/pydantic_core-2.41.4-cp314-cp314-win_amd64.whl", hash = "sha256:557a0aab88664cc552285316809cab897716a372afaf8efdbef756f8b890e894", size = 2024608, upload-time = "2025-10-14T10:21:59.557Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/51d89cc2612bd147198e120a13f150afbf0bcb4615cddb049ab10b81b79e/pydantic_core-2.41.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f1ea6f48a045745d0d9f325989d8abd3f1eaf47dd00485912d1a3a63c623a8d", size = 1967614, upload-time = "2025-10-14T10:22:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c2/472f2e31b95eff099961fa050c376ab7156a81da194f9edb9f710f68787b/pydantic_core-2.41.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6c1fe4c5404c448b13188dd8bd2ebc2bdd7e6727fa61ff481bcc2cca894018da", size = 1876904, upload-time = "2025-10-14T10:22:04.062Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/07/ea8eeb91173807ecdae4f4a5f4b150a520085b35454350fc219ba79e66a3/pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:523e7da4d43b113bf8e7b49fa4ec0c35bf4fe66b2230bfc5c13cc498f12c6c3e", size = 1882538, upload-time = "2025-10-14T10:22:06.39Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/29/b53a9ca6cd366bfc928823679c6a76c7a4c69f8201c0ba7903ad18ebae2f/pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5729225de81fb65b70fdb1907fcf08c75d498f4a6f15af005aabb1fdadc19dfa", size = 2041183, upload-time = "2025-10-14T10:22:08.812Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/3d/f8c1a371ceebcaf94d6dd2d77c6cf4b1c078e13a5837aee83f760b4f7cfd/pydantic_core-2.41.4-cp314-cp314t-win_amd64.whl", hash = "sha256:de2cfbb09e88f0f795fd90cf955858fc2c691df65b1f21f0aa00b99f3fbc661d", size = 1993542, upload-time = "2025-10-14T10:22:11.332Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ac/9fc61b4f9d079482a290afe8d206b8f490e9fd32d4fc03ed4fc698214e01/pydantic_core-2.41.4-cp314-cp314t-win_arm64.whl", hash = "sha256:d34f950ae05a83e0ede899c595f312ca976023ea1db100cd5aa188f7005e3ab0", size = 1973897, upload-time = "2025-10-14T10:22:13.444Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/82/10cdfab4ab663a6b6bd624d33f55b2cfa41af5105be033a6d5d135a92c5f/sse_starlette-3.4.2.tar.gz", hash = "sha256:2f9a7f51ed84395a0427fb9f66cb1ec11f7899d977a72cbc9070b962a2e14489", size = 35236, upload-time = "2026-05-06T19:42:13.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/27/351c71e803c56090d8d3bf9520422debeb8ed938871fd4f7ef519805a6c5/sse_starlette-3.4.2-py3-none-any.whl", hash = "sha256:6ea5d35b7ce979a3de5a0db5f77fe886b1616e4b3e1ad93fba502bd9b5fb662f", size = 16516, upload-time = "2026-05-06T19:42:12.201Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
+]


### PR DESCRIPTION
Adds the **Oracle Data Studio MCP Server** — a task-oriented MCP
surface over Oracle Essbase, Autonomous Data Warehouse (ADP / ADBS),
and Oracle Data Transforms. Composite tools (~60) wrap the
fine-grained Python clients (`oracle-data-studio` 1.0.29 on PyPI) into
LLM-friendly verbs: `essbase_explore`, `essbase_describe_database`,
`essbase_query`, `essbase_run_calculation`, `adp_query_analytic_view`,
`dt_run_pipeline`, etc.

## Highlights

* **Profile-gated**, viewer-by-default, admin opt-in. Tools that don't
  match the active profile are physically removed from the FastMCP
  registry before `mcp.run()`, not just hidden from listing.
* **Three auth paths**: env vars, OS keyring (Keychain / Credential
  Manager / Secret Service), and CLI flags. Passwords/tokens never
  touch the on-disk config; only URLs and usernames do.
* **All exception paths sanitised**: `safe_err()` strips JDBC/SQL\*Net
  DSN passwords, URL userinfo, Authorization headers, bare bearer
  tokens, OCI OCID tails (prefix preserved for diagnostics),
  `password=` k/v in JSON/query/env, and absolute filesystem paths
  (basename preserved).
* **Audit log** for every mutating / executing tool — single INFO line
  per call on `oracle-data-studio-mcp.audit` with tool, action,
  target, profile, outcome (`tools/_helpers.py`).
* **Output bounded** on every query path. `essbase_query`,
  `essbase_export_data`, `adp_query_analytic_view` take
  `max_rows=1000`; response carries `truncated: true`,
  `original_row_count`, `max_rows` when the cap fires.
* **535 unit tests**, **83.67% coverage** (gate 75%). Tests cover
  auth failure, validation failure, side effects, bounded output,
  audit emission, and credential redaction.

## Security checklist (per the project's review guidance)

| Item | Implementation | Tests |
|---|---|---|
| **R1 — Profile enforcement** | Default `viewer` (`ServerConfig.profile`). Filter executes in `profiles.apply_profile()` before `mcp.run()`. Admin opt-in. | `test_default_profile_removes_high_risk_tools`, per-profile boundary tests in `TestProfiles` |
| **R2 — Credential redaction** | `safe_err()` in `tools/_helpers.py`. All tool exception paths funnelled through it; raw message logged at DEBUG only. | 7 named redaction tests in `TestHelpers` |
| **R3 — Audit context for mutating tools** | `audit()` + `wrap_mutating_tools_with_audit()` in `tools/_helpers.py`. Single wire-up in `server.main()` covers all ~40 mutating tools. | `TestAuditLogging` (8 tests) |
| **R4 — Output bounded, untrusted handling** | `bound_mdx_result()` + `bound_rows()` in `tools/_helpers.py`. All server content serialised via `json.dumps()` before return. | `TestBoundMdxResult` (6), `TestBoundRows` (3), `TestQueryToolsRespectMaxRows` (5) |
| **R5 — Test coverage** | 535 tests, 83.67% coverage, `fail_under = 75`. | `TestEssbase*ToolDispatch`, `TestAdp*ToolDispatch`, `TestDt*ToolDispatch`, `TestServerStartupWiring`, etc. |

## Layout
