### PR TITLE
feat: add tools to list and switch OCI profiles at runtime

### DIFF
--- a/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/server.py
+++ b/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/server.py
@@ -51,6 +51,7 @@ mcp = FastMCP(
 _user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
 _ADDITIONAL_UA = f"{_user_agent_name}/{__version__}"
 known_paginated: set = {"get_rr_set"}
+_active_profile: Optional[str] = None
 _MODEL_SUFFIXES = ("_details", "_config", "_configuration", "_source_details")
 _DEFAULT_SUMMARY_ITEMS = 5
 _DEFAULT_MODEL_FIELDS = 20
@@ -504,7 +505,7 @@ def _get_config_and_signer() -> Tuple[Dict[str, Any], Any]:
 
     config = oci.config.from_file(
         file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
+        profile_name=_active_profile or os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
     config["additional_user_agent"] = _ADDITIONAL_UA
 
@@ -1479,6 +1480,42 @@ def list_oci_clients() -> dict:
         for client_fqn, cls in _discover_client_classes()
     ]
     return {"count": len(clients), "clients": clients}
+
+
+@mcp.tool(description="List all OCI profiles available in the local OCI config file.")
+def list_oci_profiles() -> dict:
+    import configparser
+    config_file = os.path.expanduser(
+        os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)
+    )
+    if not os.path.exists(config_file):
+        raise FileNotFoundError(f"OCI config file not found: {config_file}")
+    parser = configparser.ConfigParser()
+    parser.read(config_file)
+    profiles = list(parser.sections())
+    active = _active_profile or os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+    return {"profiles": profiles, "active": active}
+
+
+@mcp.tool(description="Switch the active OCI profile used for all subsequent requests in this session.")
+def set_oci_profile(
+    profile_name: Annotated[str, "Name of the OCI profile to activate, as it appears in ~/.oci/config."],
+) -> dict:
+    import configparser
+    global _active_profile
+    config_file = os.path.expanduser(
+        os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)
+    )
+    if not os.path.exists(config_file):
+        raise FileNotFoundError(f"OCI config file not found: {config_file}")
+    parser = configparser.ConfigParser()
+    parser.read(config_file)
+    if profile_name not in parser.sections():
+        available = list(parser.sections())
+        raise ValueError(f"Profile '{profile_name}' not found. Available profiles: {available}")
+    _active_profile = profile_name
+    logger.info(f"Active OCI profile switched to '{profile_name}'")
+    return {"active_profile": _active_profile}
 
 
 def main():

--- a/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_tools.py
+++ b/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_tools.py
@@ -385,3 +385,52 @@ class TestCloudSdkTools:
                 assert result["client"] == "oci.fake.FakeClient"
                 assert result["operation"] == "get_widget"
                 assert result["data"] == {"id": "w1", "ok": True}
+
+
+class TestProfileTools:
+    @pytest.mark.asyncio
+    async def test_list_oci_profiles_returns_sections(self, tmp_path):
+        config_file = tmp_path / "config"
+        config_file.write_text("[DEFAULT]\n[DEV]\nregion=us-ashburn-1\n[PROD]\nregion=us-phoenix-1\n")
+
+        with patch("oracle.oci_cloud_mcp_server.server._active_profile", None):
+            with patch.dict("os.environ", {"OCI_CONFIG_FILE": str(config_file)}, clear=False):
+                async with Client(mcp) as client:
+                    result = (await client.call_tool("list_oci_profiles", {})).data
+                assert "DEV" in result["profiles"]
+                assert "PROD" in result["profiles"]
+
+    @pytest.mark.asyncio
+    async def test_list_oci_profiles_missing_file_raises(self, tmp_path):
+        missing = str(tmp_path / "no_such_config")
+        with patch.dict("os.environ", {"OCI_CONFIG_FILE": missing}, clear=False):
+            async with Client(mcp) as client:
+                with pytest.raises(Exception):
+                    await client.call_tool("list_oci_profiles", {})
+
+    @pytest.mark.asyncio
+    async def test_set_oci_profile_switches_active(self, tmp_path):
+        import oracle.oci_cloud_mcp_server.server as srv
+
+        config_file = tmp_path / "config"
+        config_file.write_text("[DEV]\nregion=us-ashburn-1\n[PROD]\nregion=us-phoenix-1\n")
+
+        original = srv._active_profile
+        try:
+            with patch.dict("os.environ", {"OCI_CONFIG_FILE": str(config_file)}, clear=False):
+                async with Client(mcp) as client:
+                    result = (await client.call_tool("set_oci_profile", {"profile_name": "PROD"})).data
+                assert result["active_profile"] == "PROD"
+                assert srv._active_profile == "PROD"
+        finally:
+            srv._active_profile = original
+
+    @pytest.mark.asyncio
+    async def test_set_oci_profile_unknown_profile_raises(self, tmp_path):
+        config_file = tmp_path / "config"
+        config_file.write_text("[DEV]\nregion=us-ashburn-1\n")
+
+        with patch.dict("os.environ", {"OCI_CONFIG_FILE": str(config_file)}, clear=False):
+            async with Client(mcp) as client:
+                with pytest.raises(Exception):
+                    await client.call_tool("set_oci_profile", {"profile_name": "NONEXISTENT"})


### PR DESCRIPTION
Closes #220

## Problem

The OCI cloud MCP server reads the profile from environment variables at startup. Users who manage multiple tenancies (Dev, Test, Prod) had no way to switch between profiles without restarting the server or running separate instances on different ports.

## Solution

Added two new MCP tools to the oci-cloud-mcp-server:

- `list_oci_profiles` returns all profiles found in the OCI config file along with the currently active one
- `set_oci_profile` switches the active profile for all subsequent requests in the session

The `_get_config_and_signer` function now checks a module level variable `_active_profile` before falling back to the `OCI_CONFIG_PROFILE` environment variable. Since this function is called per request and not cached at startup, no other changes were needed.

## Testing

Added four tests in `TestProfileTools` covering:
- listing profiles from a config file
- error when config file is missing
- switching to a valid profile updates module state
- error when profile name does not exist in the config

All 198 tests pass.