### PR TITLE
Recovery mcp v2

### DIFF
--- a/src/oci-recovery-mcp-server/README.md
+++ b/src/oci-recovery-mcp-server/README.md
@@ -80,6 +80,7 @@ uv pip install .
 - get_database(database_id, region=None) -> Database
 - list_backups(compartment_id=None, database_id=None, lifecycle_state=None, type=None, limit=None, page=None, region=None) -> list[BackupSummary]
 - get_backup(backup_id, region=None) -> Backup
+- list_restore(compartment_id, fetch_for_child_compartment=False, resource_id=None, status=None, limit=None, page=None, sort_order=None, sort_by=None, opc_request_id=None, region=None, aggregate_pages=True) -> list[WorkRequest]
 - summarize_protected_database_backup_destination(compartment_id=None, region=None, db_home_id=None, include_last_backup_time=False) -> ProtectedDatabaseBackupDestinationSummary
 - get_db_home(db_home_id, region=None) -> DatabaseHome
 - list_db_systems(compartment_id=None, lifecycle_state=None, limit=None, page=None, region=None) -> list[DbSystemSummary]

--- a/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/models.py
+++ b/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/models.py
@@ -21,7 +21,9 @@ def _oci_to_dict(obj):
     try:
         from oci.util import to_dict as oci_to_dict
 
-        return oci_to_dict(obj)
+        out = oci_to_dict(obj)
+        if isinstance(out, dict):
+            return out
     except Exception:
         pass
     if isinstance(obj, dict):
@@ -94,20 +96,15 @@ class ProtectedDatabaseHealthCounts(OCIBaseModel):
         alias="warning",
         description="Number of Protected Databases with health=WARNING.",
     )
-    alert: int = Field(
-        0, alias="alert", description="Number of Protected Databases with health=ALERT."
-    )
+    alert: int = Field(0, alias="alert", description="Number of Protected Databases with health=ALERT.")
     unknown: int = Field(
         0,
         alias="unknown",
         description=(
-            "Number of Protected Databases with unknown or missing health "
-            "(e.g., DELETED or transitional)."
+            "Number of Protected Databases with unknown or missing health (e.g., DELETED or transitional)."
         ),
     )
-    total: int = Field(
-        0, alias="total", description="Total Protected Databases scanned."
-    )
+    total: int = Field(0, alias="total", description="Total Protected Databases scanned.")
 
 
 class ProtectedDatabaseRedoCounts(OCIBaseModel):
@@ -135,9 +132,7 @@ class ProtectedDatabaseRedoCounts(OCIBaseModel):
         alias="disabled",
         description="Count of Protected Databases with is_redo_logs_enabled = False.",
     )
-    total: int = Field(
-        0, alias="total", description="Total counted (enabled + disabled)."
-    )
+    total: int = Field(0, alias="total", description="Total counted (enabled + disabled).")
 
 
 class ProtectedDatabaseBackupSpaceSum(OCIBaseModel):
@@ -192,9 +187,7 @@ class ProtectedDatabase(OCIBaseModel):
         None,
         description="The OCID of the compartment containing this Protected Database.",
     )
-    display_name: Optional[str] = Field(
-        None, description="A user-friendly name for the Protected Database."
-    )
+    display_name: Optional[str] = Field(None, description="A user-friendly name for the Protected Database.")
 
     # Policy and networking attachments
     protection_policy_id: Optional[str] = Field(
@@ -203,8 +196,9 @@ class ProtectedDatabase(OCIBaseModel):
     policy_locked_date_time: Optional[str] = Field(
         None,
         description=(
-            "When the protection policy retention lock is scheduled to take effect "
-            "(RFC3339 string)."
+            "Retention-lock timestamp from the attached protection policy "
+            "(RFC3339 string). Null means retention lock is disabled; "
+            "a populated timestamp means retention lock is configured/effective."
         ),
     )
     recovery_service_subnets: Optional[List["RecoveryServiceSubnetDetails"]] = Field(
@@ -223,9 +217,7 @@ class ProtectedDatabase(OCIBaseModel):
         None,
         description="The VPC user name associated with the protected database, if available.",
     )
-    database_size: Optional[
-        Literal["XS", "S", "M", "L", "XL", "XXL", "AUTO", "UNKNOWN_ENUM_VALUE"]
-    ] = Field(
+    database_size: Optional[Literal["XS", "S", "M", "L", "XL", "XXL", "AUTO", "UNKNOWN_ENUM_VALUE"]] = Field(
         None,
         description="Configured database size category for the protected database.",
     )
@@ -253,9 +245,7 @@ class ProtectedDatabase(OCIBaseModel):
             "FAILED",
             "UNKNOWN_ENUM_VALUE",
         ]
-    ] = Field(
-        None, description="The current lifecycle state of the Protected Database."
-    )
+    ] = Field(None, description="The current lifecycle state of the Protected Database.")
     lifecycle_details: Optional[str] = Field(
         None, description="Additional details about the current lifecycle state."
     )
@@ -279,15 +269,12 @@ class ProtectedDatabase(OCIBaseModel):
     is_redo_logs_shipped: Optional[bool] = Field(
         None,
         description=(
-            "Whether real-time redo shipping to Recovery Service is enabled "
-            "(SDK: is_redo_logs_shipped)."
+            "Whether real-time redo shipping to Recovery Service is enabled (SDK: is_redo_logs_shipped)."
         ),
     )
 
     # Metrics
-    metrics: Optional["Metrics"] = Field(
-        None, description="Metrics associated with this Protected Database."
-    )
+    metrics: Optional["Metrics"] = Field(None, description="Metrics associated with this Protected Database.")
     subscription_id: Optional[str] = Field(
         None,
         description="The OCID of the cloud service subscription linked to the protected database.",
@@ -302,9 +289,7 @@ class ProtectedDatabase(OCIBaseModel):
     )
 
     # Tags
-    freeform_tags: Optional[Dict[str, str]] = Field(
-        None, description="Free-form tags for this resource."
-    )
+    freeform_tags: Optional[Dict[str, str]] = Field(None, description="Free-form tags for this resource.")
     defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
         None, description="Defined tags for this resource."
     )
@@ -368,9 +353,7 @@ def map_protected_database(
         compartment_id=getattr(pd, "compartment_id", None)
         or data.get("compartment_id")
         or data.get("compartmentId"),
-        display_name=getattr(pd, "display_name", None)
-        or data.get("display_name")
-        or data.get("displayName"),
+        display_name=getattr(pd, "display_name", None) or data.get("display_name") or data.get("displayName"),
         protection_policy_id=getattr(pd, "protection_policy_id", None)
         or data.get("protection_policy_id")
         or data.get("protectionPolicyId"),
@@ -381,11 +364,8 @@ def map_protected_database(
             rss_in,
             map_recovery_service_subnet_details,
         ),
-        database_id=getattr(pd, "database_id", None)
-        or data.get("database_id")
-        or data.get("databaseId"),
-        db_unique_name=getattr(pd, "db_unique_name", None)
-        or data.get("db_unique_name"),
+        database_id=getattr(pd, "database_id", None) or data.get("database_id") or data.get("databaseId"),
+        db_unique_name=getattr(pd, "db_unique_name", None) or data.get("db_unique_name"),
         vpc_user_name=getattr(pd, "vpc_user_name", None) or data.get("vpc_user_name"),
         database_size=getattr(pd, "database_size", None)
         or data.get("database_size")
@@ -396,52 +376,41 @@ def map_protected_database(
             or data.get("databaseSizeInGBs")
             or data.get("databaseSizeInGbs")
         ),
-        change_rate=(
-            getattr(pd, "change_rate", None)
-            or data.get("change_rate")
-            or data.get("changeRate")
-        ),
+        change_rate=(getattr(pd, "change_rate", None) or data.get("change_rate") or data.get("changeRate")),
         compression_ratio=(
             getattr(pd, "compression_ratio", None)
             or data.get("compression_ratio")
             or data.get("compressionRatio")
         ),
-        lifecycle_state=getattr(pd, "lifecycle_state", None)
-        or data.get("lifecycle_state"),
+        lifecycle_state=getattr(pd, "lifecycle_state", None) or data.get("lifecycle_state"),
         lifecycle_details=getattr(pd, "lifecycle_details", None)
         or data.get("lifecycle_details")
         or data.get("lifecycleDetails"),
         health_details=getattr(pd, "health_details", None)
         or data.get("health_details")
         or data.get("healthDetails"),
-        is_read_only_resource=getattr(pd, "is_read_only_resource", None)
-        or data.get("is_read_only_resource")
-        or data.get("isReadOnlyResource"),
+        is_read_only_resource=_first_not_none(
+            getattr(pd, "is_read_only_resource", None),
+            data.get("is_read_only_resource"),
+            data.get("isReadOnlyResource"),
+        ),
         health=getattr(pd, "health", None) or data.get("health"),
-        is_redo_logs_shipped=(
-            getattr(pd, "is_redo_logs_shipped", None)
-            or data.get("is_redo_logs_shipped")
-            or data.get("isRedoLogsShipped")
+        is_redo_logs_shipped=_first_not_none(
+            getattr(pd, "is_redo_logs_shipped", None),
+            data.get("is_redo_logs_shipped"),
+            data.get("isRedoLogsShipped"),
         ),
         metrics=map_metrics(getattr(pd, "metrics", None) or data.get("metrics")),
         subscription_id=getattr(pd, "subscription_id", None)
         or data.get("subscription_id")
         or data.get("subscriptionId"),
-        time_created=getattr(pd, "time_created", None)
-        or data.get("time_created")
-        or data.get("timeCreated"),
-        time_updated=getattr(pd, "time_updated", None)
-        or data.get("time_updated")
-        or data.get("timeUpdated"),
+        time_created=getattr(pd, "time_created", None) or data.get("time_created") or data.get("timeCreated"),
+        time_updated=getattr(pd, "time_updated", None) or data.get("time_updated") or data.get("timeUpdated"),
         freeform_tags=getattr(pd, "freeform_tags", None)
         or data.get("freeform_tags")
         or data.get("freeformTags"),
-        defined_tags=getattr(pd, "defined_tags", None)
-        or data.get("defined_tags")
-        or data.get("definedTags"),
-        system_tags=getattr(pd, "system_tags", None)
-        or data.get("system_tags")
-        or data.get("systemTags"),
+        defined_tags=getattr(pd, "defined_tags", None) or data.get("defined_tags") or data.get("definedTags"),
+        system_tags=getattr(pd, "system_tags", None) or data.get("system_tags") or data.get("systemTags"),
     )
 
 
@@ -453,15 +422,9 @@ class RecoveryServiceSubnet(OCIBaseModel):
     Pydantic model mirroring the fields of oci.recovery.models.RecoveryServiceSubnet.
     """
 
-    id: Optional[str] = Field(
-        None, description="The OCID of the Recovery Service Subnet (RSS)."
-    )
-    compartment_id: Optional[str] = Field(
-        None, description="The OCID of the compartment containing the RSS."
-    )
-    display_name: Optional[str] = Field(
-        None, description="A user-friendly name for the RSS."
-    )
+    id: Optional[str] = Field(None, description="The OCID of the Recovery Service Subnet (RSS).")
+    compartment_id: Optional[str] = Field(None, description="The OCID of the compartment containing the RSS.")
+    display_name: Optional[str] = Field(None, description="A user-friendly name for the RSS.")
     vcn_id: Optional[str] = Field(None, description="The OCID of the VCN.")
     subnet_id: Optional[str] = Field(None, description="The OCID of the subnet.")
     nsg_ids: Optional[List[str]] = Field(
@@ -478,20 +441,12 @@ class RecoveryServiceSubnet(OCIBaseModel):
             "FAILED",
         ]
     ] = Field(None, description="The current lifecycle state of the RSS.")
-    lifecycle_details: Optional[str] = Field(
-        None, description="Additional details about the RSS lifecycle."
-    )
+    lifecycle_details: Optional[str] = Field(None, description="Additional details about the RSS lifecycle.")
 
-    time_created: Optional[datetime] = Field(
-        None, description="The time the RSS was created (RFC3339)."
-    )
-    time_updated: Optional[datetime] = Field(
-        None, description="The time the RSS was last updated (RFC3339)."
-    )
+    time_created: Optional[datetime] = Field(None, description="The time the RSS was created (RFC3339).")
+    time_updated: Optional[datetime] = Field(None, description="The time the RSS was last updated (RFC3339).")
 
-    freeform_tags: Optional[Dict[str, str]] = Field(
-        None, description="Free-form tags for this resource."
-    )
+    freeform_tags: Optional[Dict[str, str]] = Field(None, description="Free-form tags for this resource.")
     defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
         None, description="Defined tags for this resource."
     )
@@ -533,12 +488,7 @@ def map_recovery_service_subnet(
                 if isinstance(it, str):
                     out.append(it)
                 elif isinstance(it, dict):
-                    ocid = (
-                        it.get("id")
-                        or it.get("ocid")
-                        or it.get("subnetId")
-                        or it.get("subnet_id")
-                    )
+                    ocid = it.get("id") or it.get("ocid") or it.get("subnetId") or it.get("subnet_id")
                     if ocid:
                         out.append(ocid)
         except Exception:
@@ -547,12 +497,8 @@ def map_recovery_service_subnet(
 
     # Normalize primary identifiers for VCN/subnet and ensure 'subnets' includes subnet_id when list is absent
     vcn_id_val = getattr(rss, "vcn_id", None) or data.get("vcn_id") or data.get("vcnId")
-    subnet_id_val = (
-        getattr(rss, "subnet_id", None) or data.get("subnet_id") or data.get("subnetId")
-    )
-    subnets_val = _normalize_subnets(data.get("subnets")) or (
-        [subnet_id_val] if subnet_id_val else None
-    )
+    subnet_id_val = getattr(rss, "subnet_id", None) or data.get("subnet_id") or data.get("subnetId")
+    subnets_val = _normalize_subnets(data.get("subnets")) or ([subnet_id_val] if subnet_id_val else None)
 
     return RecoveryServiceSubnet(
         id=getattr(rss, "id", None) or data.get("id"),
@@ -583,9 +529,7 @@ def map_recovery_service_subnet(
         defined_tags=getattr(rss, "defined_tags", None)
         or data.get("defined_tags")
         or data.get("definedTags"),
-        system_tags=getattr(rss, "system_tags", None)
-        or data.get("system_tags")
-        or data.get("systemTags"),
+        system_tags=getattr(rss, "system_tags", None) or data.get("system_tags") or data.get("systemTags"),
         subnets=subnets_val,
     )
 
@@ -616,9 +560,7 @@ def map_protection_policy_collection(
         return None
     data = _oci_to_dict(coll) or {}
     items = getattr(coll, "items", None) or data.get("items")
-    return ProtectionPolicyCollection(
-        items=_map_list(items, map_protection_policy_summary)
-    )
+    return ProtectionPolicyCollection(items=_map_list(items, map_protection_policy_summary))
 
 
 # endregion
@@ -636,22 +578,21 @@ class ProtectedDatabaseSummary(OCIBaseModel):
         None,
         description="The OCID of the compartment containing the Protected Database.",
     )
-    display_name: Optional[str] = Field(
-        None, description="A user-friendly name for the Protected Database."
-    )
+    display_name: Optional[str] = Field(None, description="A user-friendly name for the Protected Database.")
     protection_policy_id: Optional[str] = Field(
         None, description="The OCID of the attached Protection Policy."
     )
     policy_locked_date_time: Optional[str] = Field(
         None,
-        description="Timestamp when the protection policy was locked (RFC3339 string).",
+        description=(
+            "Retention-lock timestamp from the attached protection policy "
+            "(RFC3339 string). Null means retention lock is disabled; "
+            "a populated timestamp means retention lock is configured/effective."
+        ),
     )
     recovery_service_subnets: Optional[List["RecoveryServiceSubnetDetails"]] = Field(
         None,
-        description=(
-            "List of Recovery Service Subnet details associated with this "
-            "protected database."
-        ),
+        description=("List of Recovery Service Subnet details associated with this protected database."),
     )
     database_id: Optional[str] = Field(
         None, description="The OCID of the backing database, where applicable."
@@ -663,9 +604,7 @@ class ProtectedDatabaseSummary(OCIBaseModel):
         None,
         description="The VPC user name associated with the protected database, if available.",
     )
-    database_size: Optional[
-        Literal["XS", "S", "M", "L", "XL", "XXL", "AUTO", "UNKNOWN_ENUM_VALUE"]
-    ] = Field(
+    database_size: Optional[Literal["XS", "S", "M", "L", "XL", "XXL", "AUTO", "UNKNOWN_ENUM_VALUE"]] = Field(
         None,
         description="Configured database size category for the protected database.",
     )
@@ -709,12 +648,8 @@ class ProtectedDatabaseSummary(OCIBaseModel):
         None, description="The time the Protected Database was last updated (RFC3339)."
     )
     freeform_tags: Optional[Dict[str, str]] = Field(None, description="Free-form tags.")
-    defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
-        None, description="Defined tags."
-    )
-    system_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
-        None, description="System tags."
-    )
+    defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(None, description="Defined tags.")
+    system_tags: Optional[Dict[str, Dict[str, Any]]] = Field(None, description="System tags.")
 
 
 def map_protected_database_summary(
@@ -744,13 +679,9 @@ def map_protected_database_summary(
         or data.get("policy_locked_date_time")
         or data.get("policyLockedDateTime"),
         recovery_service_subnets=_map_list(rss_in, map_recovery_service_subnet_details),
-        database_id=getattr(pds, "database_id", None)
-        or data.get("database_id")
-        or data.get("databaseId"),
+        database_id=getattr(pds, "database_id", None) or data.get("database_id") or data.get("databaseId"),
         db_unique_name=(
-            getattr(pds, "db_unique_name", None)
-            or data.get("db_unique_name")
-            or data.get("dbUniqueName")
+            getattr(pds, "db_unique_name", None) or data.get("db_unique_name") or data.get("dbUniqueName")
         ),
         vpc_user_name=getattr(pds, "vpc_user_name", None)
         or data.get("vpc_user_name")
@@ -771,9 +702,7 @@ def map_protected_database_summary(
         is_read_only_resource=getattr(pds, "is_read_only_resource", None)
         or data.get("is_read_only_resource")
         or data.get("isReadOnlyResource"),
-        metrics=map_metrics_summary(
-            getattr(pds, "metrics", None) or data.get("metrics")
-        ),
+        metrics=map_metrics_summary(getattr(pds, "metrics", None) or data.get("metrics")),
         subscription_id=getattr(pds, "subscription_id", None)
         or data.get("subscription_id")
         or data.get("subscriptionId"),
@@ -789,9 +718,7 @@ def map_protected_database_summary(
         defined_tags=getattr(pds, "defined_tags", None)
         or data.get("defined_tags")
         or data.get("definedTags"),
-        system_tags=getattr(pds, "system_tags", None)
-        or data.get("system_tags")
-        or data.get("systemTags"),
+        system_tags=getattr(pds, "system_tags", None) or data.get("system_tags") or data.get("systemTags"),
     )
 
 
@@ -812,9 +739,7 @@ def map_protected_database_collection(
         return None
     data = _oci_to_dict(coll) or {}
     items = getattr(coll, "items", None) or data.get("items")
-    return ProtectedDatabaseCollection(
-        items=_map_list(items, map_protected_database_summary)
-    )
+    return ProtectedDatabaseCollection(items=_map_list(items, map_protected_database_summary))
 
 
 # endregion
@@ -830,34 +755,20 @@ class RecoveryServiceSubnetDetails(OCIBaseModel):
     """
 
     id: Optional[str] = Field(None, description="The OCID of the RSS.")
-    compartment_id: Optional[str] = Field(
-        None, description="The OCID of the compartment containing the RSS."
-    )
+    compartment_id: Optional[str] = Field(None, description="The OCID of the compartment containing the RSS.")
     display_name: Optional[str] = Field(None, description="A user-friendly name.")
     vcn_id: Optional[str] = Field(None, description="The OCID of the VCN.")
     subnet_id: Optional[str] = Field(None, description="The OCID of the subnet.")
-    nsg_ids: Optional[List[str]] = Field(
-        None, description="List of NSG OCIDs associated to the RSS."
+    nsg_ids: Optional[List[str]] = Field(None, description="List of NSG OCIDs associated to the RSS.")
+    lifecycle_state: Optional[Literal["CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"]] = (
+        Field(None, description="The current lifecycle state.")
     )
-    lifecycle_state: Optional[
-        Literal["CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"]
-    ] = Field(None, description="The current lifecycle state.")
-    lifecycle_details: Optional[str] = Field(
-        None, description="Additional lifecycle details."
-    )
-    time_created: Optional[datetime] = Field(
-        None, description="Creation time (RFC3339)."
-    )
-    time_updated: Optional[datetime] = Field(
-        None, description="Last update time (RFC3339)."
-    )
+    lifecycle_details: Optional[str] = Field(None, description="Additional lifecycle details.")
+    time_created: Optional[datetime] = Field(None, description="Creation time (RFC3339).")
+    time_updated: Optional[datetime] = Field(None, description="Last update time (RFC3339).")
     freeform_tags: Optional[Dict[str, str]] = Field(None, description="Free-form tags.")
-    defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
-        None, description="Defined tags."
-    )
-    system_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
-        None, description="System tags."
-    )
+    defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(None, description="Defined tags.")
+    system_tags: Optional[Dict[str, Dict[str, Any]]] = Field(None, description="System tags.")
 
 
 def map_recovery_service_subnet_details(
@@ -892,9 +803,7 @@ def map_recovery_service_subnet_details(
         or data.get("display_name")
         or data.get("displayName"),
         vcn_id=getattr(det, "vcn_id", None) or data.get("vcn_id") or data.get("vcnId"),
-        subnet_id=getattr(det, "subnet_id", None)
-        or data.get("subnet_id")
-        or data.get("subnetId"),
+        subnet_id=getattr(det, "subnet_id", None) or data.get("subnet_id") or data.get("subnetId"),
         nsg_ids=nsgs,
         lifecycle_state=getattr(det, "lifecycle_state", None)
         or data.get("lifecycle_state")
@@ -914,9 +823,7 @@ def map_recovery_service_subnet_details(
         defined_tags=getattr(det, "defined_tags", None)
         or data.get("defined_tags")
         or data.get("definedTags"),
-        system_tags=getattr(det, "system_tags", None)
-        or data.get("system_tags")
-        or data.get("systemTags"),
+        system_tags=getattr(det, "system_tags", None) or data.get("system_tags") or data.get("systemTags"),
     )
 
 
@@ -926,21 +833,13 @@ class RecoveryServiceSubnetInput(OCIBaseModel):
     Represents the payload to create/update a Recovery Service Subnet.
     """
 
-    display_name: Optional[str] = Field(
-        None, description="A user-friendly name for the RSS."
-    )
-    compartment_id: Optional[str] = Field(
-        None, description="The OCID of the compartment for the RSS."
-    )
+    display_name: Optional[str] = Field(None, description="A user-friendly name for the RSS.")
+    compartment_id: Optional[str] = Field(None, description="The OCID of the compartment for the RSS.")
     vcn_id: Optional[str] = Field(None, description="The OCID of the VCN.")
     subnet_id: Optional[str] = Field(None, description="The OCID of the subnet.")
-    nsg_ids: Optional[List[str]] = Field(
-        None, description="List of NSG OCIDs to associate."
-    )
+    nsg_ids: Optional[List[str]] = Field(None, description="List of NSG OCIDs to associate.")
     freeform_tags: Optional[Dict[str, str]] = Field(None, description="Free-form tags.")
-    defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
-        None, description="Defined tags."
-    )
+    defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(None, description="Defined tags.")
 
 
 def map_recovery_service_subnet_input(
@@ -963,9 +862,7 @@ def map_recovery_service_subnet_input(
         or data.get("compartment_id")
         or data.get("compartmentId"),
         vcn_id=getattr(inp, "vcn_id", None) or data.get("vcn_id") or data.get("vcnId"),
-        subnet_id=getattr(inp, "subnet_id", None)
-        or data.get("subnet_id")
-        or data.get("subnetId"),
+        subnet_id=getattr(inp, "subnet_id", None) or data.get("subnet_id") or data.get("subnetId"),
         nsg_ids=nsgs,
         freeform_tags=getattr(inp, "freeform_tags", None)
         or data.get("freeform_tags")
@@ -982,26 +879,18 @@ class RecoveryServiceSubnetSummary(OCIBaseModel):
     """
 
     id: Optional[str] = Field(None, description="The OCID of the RSS.")
-    compartment_id: Optional[str] = Field(
-        None, description="The OCID of the compartment containing the RSS."
-    )
+    compartment_id: Optional[str] = Field(None, description="The OCID of the compartment containing the RSS.")
     display_name: Optional[str] = Field(None, description="A user-friendly name.")
     vcn_id: Optional[str] = Field(None, description="The OCID of the VCN.")
     subnet_id: Optional[str] = Field(None, description="The OCID of the subnet.")
     nsg_ids: Optional[List[str]] = Field(None, description="List of NSG OCIDs.")
-    lifecycle_state: Optional[
-        Literal["CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"]
-    ] = Field(None, description="The current lifecycle state.")
-    time_created: Optional[datetime] = Field(
-        None, description="Creation time (RFC3339)."
+    lifecycle_state: Optional[Literal["CREATING", "ACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED"]] = (
+        Field(None, description="The current lifecycle state.")
     )
+    time_created: Optional[datetime] = Field(None, description="Creation time (RFC3339).")
     freeform_tags: Optional[Dict[str, str]] = Field(None, description="Free-form tags.")
-    defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
-        None, description="Defined tags."
-    )
-    system_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
-        None, description="System tags."
-    )
+    defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(None, description="Defined tags.")
+    system_tags: Optional[Dict[str, Dict[str, Any]]] = Field(None, description="System tags.")
 
 
 def map_recovery_service_subnet_summary(
@@ -1025,9 +914,7 @@ def map_recovery_service_subnet_summary(
         or data.get("display_name")
         or data.get("displayName"),
         vcn_id=getattr(rss, "vcn_id", None) or data.get("vcn_id") or data.get("vcnId"),
-        subnet_id=getattr(rss, "subnet_id", None)
-        or data.get("subnet_id")
-        or data.get("subnetId"),
+        subnet_id=getattr(rss, "subnet_id", None) or data.get("subnet_id") or data.get("subnetId"),
         nsg_ids=nsgs,
         lifecycle_state=getattr(rss, "lifecycle_state", None)
         or data.get("lifecycle_state")
@@ -1041,9 +928,7 @@ def map_recovery_service_subnet_summary(
         defined_tags=getattr(rss, "defined_tags", None)
         or data.get("defined_tags")
         or data.get("definedTags"),
-        system_tags=getattr(rss, "system_tags", None)
-        or data.get("system_tags")
-        or data.get("systemTags"),
+        system_tags=getattr(rss, "system_tags", None) or data.get("system_tags") or data.get("systemTags"),
     )
 
 
@@ -1064,9 +949,7 @@ def map_recovery_service_subnet_collection(
         return None
     data = _oci_to_dict(coll) or {}
     items = getattr(coll, "items", None) or data.get("items")
-    return RecoveryServiceSubnetCollection(
-        items=_map_list(items, map_recovery_service_subnet_summary)
-    )
+    return RecoveryServiceSubnetCollection(items=_map_list(items, map_recovery_service_subnet_summary))
 
 
 # endregion
@@ -1080,9 +963,7 @@ class Metrics(OCIBaseModel):
     Captures common Recovery metrics fields and remains tolerant to service evolution.
     """
 
-    backup_space_used_in_gbs: Optional[float] = Field(
-        None, description="Total backup space used in GBs."
-    )
+    backup_space_used_in_gbs: Optional[float] = Field(None, description="Total backup space used in GBs.")
     database_size_in_gbs: Optional[float] = Field(
         None, description="Logical database size in GBs, if reported."
     )
@@ -1095,24 +976,18 @@ class Metrics(OCIBaseModel):
     latest_backup_time: Optional[datetime] = Field(
         None, description="Time of the latest successful backup (RFC3339), if reported."
     )
-    backup_space_estimate_in_gbs: Optional[float] = Field(
-        None, description="Estimated backup space in GBs."
-    )
+    backup_space_estimate_in_gbs: Optional[float] = Field(None, description="Estimated backup space in GBs.")
     current_retention_period_in_seconds: Optional[float] = Field(
         None, description="Current recoverable window length in seconds."
     )
-    is_redo_logs_enabled: Optional[bool] = Field(
-        None, description="Whether redo transport is enabled."
-    )
+    is_redo_logs_enabled: Optional[bool] = Field(None, description="Whether redo transport is enabled.")
     minimum_recovery_needed_in_days: Optional[float] = Field(
         None, description="Minimum days of recovery needed."
     )
     retention_period_in_days: Optional[float] = Field(
         None, description="Configured retention period in days."
     )
-    unprotected_window_in_seconds: Optional[float] = Field(
-        None, description="Unprotected window in seconds."
-    )
+    unprotected_window_in_seconds: Optional[float] = Field(None, description="Unprotected window in seconds.")
 
 
 def map_metrics(m) -> Metrics | None:
@@ -1123,44 +998,64 @@ def map_metrics(m) -> Metrics | None:
         return None
     data = _oci_to_dict(m) or {}
     return Metrics(
-        backup_space_used_in_gbs=getattr(m, "backup_space_used_in_gbs", None)
-        or data.get("backup_space_used_in_gbs")
-        or data.get("backupSpaceUsedInGbs"),
-        database_size_in_gbs=getattr(m, "database_size_in_gbs", None)
-        or data.get("database_size_in_gbs")
-        or data.get("databaseSizeInGbs")
-        or data.get("dbSizeInGbs"),
-        recoverable_window_start_time=getattr(m, "recoverable_window_start_time", None)
-        or data.get("recoverable_window_start_time")
-        or data.get("recoverableWindowStartTime"),
-        recoverable_window_end_time=getattr(m, "recoverable_window_end_time", None)
-        or data.get("recoverable_window_end_time")
-        or data.get("recoverableWindowEndTime"),
-        latest_backup_time=getattr(m, "latest_backup_time", None)
-        or data.get("latest_backup_time")
-        or data.get("latestBackupTime"),
-        backup_space_estimate_in_gbs=getattr(m, "backup_space_estimate_in_gbs", None)
-        or data.get("backup_space_estimate_in_gbs")
-        or data.get("backupSpaceEstimateInGbs"),
-        current_retention_period_in_seconds=getattr(
-            m, "current_retention_period_in_seconds", None
-        )
-        or data.get("current_retention_period_in_seconds")
-        or data.get("currentRetentionPeriodInSeconds"),
-        is_redo_logs_enabled=getattr(m, "is_redo_logs_enabled", None)
-        or data.get("is_redo_logs_enabled")
-        or data.get("isRedoLogsEnabled"),
-        minimum_recovery_needed_in_days=getattr(
-            m, "minimum_recovery_needed_in_days", None
-        )
-        or data.get("minimum_recovery_needed_in_days")
-        or data.get("minimumRecoveryNeededInDays"),
-        retention_period_in_days=getattr(m, "retention_period_in_days", None)
-        or data.get("retention_period_in_days")
-        or data.get("retentionPeriodInDays"),
-        unprotected_window_in_seconds=getattr(m, "unprotected_window_in_seconds", None)
-        or data.get("unprotected_window_in_seconds")
-        or data.get("unprotectedWindowInSeconds"),
+        backup_space_used_in_gbs=_first_not_none(
+            getattr(m, "backup_space_used_in_gbs", None),
+            data.get("backup_space_used_in_gbs"),
+            data.get("backupSpaceUsedInGbs"),
+        ),
+        database_size_in_gbs=_first_not_none(
+            getattr(m, "db_size_in_gbs", None),
+            getattr(m, "database_size_in_gbs", None),
+            data.get("dbSizeInGBs"),
+            data.get("dbSizeInGbs"),
+            data.get("database_size_in_gbs"),
+            data.get("databaseSizeInGbs"),
+        ),
+        recoverable_window_start_time=_first_not_none(
+            getattr(m, "recoverable_window_start_time", None),
+            data.get("recoverable_window_start_time"),
+            data.get("recoverableWindowStartTime"),
+        ),
+        recoverable_window_end_time=_first_not_none(
+            getattr(m, "recoverable_window_end_time", None),
+            data.get("recoverable_window_end_time"),
+            data.get("recoverableWindowEndTime"),
+        ),
+        latest_backup_time=_first_not_none(
+            getattr(m, "latest_backup_time", None),
+            data.get("latest_backup_time"),
+            data.get("latestBackupTime"),
+        ),
+        backup_space_estimate_in_gbs=_first_not_none(
+            getattr(m, "backup_space_estimate_in_gbs", None),
+            data.get("backup_space_estimate_in_gbs"),
+            data.get("backupSpaceEstimateInGbs"),
+        ),
+        current_retention_period_in_seconds=_first_not_none(
+            getattr(m, "current_retention_period_in_seconds", None),
+            data.get("current_retention_period_in_seconds"),
+            data.get("currentRetentionPeriodInSeconds"),
+        ),
+        is_redo_logs_enabled=_first_not_none(
+            getattr(m, "is_redo_logs_enabled", None),
+            data.get("is_redo_logs_enabled"),
+            data.get("isRedoLogsEnabled"),
+        ),
+        minimum_recovery_needed_in_days=_first_not_none(
+            getattr(m, "minimum_recovery_needed_in_days", None),
+            data.get("minimum_recovery_needed_in_days"),
+            data.get("minimumRecoveryNeededInDays"),
+        ),
+        retention_period_in_days=_first_not_none(
+            getattr(m, "retention_period_in_days", None),
+            data.get("retention_period_in_days"),
+            data.get("retentionPeriodInDays"),
+        ),
+        unprotected_window_in_seconds=_first_not_none(
+            getattr(m, "unprotected_window_in_seconds", None),
+            data.get("unprotected_window_in_seconds"),
+            data.get("unprotectedWindowInSeconds"),
+        ),
     )
 
 
@@ -1198,21 +1093,31 @@ def map_metrics_summary(ms) -> MetricsSummary | None:
         return None
     data = _oci_to_dict(ms) or {}
     return MetricsSummary(
-        backup_space_used_in_gbs=getattr(ms, "backup_space_used_in_gbs", None)
-        or data.get("backup_space_used_in_gbs")
-        or data.get("backupSpaceUsedInGbs"),
-        database_size_in_gbs=getattr(ms, "database_size_in_gbs", None)
-        or data.get("database_size_in_gbs")
-        or data.get("databaseSizeInGbs"),
-        recoverable_window_start_time=getattr(ms, "recoverable_window_start_time", None)
-        or data.get("recoverable_window_start_time")
-        or data.get("recoverableWindowStartTime"),
-        recoverable_window_end_time=getattr(ms, "recoverable_window_end_time", None)
-        or data.get("recoverable_window_end_time")
-        or data.get("recoverableWindowEndTime"),
-        latest_backup_time=getattr(ms, "latest_backup_time", None)
-        or data.get("latest_backup_time")
-        or data.get("latestBackupTime"),
+        backup_space_used_in_gbs=_first_not_none(
+            getattr(ms, "backup_space_used_in_gbs", None),
+            data.get("backup_space_used_in_gbs"),
+            data.get("backupSpaceUsedInGbs"),
+        ),
+        database_size_in_gbs=_first_not_none(
+            getattr(ms, "database_size_in_gbs", None),
+            data.get("database_size_in_gbs"),
+            data.get("databaseSizeInGbs"),
+        ),
+        recoverable_window_start_time=_first_not_none(
+            getattr(ms, "recoverable_window_start_time", None),
+            data.get("recoverable_window_start_time"),
+            data.get("recoverableWindowStartTime"),
+        ),
+        recoverable_window_end_time=_first_not_none(
+            getattr(ms, "recoverable_window_end_time", None),
+            data.get("recoverable_window_end_time"),
+            data.get("recoverableWindowEndTime"),
+        ),
+        latest_backup_time=_first_not_none(
+            getattr(ms, "latest_backup_time", None),
+            data.get("latest_backup_time"),
+            data.get("latestBackupTime"),
+        ),
     )
 
 
@@ -1228,9 +1133,7 @@ class ProtectionPolicy(OCIBaseModel):
     """
 
     id: Optional[str] = Field(None, description="The OCID of the protection policy.")
-    display_name: Optional[str] = Field(
-        None, description="A user-friendly name for the protection policy."
-    )
+    display_name: Optional[str] = Field(None, description="A user-friendly name for the protection policy.")
     compartment_id: Optional[str] = Field(
         None,
         description="The OCID of the compartment containing the protection policy.",
@@ -1270,9 +1173,7 @@ class ProtectionPolicy(OCIBaseModel):
     lifecycle_details: Optional[str] = Field(
         None, description="Additional details about the current lifecycle state."
     )
-    freeform_tags: Optional[Dict[str, str]] = Field(
-        None, description="Free-form tags for this resource."
-    )
+    freeform_tags: Optional[Dict[str, str]] = Field(None, description="Free-form tags for this resource.")
     defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
         None, description="Defined tags for this resource."
     )
@@ -1295,15 +1196,11 @@ def map_protection_policy(
 
     return ProtectionPolicy(
         id=getattr(pp, "id", None) or data.get("id"),
-        display_name=getattr(pp, "display_name", None)
-        or data.get("display_name")
-        or data.get("displayName"),
+        display_name=getattr(pp, "display_name", None) or data.get("display_name") or data.get("displayName"),
         compartment_id=getattr(pp, "compartment_id", None)
         or data.get("compartment_id")
         or data.get("compartmentId"),
-        backup_retention_period_in_days=getattr(
-            pp, "backup_retention_period_in_days", None
-        )
+        backup_retention_period_in_days=getattr(pp, "backup_retention_period_in_days", None)
         or data.get("backup_retention_period_in_days")
         or data.get("backupRetentionPeriodInDays"),
         is_predefined_policy=_first_not_none(
@@ -1319,12 +1216,8 @@ def map_protection_policy(
             data.get("must_enforce_cloud_locality"),
             data.get("mustEnforceCloudLocality"),
         ),
-        time_created=getattr(pp, "time_created", None)
-        or data.get("time_created")
-        or data.get("timeCreated"),
-        time_updated=getattr(pp, "time_updated", None)
-        or data.get("time_updated")
-        or data.get("timeUpdated"),
+        time_created=getattr(pp, "time_created", None) or data.get("time_created") or data.get("timeCreated"),
+        time_updated=getattr(pp, "time_updated", None) or data.get("time_updated") or data.get("timeUpdated"),
         lifecycle_state=getattr(pp, "lifecycle_state", None)
         or data.get("lifecycle_state")
         or data.get("lifecycleState"),
@@ -1334,12 +1227,8 @@ def map_protection_policy(
         freeform_tags=getattr(pp, "freeform_tags", None)
         or data.get("freeform_tags")
         or data.get("freeformTags"),
-        defined_tags=getattr(pp, "defined_tags", None)
-        or data.get("defined_tags")
-        or data.get("definedTags"),
-        system_tags=getattr(pp, "system_tags", None)
-        or data.get("system_tags")
-        or data.get("systemTags"),
+        defined_tags=getattr(pp, "defined_tags", None) or data.get("defined_tags") or data.get("definedTags"),
+        system_tags=getattr(pp, "system_tags", None) or data.get("system_tags") or data.get("systemTags"),
     )
 
 
@@ -1352,9 +1241,7 @@ class ProtectionPolicySummary(OCIBaseModel):
     """
 
     id: Optional[str] = Field(None, description="The OCID of the protection policy.")
-    display_name: Optional[str] = Field(
-        None, description="A user-friendly name for the protection policy."
-    )
+    display_name: Optional[str] = Field(None, description="A user-friendly name for the protection policy.")
     compartment_id: Optional[str] = Field(
         None,
         description="The OCID of the compartment containing the protection policy.",
@@ -1394,9 +1281,7 @@ class ProtectionPolicySummary(OCIBaseModel):
     lifecycle_details: Optional[str] = Field(
         None, description="Additional details about the current lifecycle state."
     )
-    freeform_tags: Optional[Dict[str, str]] = Field(
-        None, description="Free-form tags for this resource."
-    )
+    freeform_tags: Optional[Dict[str, str]] = Field(None, description="Free-form tags for this resource.")
     defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
         None, description="Defined tags for this resource."
     )
@@ -1425,9 +1310,7 @@ def map_protection_policy_summary(
         compartment_id=getattr(pps, "compartment_id", None)
         or data.get("compartment_id")
         or data.get("compartmentId"),
-        backup_retention_period_in_days=getattr(
-            pps, "backup_retention_period_in_days", None
-        )
+        backup_retention_period_in_days=getattr(pps, "backup_retention_period_in_days", None)
         or data.get("backup_retention_period_in_days")
         or data.get("backupRetentionPeriodInDays"),
         is_predefined_policy=getattr(pps, "is_predefined_policy", None)
@@ -1457,9 +1340,7 @@ def map_protection_policy_summary(
         defined_tags=getattr(pps, "defined_tags", None)
         or data.get("defined_tags")
         or data.get("definedTags"),
-        system_tags=getattr(pps, "system_tags", None)
-        or data.get("system_tags")
-        or data.get("systemTags"),
+        system_tags=getattr(pps, "system_tags", None) or data.get("system_tags") or data.get("systemTags"),
     )
 
 
@@ -1474,38 +1355,20 @@ class BackupDestinationDetails(OCIBaseModel):
     Covers common fields across destination types; unmodeled keys are preserved in 'extras'.
     """
 
-    type: Optional[str] = Field(
-        None, description="Destination type, e.g., DBRS, OBJECT_STORE, NFS."
-    )
-    destination_type: Optional[str] = Field(
-        None, description="Original destination type value if provided."
-    )
-    id: Optional[str] = Field(
-        None, description="Destination OCID/identifier when applicable."
-    )
+    type: Optional[str] = Field(None, description="Destination type, e.g., DBRS, OBJECT_STORE, NFS.")
+    destination_type: Optional[str] = Field(None, description="Original destination type value if provided.")
+    id: Optional[str] = Field(None, description="Destination OCID/identifier when applicable.")
     backup_destination_id: Optional[str] = Field(
         None, description="Backup destination OCID if provided by SDK."
     )
-    bucket_name: Optional[str] = Field(
-        None, description="Object Storage bucket name (OBJECT_STORE only)."
-    )
-    namespace: Optional[str] = Field(
-        None, description="Object Storage namespace (OBJECT_STORE only)."
-    )
-    region: Optional[str] = Field(
-        None, description="Region for Object Storage destination."
-    )
-    local_mount_point: Optional[str] = Field(
-        None, description="Local mount point path (NFS)."
-    )
+    bucket_name: Optional[str] = Field(None, description="Object Storage bucket name (OBJECT_STORE only).")
+    namespace: Optional[str] = Field(None, description="Object Storage namespace (OBJECT_STORE only).")
+    region: Optional[str] = Field(None, description="Region for Object Storage destination.")
+    local_mount_point: Optional[str] = Field(None, description="Local mount point path (NFS).")
     nfs_server: Optional[str] = Field(None, description="NFS server address (NFS).")
     path: Optional[str] = Field(None, description="Destination path if provided.")
-    vault_id: Optional[str] = Field(
-        None, description="Vault OCID for encryption (if applicable)."
-    )
-    encryption_key_id: Optional[str] = Field(
-        None, description="KMS key OCID (if applicable)."
-    )
+    vault_id: Optional[str] = Field(None, description="Vault OCID for encryption (if applicable).")
+    encryption_key_id: Optional[str] = Field(None, description="KMS key OCID (if applicable).")
     compartment_id: Optional[str] = Field(
         None, description="Compartment OCID of the destination (if applicable)."
     )
@@ -1607,9 +1470,7 @@ class DbBackupConfig(OCIBaseModel):
     Nested under Database/DatabaseSummary as db_backup_config.
     """
 
-    is_auto_backup_enabled: Optional[bool] = Field(
-        None, description="Whether auto backup is enabled."
-    )
+    is_auto_backup_enabled: Optional[bool] = Field(None, description="Whether auto backup is enabled.")
     auto_backup_window: Optional[str] = Field(
         None, description="Preferred start time window for auto backups."
     )
@@ -1619,9 +1480,7 @@ class DbBackupConfig(OCIBaseModel):
     vpcu_user: Optional[str] = Field(
         None, description="Virtual Private Catalog user (VPC user) if configured."
     )
-    backup_deletion_policy: Optional[str] = Field(
-        None, description="Deletion policy for backups."
-    )
+    backup_deletion_policy: Optional[str] = Field(None, description="Deletion policy for backups.")
     backup_destination_details: Optional[List[BackupDestinationDetails]] = Field(
         None, description="Backup destination details."
     )
@@ -1656,9 +1515,7 @@ def map_db_backup_config(cfg) -> DbBackupConfig | None:
         "preferred_backup_window",
         "preferredBackupWindow",
     )
-    recovery_days = pick(
-        "recovery_window_in_days", "recoveryWindowInDays", "recovery_window"
-    )
+    recovery_days = pick("recovery_window_in_days", "recoveryWindowInDays", "recovery_window")
     vpcu = pick(
         "vpcu_user",
         "vpc_user",
@@ -1724,26 +1581,23 @@ class Database(OCIBaseModel):
     compartment_id: Optional[str] = Field(
         None, description="The OCID of the compartment containing the Database."
     )
-    lifecycle_state: Optional[str] = Field(
-        None, description="The current lifecycle state of the Database."
-    )
+    lifecycle_state: Optional[str] = Field(None, description="The current lifecycle state of the Database.")
     db_name: Optional[str] = Field(None, description="The database name.")
-    db_unique_name: Optional[str] = Field(
-        None, description="The DB_UNIQUE_NAME of the database."
-    )
+    db_unique_name: Optional[str] = Field(None, description="The DB_UNIQUE_NAME of the database.")
     db_home_id: Optional[str] = Field(None, description="The OCID of the DB Home.")
-    db_system_id: Optional[str] = Field(
-        None, description="The OCID of the DB System (if applicable)."
-    )
-    db_backup_config: Optional["DbBackupConfig"] = Field(
-        None, description="Database backup configuration."
-    )
+    db_system_id: Optional[str] = Field(None, description="The OCID of the DB System (if applicable).")
+    db_backup_config: Optional["DbBackupConfig"] = Field(None, description="Database backup configuration.")
     protection_policy_id: Optional[str] = Field(
         None,
         description="Recovery Service Protection Policy OCID linked via Protected Database, if any.",
     )
-    time_created: Optional[datetime] = Field(
-        None, description="Creation time (RFC3339)."
+    time_created: Optional[datetime] = Field(None, description="Creation time (RFC3339).")
+    freeform_tags: Optional[Dict[str, str]] = Field(None, description="Free-form tags for this database.")
+    defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
+        None, description="Defined tags for this database."
+    )
+    system_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
+        None, description="System tags for this database."
     )
 
 
@@ -1759,27 +1613,24 @@ def map_database(db) -> Database | None:
         lifecycle_state=getattr(db, "lifecycle_state", None)
         or data.get("lifecycle_state")
         or data.get("lifecycleState"),
-        db_name=getattr(db, "db_name", None)
-        or data.get("db_name")
-        or data.get("dbName"),
+        db_name=getattr(db, "db_name", None) or data.get("db_name") or data.get("dbName"),
         db_unique_name=getattr(db, "db_unique_name", None)
         or data.get("db_unique_name")
         or data.get("dbUniqueName"),
-        db_home_id=getattr(db, "db_home_id", None)
-        or data.get("db_home_id")
-        or data.get("dbHomeId"),
-        db_system_id=getattr(db, "db_system_id", None)
-        or data.get("db_system_id")
-        or data.get("dbSystemId"),
+        db_home_id=getattr(db, "db_home_id", None) or data.get("db_home_id") or data.get("dbHomeId"),
+        db_system_id=getattr(db, "db_system_id", None) or data.get("db_system_id") or data.get("dbSystemId"),
         db_backup_config=map_db_backup_config(
             getattr(db, "db_backup_config", None)
             or data.get("db_backup_config")
             or data.get("dbBackupConfig")
             or data.get("databaseBackupConfig")
         ),
-        time_created=getattr(db, "time_created", None)
-        or data.get("time_created")
-        or data.get("timeCreated"),
+        time_created=getattr(db, "time_created", None) or data.get("time_created") or data.get("timeCreated"),
+        freeform_tags=getattr(db, "freeform_tags", None)
+        or data.get("freeform_tags")
+        or data.get("freeformTags"),
+        defined_tags=getattr(db, "defined_tags", None) or data.get("defined_tags") or data.get("definedTags"),
+        system_tags=getattr(db, "system_tags", None) or data.get("system_tags") or data.get("systemTags"),
     )
 
 
@@ -1792,26 +1643,23 @@ class DatabaseSummary(OCIBaseModel):
     compartment_id: Optional[str] = Field(
         None, description="The OCID of the compartment containing the Database."
     )
-    lifecycle_state: Optional[str] = Field(
-        None, description="The current lifecycle state of the Database."
-    )
+    lifecycle_state: Optional[str] = Field(None, description="The current lifecycle state of the Database.")
     db_name: Optional[str] = Field(None, description="The database name.")
-    db_unique_name: Optional[str] = Field(
-        None, description="The DB_UNIQUE_NAME of the database."
-    )
+    db_unique_name: Optional[str] = Field(None, description="The DB_UNIQUE_NAME of the database.")
     db_home_id: Optional[str] = Field(None, description="The OCID of the DB Home.")
-    db_system_id: Optional[str] = Field(
-        None, description="The OCID of the DB System (if applicable)."
-    )
-    db_backup_config: Optional["DbBackupConfig"] = Field(
-        None, description="Database backup configuration."
-    )
+    db_system_id: Optional[str] = Field(None, description="The OCID of the DB System (if applicable).")
+    db_backup_config: Optional["DbBackupConfig"] = Field(None, description="Database backup configuration.")
     protection_policy_id: Optional[str] = Field(
         None,
         description="Recovery Service Protection Policy OCID linked via Protected Database, if any.",
     )
-    time_created: Optional[datetime] = Field(
-        None, description="Creation time (RFC3339)."
+    time_created: Optional[datetime] = Field(None, description="Creation time (RFC3339).")
+    freeform_tags: Optional[Dict[str, str]] = Field(None, description="Free-form tags for this database.")
+    defined_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
+        None, description="Defined tags for this database."
+    )
+    system_tags: Optional[Dict[str, Dict[str, Any]]] = Field(
+        None, description="System tags for this database."
     )
 
 
@@ -1827,27 +1675,24 @@ def map_database_summary(db) -> DatabaseSummary | None:
         lifecycle_state=getattr(db, "lifecycle_state", None)
         or data.get("lifecycle_state")
         or data.get("lifecycleState"),
-        db_name=getattr(db, "db_name", None)
-        or data.get("db_name")
-        or data.get("dbName"),
+        db_name=getattr(db, "db_name", None) or data.get("db_name") or data.get("dbName"),
         db_unique_name=getattr(db, "db_unique_name", None)
         or data.get("db_unique_name")
         or data.get("dbUniqueName"),
-        db_home_id=getattr(db, "db_home_id", None)
-        or data.get("db_home_id")
-        or data.get("dbHomeId"),
-        db_system_id=getattr(db, "db_system_id", None)
-        or data.get("db_system_id")
-        or data.get("dbSystemId"),
+        db_home_id=getattr(db, "db_home_id", None) or data.get("db_home_id") or data.get("dbHomeId"),
+        db_system_id=getattr(db, "db_system_id", None) or data.get("db_system_id") or data.get("dbSystemId"),
         db_backup_config=map_db_backup_config(
             getattr(db, "db_backup_config", None)
             or data.get("db_backup_config")
             or data.get("dbBackupConfig")
             or data.get("databaseBackupConfig")
         ),
-        time_created=getattr(db, "time_created", None)
-        or data.get("time_created")
-        or data.get("timeCreated"),
+        time_created=getattr(db, "time_created", None) or data.get("time_created") or data.get("timeCreated"),
+        freeform_tags=getattr(db, "freeform_tags", None)
+        or data.get("freeform_tags")
+        or data.get("freeformTags"),
+        defined_tags=getattr(db, "defined_tags", None) or data.get("defined_tags") or data.get("definedTags"),
+        system_tags=getattr(db, "system_tags", None) or data.get("system_tags") or data.get("systemTags"),
     )
 
 
@@ -1878,16 +1723,14 @@ class BackupSummary(OCIBaseModel):
         None,
         alias="database-size-in-gbs",
         description=(
-            "Database size in GBs (from Recovery metrics) for the database "
-            "that this backup belongs to."
+            "Database size in GBs (from Recovery metrics) for the database that this backup belongs to."
         ),
     )
     backup_destination_type: Optional[str] = Field(
         None,
         alias="backup-destination-type",
         description=(
-            "Primary backup destination type for the database "
-            "(e.g., DBRS, OBJECT_STORE, NFS, UNKNOWN)."
+            "Primary backup destination type for the database (e.g., DBRS, OBJECT_STORE, NFS, UNKNOWN)."
         ),
     )
 
@@ -1898,25 +1741,17 @@ def map_backup_summary(b) -> BackupSummary | None:
     data = _oci_to_dict(b) or {}
     return BackupSummary(
         id=getattr(b, "id", None) or data.get("id"),
-        display_name=getattr(b, "display_name", None)
-        or data.get("display_name")
-        or data.get("displayName"),
+        display_name=getattr(b, "display_name", None) or data.get("display_name") or data.get("displayName"),
         compartment_id=getattr(b, "compartment_id", None)
         or data.get("compartment_id")
         or data.get("compartmentId"),
-        database_id=getattr(b, "database_id", None)
-        or data.get("database_id")
-        or data.get("databaseId"),
+        database_id=getattr(b, "database_id", None) or data.get("database_id") or data.get("databaseId"),
         lifecycle_state=getattr(b, "lifecycle_state", None)
         or data.get("lifecycle_state")
         or data.get("lifecycleState"),
         type=getattr(b, "type", None) or data.get("type"),
-        time_started=getattr(b, "time_started", None)
-        or data.get("time_started")
-        or data.get("timeStarted"),
-        time_ended=getattr(b, "time_ended", None)
-        or data.get("time_ended")
-        or data.get("timeEnded"),
+        time_started=getattr(b, "time_started", None) or data.get("time_started") or data.get("timeStarted"),
+        time_ended=getattr(b, "time_ended", None) or data.get("time_ended") or data.get("timeEnded"),
         database_size_in_gbs=getattr(b, "database_size_in_gbs", None)
         or data.get("database_size_in_gbs")
         or data.get("databaseSizeInGBs")
@@ -1946,9 +1781,7 @@ class Backup(OCIBaseModel):
     type: Optional[str] = Field(None, description="Backup type.")
     time_started: Optional[datetime] = Field(None, description="Start time (RFC3339).")
     time_ended: Optional[datetime] = Field(None, description="End time (RFC3339).")
-    database_version: Optional[str] = Field(
-        None, description="Database version at backup time."
-    )
+    database_version: Optional[str] = Field(None, description="Database version at backup time.")
     # Enriched fields populated by server get/list backup tools
     retention_period_in_days: Optional[float] = Field(
         None,
@@ -1964,16 +1797,14 @@ class Backup(OCIBaseModel):
         None,
         alias="database-size-in-gbs",
         description=(
-            "Database size in GBs (from Recovery metrics) for the database "
-            "that this backup belongs to."
+            "Database size in GBs (from Recovery metrics) for the database that this backup belongs to."
         ),
     )
     backup_destination_type: Optional[str] = Field(
         None,
         alias="backup-destination-type",
         description=(
-            "Primary backup destination type for the database "
-            "(e.g., DBRS, OBJECT_STORE, NFS, UNKNOWN)."
+            "Primary backup destination type for the database (e.g., DBRS, OBJECT_STORE, NFS, UNKNOWN)."
         ),
     )
 
@@ -1984,25 +1815,17 @@ def map_backup(b) -> Backup | None:
     data = _oci_to_dict(b) or {}
     return Backup(
         id=getattr(b, "id", None) or data.get("id"),
-        display_name=getattr(b, "display_name", None)
-        or data.get("display_name")
-        or data.get("displayName"),
+        display_name=getattr(b, "display_name", None) or data.get("display_name") or data.get("displayName"),
         compartment_id=getattr(b, "compartment_id", None)
         or data.get("compartment_id")
         or data.get("compartmentId"),
-        database_id=getattr(b, "database_id", None)
-        or data.get("database_id")
-        or data.get("databaseId"),
+        database_id=getattr(b, "database_id", None) or data.get("database_id") or data.get("databaseId"),
         lifecycle_state=getattr(b, "lifecycle_state", None)
         or data.get("lifecycle_state")
         or data.get("lifecycleState"),
         type=getattr(b, "type", None) or data.get("type"),
-        time_started=getattr(b, "time_started", None)
-        or data.get("time_started")
-        or data.get("timeStarted"),
-        time_ended=getattr(b, "time_ended", None)
-        or data.get("time_ended")
-        or data.get("timeEnded"),
+        time_started=getattr(b, "time_started", None) or data.get("time_started") or data.get("timeStarted"),
+        time_ended=getattr(b, "time_ended", None) or data.get("time_ended") or data.get("timeEnded"),
         database_size_in_gbs=getattr(b, "database_size_in_gbs", None)
         or data.get("database_size_in_gbs")
         or data.get("databaseSizeInGBs")
@@ -2022,6 +1845,59 @@ def map_backup(b) -> Backup | None:
     )
 
 
+class WorkRequest(OCIBaseModel):
+    """
+    Pydantic model mirroring oci.work_requests.models.WorkRequest.
+    """
+
+    id: Optional[str] = Field(None, description="The OCID of the work request.")
+    compartment_id: Optional[str] = Field(None, description="Compartment OCID.")
+    operation_type: Optional[str] = Field(
+        None,
+        description="The operation type for this work request (for example, Restore Database).",
+    )
+    status: Optional[str] = Field(None, description="Current status of the work request.")
+    percent_complete: Optional[float] = Field(None, description="Percent complete of the work request.")
+    resource_id: Optional[str] = Field(
+        None,
+        description="Primary related resource OCID when available (for example, Database OCID).",
+    )
+    time_accepted: Optional[datetime] = Field(None, description="Time accepted (RFC3339).")
+    time_started: Optional[datetime] = Field(None, description="Time started (RFC3339).")
+    time_finished: Optional[datetime] = Field(None, description="Time finished (RFC3339).")
+
+
+def map_work_request(w) -> WorkRequest | None:
+    if w is None:
+        return None
+    data = _oci_to_dict(w)
+    if not isinstance(data, dict):
+        data = getattr(w, "__dict__", {}) if hasattr(w, "__dict__") else {}
+    return WorkRequest(
+        id=getattr(w, "id", None) or data.get("id"),
+        compartment_id=getattr(w, "compartment_id", None)
+        or data.get("compartment_id")
+        or data.get("compartmentId"),
+        operation_type=getattr(w, "operation_type", None)
+        or data.get("operation_type")
+        or data.get("operationType"),
+        status=getattr(w, "status", None) or data.get("status"),
+        percent_complete=_first_not_none(
+            getattr(w, "percent_complete", None),
+            data.get("percent_complete"),
+            data.get("percentComplete"),
+        ),
+        resource_id=getattr(w, "resource_id", None) or data.get("resource_id") or data.get("resourceId"),
+        time_accepted=getattr(w, "time_accepted", None)
+        or data.get("time_accepted")
+        or data.get("timeAccepted"),
+        time_started=getattr(w, "time_started", None) or data.get("time_started") or data.get("timeStarted"),
+        time_finished=getattr(w, "time_finished", None)
+        or data.get("time_finished")
+        or data.get("timeFinished"),
+    )
+
+
 class DatabaseHomeSummary(OCIBaseModel):
     """
     Pydantic model mirroring oci.database.models.DbHomeSummary.
@@ -2033,9 +1909,7 @@ class DatabaseHomeSummary(OCIBaseModel):
     db_system_id: Optional[str] = Field(None, description="DB System OCID.")
     lifecycle_state: Optional[str] = Field(None, description="Lifecycle state.")
     db_version: Optional[str] = Field(None, description="DB version.")
-    time_created: Optional[datetime] = Field(
-        None, description="Creation time (RFC3339)."
-    )
+    time_created: Optional[datetime] = Field(None, description="Creation time (RFC3339).")
 
 
 def map_database_home_summary(h) -> DatabaseHomeSummary | None:
@@ -2044,24 +1918,16 @@ def map_database_home_summary(h) -> DatabaseHomeSummary | None:
     data = _oci_to_dict(h) or {}
     return DatabaseHomeSummary(
         id=getattr(h, "id", None) or data.get("id"),
-        display_name=getattr(h, "display_name", None)
-        or data.get("display_name")
-        or data.get("displayName"),
+        display_name=getattr(h, "display_name", None) or data.get("display_name") or data.get("displayName"),
         compartment_id=getattr(h, "compartment_id", None)
         or data.get("compartment_id")
         or data.get("compartmentId"),
-        db_system_id=getattr(h, "db_system_id", None)
-        or data.get("db_system_id")
-        or data.get("dbSystemId"),
+        db_system_id=getattr(h, "db_system_id", None) or data.get("db_system_id") or data.get("dbSystemId"),
         lifecycle_state=getattr(h, "lifecycle_state", None)
         or data.get("lifecycle_state")
         or data.get("lifecycleState"),
-        db_version=getattr(h, "db_version", None)
-        or data.get("db_version")
-        or data.get("dbVersion"),
-        time_created=getattr(h, "time_created", None)
-        or data.get("time_created")
-        or data.get("timeCreated"),
+        db_version=getattr(h, "db_version", None) or data.get("db_version") or data.get("dbVersion"),
+        time_created=getattr(h, "time_created", None) or data.get("time_created") or data.get("timeCreated"),
     )
 
 
@@ -2076,9 +1942,7 @@ class DatabaseHome(OCIBaseModel):
     db_system_id: Optional[str] = Field(None, description="DB System OCID.")
     lifecycle_state: Optional[str] = Field(None, description="Lifecycle state.")
     db_version: Optional[str] = Field(None, description="DB version.")
-    time_created: Optional[datetime] = Field(
-        None, description="Creation time (RFC3339)."
-    )
+    time_created: Optional[datetime] = Field(None, description="Creation time (RFC3339).")
 
 
 def map_database_home(h) -> DatabaseHome | None:
@@ -2087,24 +1951,16 @@ def map_database_home(h) -> DatabaseHome | None:
     data = _oci_to_dict(h) or {}
     return DatabaseHome(
         id=getattr(h, "id", None) or data.get("id"),
-        display_name=getattr(h, "display_name", None)
-        or data.get("display_name")
-        or data.get("displayName"),
+        display_name=getattr(h, "display_name", None) or data.get("display_name") or data.get("displayName"),
         compartment_id=getattr(h, "compartment_id", None)
         or data.get("compartment_id")
         or data.get("compartmentId"),
-        db_system_id=getattr(h, "db_system_id", None)
-        or data.get("db_system_id")
-        or data.get("dbSystemId"),
+        db_system_id=getattr(h, "db_system_id", None) or data.get("db_system_id") or data.get("dbSystemId"),
         lifecycle_state=getattr(h, "lifecycle_state", None)
         or data.get("lifecycle_state")
         or data.get("lifecycleState"),
-        db_version=getattr(h, "db_version", None)
-        or data.get("db_version")
-        or data.get("dbVersion"),
-        time_created=getattr(h, "time_created", None)
-        or data.get("time_created")
-        or data.get("timeCreated"),
+        db_version=getattr(h, "db_version", None) or data.get("db_version") or data.get("dbVersion"),
+        time_created=getattr(h, "time_created", None) or data.get("time_created") or data.get("timeCreated"),
     )
 
 
@@ -2120,9 +1976,7 @@ class DbSystemSummary(OCIBaseModel):
     shape: Optional[str] = Field(None, description="Shape.")
     cpu_core_count: Optional[int] = Field(None, description="CPU core count.")
     node_count: Optional[int] = Field(None, description="Node count.")
-    time_created: Optional[datetime] = Field(
-        None, description="Creation time (RFC3339)."
-    )
+    time_created: Optional[datetime] = Field(None, description="Creation time (RFC3339).")
 
 
 def map_db_system_summary(s) -> DbSystemSummary | None:
@@ -2131,9 +1985,7 @@ def map_db_system_summary(s) -> DbSystemSummary | None:
     data = _oci_to_dict(s) or {}
     return DbSystemSummary(
         id=getattr(s, "id", None) or data.get("id"),
-        display_name=getattr(s, "display_name", None)
-        or data.get("display_name")
-        or data.get("displayName"),
+        display_name=getattr(s, "display_name", None) or data.get("display_name") or data.get("displayName"),
         compartment_id=getattr(s, "compartment_id", None)
         or data.get("compartment_id")
         or data.get("compartmentId"),
@@ -2144,12 +1996,8 @@ def map_db_system_summary(s) -> DbSystemSummary | None:
         cpu_core_count=getattr(s, "cpu_core_count", None)
         or data.get("cpu_core_count")
         or data.get("cpuCoreCount"),
-        node_count=getattr(s, "node_count", None)
-        or data.get("node_count")
-        or data.get("nodeCount"),
-        time_created=getattr(s, "time_created", None)
-        or data.get("time_created")
-        or data.get("timeCreated"),
+        node_count=getattr(s, "node_count", None) or data.get("node_count") or data.get("nodeCount"),
+        time_created=getattr(s, "time_created", None) or data.get("time_created") or data.get("timeCreated"),
     )
 
 
@@ -2167,9 +2015,7 @@ class DbSystem(OCIBaseModel):
     node_count: Optional[int] = Field(None, description="Node count.")
     license_model: Optional[str] = Field(None, description="License model.")
     availability_domain: Optional[str] = Field(None, description="Availability domain.")
-    time_created: Optional[datetime] = Field(
-        None, description="Creation time (RFC3339)."
-    )
+    time_created: Optional[datetime] = Field(None, description="Creation time (RFC3339).")
 
 
 def map_db_system(s) -> DbSystem | None:
@@ -2178,9 +2024,7 @@ def map_db_system(s) -> DbSystem | None:
     data = _oci_to_dict(s) or {}
     return DbSystem(
         id=getattr(s, "id", None) or data.get("id"),
-        display_name=getattr(s, "display_name", None)
-        or data.get("display_name")
-        or data.get("displayName"),
+        display_name=getattr(s, "display_name", None) or data.get("display_name") or data.get("displayName"),
         compartment_id=getattr(s, "compartment_id", None)
         or data.get("compartment_id")
         or data.get("compartmentId"),
@@ -2191,18 +2035,14 @@ def map_db_system(s) -> DbSystem | None:
         cpu_core_count=getattr(s, "cpu_core_count", None)
         or data.get("cpu_core_count")
         or data.get("cpuCoreCount"),
-        node_count=getattr(s, "node_count", None)
-        or data.get("node_count")
-        or data.get("nodeCount"),
+        node_count=getattr(s, "node_count", None) or data.get("node_count") or data.get("nodeCount"),
         license_model=getattr(s, "license_model", None)
         or data.get("license_model")
         or data.get("licenseModel"),
         availability_domain=getattr(s, "availability_domain", None)
         or data.get("availability_domain")
         or data.get("availabilityDomain"),
-        time_created=getattr(s, "time_created", None)
-        or data.get("time_created")
-        or data.get("timeCreated"),
+        time_created=getattr(s, "time_created", None) or data.get("time_created") or data.get("timeCreated"),
     )
 
 
@@ -2212,28 +2052,20 @@ def map_db_system(s) -> DbSystem | None:
 class ProtectedDatabaseBackupDestinationItem(OCIBaseModel):
     database_id: str = Field(..., description="Database OCID.")
     db_name: Optional[str] = Field(None, description="Database name.")
-    status: Optional[str] = Field(
-        None, description="CONFIGURED | HAS_BACKUPS | UNCONFIGURED"
-    )
+    status: Optional[str] = Field(None, description="CONFIGURED | HAS_BACKUPS | UNCONFIGURED")
     destination_types: List[str] = Field(
         default_factory=list,
         description="Backup destination type(s) (e.g., DBRS, OSS, NFS).",
     )
-    destination_ids: List[str] = Field(
-        default_factory=list, description="Backup destination OCIDs."
-    )
-    last_backup_time: Optional[datetime] = Field(
-        None, description="Most recent backup time, if computed."
-    )
+    destination_ids: List[str] = Field(default_factory=list, description="Backup destination OCIDs.")
+    last_backup_time: Optional[datetime] = Field(None, description="Most recent backup time, if computed.")
 
 
 class ProtectedDatabaseBackupDestinationSummary(OCIBaseModel):
     compartment_id: Optional[str] = Field(None, description="Compartment OCID.")
     region: Optional[str] = Field(None, description="Region.")
     total_databases: int = Field(0, description="Total databases scanned.")
-    unconfigured_count: int = Field(
-        0, description="Count of databases without configured automatic backups."
-    )
+    unconfigured_count: int = Field(0, description="Count of databases without configured automatic backups.")
     counts_by_destination_type: Dict[str, int] = Field(
         default_factory=dict, description="Counts by destination type."
     )
@@ -2252,3 +2084,4 @@ class ProtectedDatabaseBackupDestinationSummary(OCIBaseModel):
 
 
 # endregion
+

--- a/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/server.py
+++ b/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/server.py
@@ -58,6 +58,7 @@ from oracle.oci_recovery_mcp_server.models import (
     DatabaseSummary,
     DbSystem,
     DbSystemSummary,
+    WorkRequest,
     ProtectedDatabase,
     ProtectedDatabaseBackupDestinationItem,
     ProtectedDatabaseBackupDestinationSummary,
@@ -76,6 +77,7 @@ from oracle.oci_recovery_mcp_server.models import (
     map_db_backup_config,
     map_db_system,
     map_db_system_summary,
+    map_work_request,
     map_protected_database,
     map_protected_database_summary,
     map_protection_policy,
@@ -91,6 +93,8 @@ from . import __project__, __version__
 - summarize_protected_database_health
 - summarize_protected_database_redo_status
 - summarize_backup_space_used
+- check_recovery_service_limits
+- list_subscribed_regions
 - list_protection_policies
 - get_protection_policy
 - list_recovery_service_subnets
@@ -100,6 +104,7 @@ from . import __project__, __version__
 - get_database
 - list_backups
 - get_backup
+- list_restore
 - summarize_protected_database_backup_destination
 - list_db_homes
 - get_db_home
@@ -729,6 +734,27 @@ def get_database_client(region: str = None, *, request_id: Optional[str] = None)
     return _wrap_oci_client(client, request_id=rid, client_name="database")
 
 
+def get_work_request_client(region: str | None = None, *, request_id: Optional[str] = None):
+    """Create an OCI Work Requests client using auth selected via env vars."""
+    regional_config, signer = _get_http_config_and_signer(region)
+    if signer is None:
+        config = _load_oci_config_for_server()
+        regional_config = config if region is None else {**config, "region": region}
+    method = _effective_auth_method()
+    if signer is not None:
+        client = oci.work_requests.WorkRequestClient(regional_config, **_get_oci_client_kwargs(signer))
+    elif method == "apikey":
+        client = oci.work_requests.WorkRequestClient(regional_config, **_get_oci_client_kwargs())
+    else:
+        signer = _build_signer_for_session(regional_config)
+        client = oci.work_requests.WorkRequestClient(
+            regional_config, **_get_oci_client_kwargs(signer)
+        )
+
+    rid = request_id or uuid.uuid4().hex
+    return _wrap_oci_client(client, request_id=rid, client_name="work_requests")
+
+
 def get_monitoring_client(region: str | None = None, *, request_id: Optional[str] = None):
     logger.info("entering get_monitoring_client")
     regional_config, signer = _get_http_config_and_signer(region)
@@ -748,6 +774,94 @@ def get_monitoring_client(region: str | None = None, *, request_id: Optional[str
 
     rid = request_id or uuid.uuid4().hex
     return _wrap_oci_client(client, request_id=rid, client_name="monitoring")
+
+
+def get_limits_client(region: str | None = None, *, request_id: Optional[str] = None):
+    """Create an OCI Limits client using auth selected via env vars."""
+    regional_config, signer = _get_http_config_and_signer(region)
+    if signer is None:
+        config = _load_oci_config_for_server()
+        regional_config = config if region is None else {**config, "region": region}
+    method = _effective_auth_method()
+    if signer is not None:
+        client = oci.limits.LimitsClient(regional_config, **_get_oci_client_kwargs(signer))
+    elif method == "apikey":
+        client = oci.limits.LimitsClient(regional_config, **_get_oci_client_kwargs())
+    else:
+        signer = _build_signer_for_session(regional_config)
+        client = oci.limits.LimitsClient(regional_config, **_get_oci_client_kwargs(signer))
+
+    rid = request_id or uuid.uuid4().hex
+    return _wrap_oci_client(client, request_id=rid, client_name="limits")
+
+
+def get_onesubscription_client(region: str | None = None, *, request_id: Optional[str] = None):
+    """
+    Create a OneSubscription SubscribedService client.
+
+    We use this to discover which regions a tenancy is subscribed to for a given service,
+    so we can execute compartment-scoped queries across all relevant regions.
+    """
+    regional_config, signer = _get_http_config_and_signer(region)
+    if signer is None:
+        config = _load_oci_config_for_server()
+        regional_config = config if region is None else {**config, "region": region}
+    method = _effective_auth_method()
+    if signer is not None:
+        client = oci.onesubscription.SubscribedServiceClient(regional_config, **_get_oci_client_kwargs(signer))
+    elif method == "apikey":
+        client = oci.onesubscription.SubscribedServiceClient(regional_config, **_get_oci_client_kwargs())
+    else:
+        signer = _build_signer_for_session(regional_config)
+        client = oci.onesubscription.SubscribedServiceClient(
+            regional_config, **_get_oci_client_kwargs(signer)
+        )
+
+    rid = request_id or uuid.uuid4().hex
+    return _wrap_oci_client(client, request_id=rid, client_name="onesubscription")
+
+
+_REGION_CACHE: dict[str, Any] = {
+    "fetched_at": 0.0,
+    "ttl_seconds": int(os.getenv("ORACLE_MCP_REGION_CACHE_TTL_SECONDS", "3600")),
+    # items: dict[cache_key -> list[str]]
+    "items": {},
+}
+
+
+def _iam_subscribed_regions_with_status(*, request_id: str) -> list[dict]:
+    """
+    Returns the tenancy's subscribed regions from IAM (IdentityClient.list_region_subscriptions).
+    Output items are: {"region": "<region_name>", "status": "<READY|...>"}.
+
+    Cached in-process for ORACLE_MCP_REGION_CACHE_TTL_SECONDS to avoid repeated IAM calls.
+    """
+    now = time.time()
+    ttl = float(_REGION_CACHE.get("ttl_seconds") or 3600)
+    items = _REGION_CACHE.get("items") or {}
+
+    cache_key = "iam:list_region_subscriptions"
+    fetched_at = float(_REGION_CACHE.get("fetched_at") or 0.0)
+    if cache_key in items and (now - fetched_at) < ttl:
+        return items.get(cache_key) or []
+
+    identity = get_identity_client(request_id=request_id)
+    tenancy_id = get_tenancy()
+    resp = identity.list_region_subscriptions(tenancy_id=tenancy_id)
+    subs = getattr(resp, "data", None) or []
+
+    out: list[dict] = []
+    for sub in subs:
+        region_name = getattr(sub, "region_name", None) or getattr(sub, "regionName", None)
+        status = getattr(sub, "status", None)
+        if region_name:
+            out.append({"region": region_name, "status": status})
+
+    out = sorted(out, key=lambda x: x.get("region") or "")
+    items[cache_key] = out
+    _REGION_CACHE["items"] = items
+    _REGION_CACHE["fetched_at"] = now
+    return out
 
 
 def get_tenancy():
@@ -786,6 +900,261 @@ def list_all_compartments_internal(only_one_page: bool, limit=100):
         )
         compartments.extend(response.data)
     return compartments
+
+
+_COMPARTMENT_CACHE: dict[str, Any] = {
+    "fetched_at": 0.0,
+    "ttl_seconds": int(os.getenv("ORACLE_MCP_COMPARTMENT_CACHE_TTL_SECONDS", "300")),
+    "items": None,  # type: ignore
+}
+
+
+def _list_all_compartments_cached(*, request_id: Optional[str] = None) -> list[Any]:
+    """
+    Return all accessible ACTIVE compartments in the tenancy (plus root tenancy)
+    with a small in-process TTL cache to avoid repeated Identity scans.
+
+    NOTE:
+    - OCI CLI `oci iam compartment list --compartment-id <root>` returns ONLY direct children.
+    - For our use-case (expand subtree), we list the full subtree using:
+        list_compartments(compartment_id_in_subtree=True, access_level="ACCESSIBLE")
+      and then build a parent->children index locally to BFS the descendants.
+    """
+    now = time.time()
+    ttl = float(_COMPARTMENT_CACHE.get("ttl_seconds") or 300)
+    items = _COMPARTMENT_CACHE.get("items")
+    fetched_at = float(_COMPARTMENT_CACHE.get("fetched_at") or 0.0)
+
+    if items and (now - fetched_at) < ttl:
+        return items  # type: ignore[return-value]
+
+    rid = request_id or uuid.uuid4().hex
+
+    # Refresh cache
+    try:
+        comps = list_all_compartments_internal(False)
+
+        # Normalize shape and ensure we always have the root tenancy in the list.
+        # list_all_compartments_internal already tries to append tenancy, but we make it robust.
+        tenancy_id = get_tenancy()
+        seen_ids: set[str] = set()
+        normalized: list[Any] = []
+
+        for c in comps or []:
+            try:
+                cid = getattr(c, "id", None) or getattr(c, "ocid", None)
+            except Exception:
+                cid = None
+            if not cid or cid in seen_ids:
+                continue
+            seen_ids.add(cid)
+            normalized.append(c)
+
+        if tenancy_id and tenancy_id not in seen_ids:
+            try:
+                identity_client = get_identity_client(request_id=rid)
+                t = identity_client.get_compartment(compartment_id=tenancy_id).data
+                normalized.append(t)
+            except Exception:
+                pass
+
+        comps = normalized
+    except Exception as e:
+        # If identity listing fails, fall back to empty (callers will handle)
+        _log_event(
+            "compartment_cache_refresh_failed",
+            request_id=rid,
+            tool=None,
+            phase="error",
+            payload={"error": str(e)},
+            level=logging.WARNING,
+        )
+        comps = []
+
+    _COMPARTMENT_CACHE["items"] = comps
+    _COMPARTMENT_CACHE["fetched_at"] = now
+    return comps
+
+
+def _build_children_index(compartments: list[Any]) -> dict[str, list[str]]:
+    """
+    Build a parent->children map from identity compartment objects.
+
+    Identity compartment model uses:
+      - id: compartment OCID
+      - compartment_id: parent OCID (called "compartment-id" in OCI CLI JSON)
+    """
+    children: dict[str, list[str]] = {}
+    for c in compartments or []:
+        try:
+            cid = getattr(c, "id", None) or getattr(c, "ocid", None)
+            pid = (
+                getattr(c, "compartment_id", None)
+                or getattr(c, "compartmentId", None)
+                or getattr(c, "parent_id", None)
+                or getattr(c, "parentId", None)
+            )
+            if not cid or not pid:
+                continue
+            children.setdefault(pid, []).append(cid)
+        except Exception:
+            continue
+    return children
+
+
+def _expand_compartment_scope(
+    root_compartment_id: str,
+    *,
+    include_child_compartments: bool,
+    request_id: Optional[str] = None,
+) -> list[str]:
+    """
+    Expand a root compartment into a list including all descendant compartments (BFS)
+    when include_child_compartments=True.
+
+    Robustness:
+    - Primary approach: use cached full-subtree identity listing (compartment_id_in_subtree=True)
+      and build a parent->children index locally.
+    - Fallback: if that yields only the root (common in restricted IAM environments),
+      do a direct-children crawl using IdentityClient.list_compartments(compartment_id=<pid>)
+      recursively.
+
+    Safety:
+    - Cap max compartments scanned via ORACLE_MCP_MAX_COMPARTMENTS_IN_SCOPE (default 200).
+    """
+    if not include_child_compartments:
+        return [root_compartment_id]
+
+    cap = int(os.getenv("ORACLE_MCP_MAX_COMPARTMENTS_IN_SCOPE", "200"))
+    rid = request_id or uuid.uuid4().hex
+
+    # ---------------- Primary: cached full-subtree listing ----------------
+    try:
+        comps = _list_all_compartments_cached(request_id=rid)
+        children_index = _build_children_index(comps)
+
+        scope: list[str] = []
+        seen: set[str] = set()
+        queue: list[str] = [root_compartment_id]
+
+        while queue:
+            cid = queue.pop(0)
+            if cid in seen:
+                continue
+            seen.add(cid)
+            scope.append(cid)
+
+            if cap and len(scope) >= cap:
+                _log_event(
+                    "compartment_scope_capped",
+                    request_id=rid,
+                    tool=None,
+                    phase="warn",
+                    payload={"root": root_compartment_id, "cap": cap},
+                    level=logging.WARNING,
+                )
+                return scope
+
+            for child in children_index.get(cid, []) or []:
+                if child not in seen:
+                    queue.append(child)
+
+        # If we found at least one child, we're done.
+        if len(scope) > 1:
+            return scope
+    except Exception:
+        # Fall through to direct-children crawl fallback
+        pass
+
+    # ---------------- Fallback: direct-children crawl ----------------
+    try:
+        identity_client = get_identity_client(request_id=rid)
+
+        scope: list[str] = []
+        seen: set[str] = set()
+        queue: list[str] = [root_compartment_id]
+
+        while queue:
+            pid = queue.pop(0)
+            if pid in seen:
+                continue
+            seen.add(pid)
+            scope.append(pid)
+
+            if cap and len(scope) >= cap:
+                _log_event(
+                    "compartment_scope_capped",
+                    request_id=rid,
+                    tool=None,
+                    phase="warn",
+                    payload={"root": root_compartment_id, "cap": cap},
+                    level=logging.WARNING,
+                )
+                break
+
+            next_page = None
+            while True:
+                resp = identity_client.list_compartments(
+                    compartment_id=pid,
+                    access_level="ACCESSIBLE",
+                    lifecycle_state="ACTIVE",
+                    limit=1000,
+                    page=next_page,
+                )
+                for c in resp.data or []:
+                    cid = getattr(c, "id", None) or getattr(c, "ocid", None)
+                    if cid and cid not in seen:
+                        queue.append(cid)
+
+                has_next = bool(getattr(resp, "has_next_page", False))
+                next_page = getattr(resp, "next_page", None) if has_next else None
+                if not has_next:
+                    break
+
+        return scope
+    except Exception:
+        # Final fallback: only root
+        return [root_compartment_id]
+
+
+def _compartment_ids_for_tool(
+    root_compartment_id: str,
+    *,
+    fetch_for_child_compartment: bool,
+    request_id: Optional[str] = None,
+) -> list[str]:
+    """
+    Helper used by tools to decide compartment scope.
+
+    Behavior:
+    - fetch_for_child_compartment=False  -> [root_compartment_id]
+    - fetch_for_child_compartment=True   -> full subtree (including root)
+
+    IMPORTANT:
+    - We should avoid tool->tool style calls from inside server handlers.
+    - Instead, we reuse the underlying internal helper `_expand_compartment_scope(...)`
+      which implements robust subtree expansion with caching + fallback.
+    """
+    resolved_root = _resolve_compartment_id(root_compartment_id)
+
+    if not fetch_for_child_compartment:
+        return [resolved_root]
+
+    rid = request_id or uuid.uuid4().hex
+
+    try:
+        ids = _expand_compartment_scope(
+            resolved_root,
+            include_child_compartments=True,
+            request_id=rid,
+        )
+        if isinstance(ids, list) and ids:
+            return [str(x) for x in ids if x]
+    except Exception:
+        pass
+
+    # Final fallback: only root
+    return [resolved_root]
 
 
 def _fetch_db_home_ids_for_compartment(compartment_id: str, region: Optional[str] = None) -> list[str]:
@@ -876,6 +1245,127 @@ def _resolve_compartment_id(
     return resolved_id
 
 
+def fetch_child_compartments(
+    compartment_id: Annotated[str, "Root compartment OCID to expand (included in results)."],
+    include_self: Annotated[
+        bool, "When true (default), include the given compartment_id in the output."
+    ] = True,
+    limit: Annotated[
+        Optional[int],
+        "Optional cap on how many compartmentIds to return (defaults to ORACLE_MCP_MAX_COMPARTMENTS_IN_SCOPE or 200).",
+    ] = None,
+) -> dict:
+    """
+    Internal helper that expands a root compartment to its subtree.
+
+    Returns a simple JSON-like dict:
+      {
+        "rootCompartmentId": "<ocid>",
+        "total": N,
+        "compartmentIds": ["<ocid1>", "<ocid2>", ...]
+      }
+
+    Implementation notes:
+    - OCI CLI `oci iam compartment list --compartment-id <X>` returns ONLY direct children.
+    - This tool returns the full subtree under <X>.
+    - Some environments do not allow `compartment_id_in_subtree=True` even with ACCESSIBLE.
+      If subtree listing yields no children for the root, we fall back to a direct-children crawl.
+    """
+    request_id = uuid.uuid4().hex
+    compartment_id = _resolve_compartment_id(compartment_id)
+    identity_client = get_identity_client(request_id=request_id)
+
+    # 1) Try fast path: use our cached full-subtree listing and BFS it.
+    scope = _expand_compartment_scope(
+        compartment_id,
+        include_child_compartments=True,
+        request_id=request_id,
+    )
+
+    # 2) If subtree expansion produced only the root, fall back to direct-children crawl.
+    # This matches the CLI semantics and works even when subtree listing is restricted.
+    if len(scope) <= 1:
+        cap = limit
+        if cap is None:
+            cap = int(os.getenv("ORACLE_MCP_MAX_COMPARTMENTS_IN_SCOPE", "200"))
+
+        queue: list[str] = [compartment_id]
+        seen: set[str] = set()
+        out: list[str] = []
+
+        while queue:
+            pid = queue.pop(0)
+            if pid in seen:
+                continue
+            seen.add(pid)
+            out.append(pid)
+
+            if cap and len(out) >= cap:
+                _log_event(
+                    "compartment_scope_capped",
+                    request_id=request_id,
+                    tool="fetch_child_compartments",
+                    phase="warn",
+                    payload={"root": compartment_id, "cap": cap},
+                    level=logging.WARNING,
+                )
+                break
+
+            next_page = None
+            while True:
+                resp = identity_client.list_compartments(
+                    compartment_id=pid,
+                    access_level="ACCESSIBLE",
+                    lifecycle_state="ACTIVE",
+                    limit=1000,
+                    page=next_page,
+                )
+                children = resp.data or []
+                for c in children:
+                    cid = getattr(c, "id", None) or getattr(c, "ocid", None)
+                    if cid and cid not in seen:
+                        queue.append(cid)
+
+                has_next = bool(getattr(resp, "has_next_page", False))
+                next_page = getattr(resp, "next_page", None) if has_next else None
+                if not has_next:
+                    break
+
+        scope = out
+
+    # include_self behavior
+    if not include_self:
+        scope = [x for x in scope if x != compartment_id]
+
+    # final cap enforcement (also applies to fast-path)
+    cap2 = limit
+    if cap2 is None:
+        cap2 = int(os.getenv("ORACLE_MCP_MAX_COMPARTMENTS_IN_SCOPE", "200"))
+    if cap2 and len(scope) > cap2:
+        scope = scope[:cap2]
+
+    return {
+        "rootCompartmentId": compartment_id,
+        "total": len(scope),
+        "compartmentIds": scope,
+    }
+
+
+def get_compartment_by_name_tool(
+    name: Annotated[
+        str,
+        "Compartment display name to search for (case-insensitive). Searches all "
+        "accessible ACTIVE compartments in the tenancy, including the root tenancy.",
+    ],
+) -> str:
+    """Internal helper to return a compartment matching the provided name."""
+    compartment = get_compartment_by_name(name)
+    if compartment:
+        return str(compartment)
+    else:
+        return json.dumps({"error": f"Compartment '{name}' not found."})
+
+
 @mcp.tool(
     description=(
         "Lists protected databases in a compartment with optional filters. The "
@@ -889,6 +1379,10 @@ def _resolve_compartment_id(
 @_tool_logger("list_protected_databases")
 def list_protected_databases(
     compartment_id: Annotated[str, "The compartment OCID or compartment display name"],
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns the combined results.",
+    ] = False,
     lifecycle_state: Annotated[
         Optional[str],
         (
@@ -918,163 +1412,199 @@ def list_protected_databases(
         # Keep tool behavior intact; only add correlation-id based logging via wrapped client
         request_id = uuid.uuid4().hex
         client = get_recovery_client(region, request_id=request_id)
-        compartment_id = _resolve_compartment_id(compartment_id)
 
         results: list[ProtectedDatabaseSummary] = []
-        has_next_page = True
-        next_page: Optional[str] = page
 
-        while has_next_page:
-            # Build request kwargs from provided filters
-            kwargs = {
-                "compartment_id": compartment_id,
-                "page": next_page,
-            }
-            if lifecycle_state is not None:
-                kwargs["lifecycle_state"] = lifecycle_state
-            if display_name is not None:
-                kwargs["display_name"] = display_name
-            if id is not None:
-                kwargs["id"] = id
-            if protection_policy_id is not None:
-                kwargs["protection_policy_id"] = protection_policy_id
-            if recovery_service_subnet_id is not None:
-                kwargs["recovery_service_subnet_id"] = recovery_service_subnet_id
-            if limit is not None:
-                kwargs["limit"] = limit
-            if sort_order is not None:
-                kwargs["sort_order"] = sort_order
-            if sort_by is not None:
-                kwargs["sort_by"] = sort_by
-            if opc_request_id is not None:
-                kwargs["opc_request_id"] = opc_request_id
+        comp_ids = _compartment_ids_for_tool(
+            compartment_id,
+            fetch_for_child_compartment=fetch_for_child_compartment,
+            request_id=request_id,
+        )
 
-            # Invoke list API and handle pagination
-            response: oci.response.Response = client.list_protected_databases(**kwargs)
-            has_next_page = response.has_next_page
-            next_page = response.next_page if hasattr(response, "next_page") else None
+        for comp_id in comp_ids:
+            has_next_page = True
+            next_page: Optional[str] = page
 
-            # Normalize list and map into our summaries
-            data = response.data
-            items = getattr(data, "items", data)  # collection.items or raw list
-            for d in items:
-                logger.info(f"Item structure: {d}")
-                pd_summary = map_protected_database_summary(d)
-                if pd_summary is None:
-                    continue
+            while has_next_page:
+                # Build request kwargs from provided filters
+                kwargs = {
+                    "compartment_id": comp_id,
+                    "page": next_page,
+                }
+                if lifecycle_state is not None:
+                    kwargs["lifecycle_state"] = lifecycle_state
+                if display_name is not None:
+                    kwargs["display_name"] = display_name
+                if id is not None:
+                    kwargs["id"] = id
+                if protection_policy_id is not None:
+                    kwargs["protection_policy_id"] = protection_policy_id
+                if recovery_service_subnet_id is not None:
+                    kwargs["recovery_service_subnet_id"] = recovery_service_subnet_id
+                if limit is not None:
+                    kwargs["limit"] = limit
+                if sort_order is not None:
+                    kwargs["sort_order"] = sort_order
+                if sort_by is not None:
+                    kwargs["sort_by"] = sort_by
+                if opc_request_id is not None:
+                    kwargs["opc_request_id"] = opc_request_id
 
-                # Start with a dict view of the Pydantic summary (exclude Nones)
-                try:
-                    pd_dict = pd_summary.model_dump(exclude_none=True)
-                except Exception:
+                # Invoke list API and handle pagination
+                response: oci.response.Response = client.list_protected_databases(**kwargs)
+                has_next_page = response.has_next_page
+                next_page = response.next_page if hasattr(response, "next_page") else None
+
+                # Normalize list and map into our summaries
+                data = response.data
+                items = getattr(data, "items", data)  # collection.items or raw list
+                for d in items:
+                    logger.debug(f"Item structure: {d}")
+                    pd_summary = map_protected_database_summary(d)
+                    if pd_summary is None:
+                        continue
+
+                    # Start with a dict view of the Pydantic summary (exclude Nones)
                     try:
-                        pd_dict = pd_summary.dict(exclude_none=True)
+                        pd_dict = pd_summary.model_dump(exclude_none=True)
                     except Exception:
-                        pd_dict = dict(getattr(pd_summary, "__dict__", {}))
-
-                # Enrich/clean Recovery Service Subnet details similarly to get_protected_database
-                try:
-                    rss_list = getattr(pd_summary, "recovery_service_subnets", None)
-                    if rss_list:
-                        enriched = []
-                        for det in rss_list:
-                            if det is None:
-                                continue
-                            rss_id = getattr(det, "id", None)
-                            needs_enrich = bool(
-                                rss_id
-                                and (
-                                    getattr(det, "vcn_id", None) is None
-                                    or getattr(det, "subnet_id", None) is None
-                                    or getattr(det, "display_name", None) is None
-                                    or getattr(det, "compartment_id", None) is None
-                                )
-                            )
-                            if needs_enrich:
-                                try:
-                                    rss_resp: oci.response.Response = client.get_recovery_service_subnet(
-                                        recovery_service_subnet_id=rss_id
-                                    )
-                                    full_rss = rss_resp.data
-                                    mapped_det = map_recovery_service_subnet_details(full_rss)
-                                    enriched.append(mapped_det or det)
-                                except Exception:
-                                    enriched.append(det)
-                            else:
-                                enriched.append(det)
-                        # Clean and serialize RSS list, dropping noisy fields to match get_protected_database
-                        cleaned_rss = []
-                        for ed in enriched:
-                            if isinstance(ed, dict):
-                                rd = dict(ed)
-                            else:
-                                try:
-                                    rd = ed.model_dump(exclude_none=True)
-                                except Exception:
-                                    try:
-                                        rd = ed.dict(exclude_none=True)
-                                    except Exception:
-                                        rd = dict(getattr(ed, "__dict__", {}))
-                            for _rm in (
-                                "lifecycle_details",
-                                "time_created",
-                                "time_updated",
-                                "freeform_tags",
-                                "defined_tags",
-                                "system_tags",
-                            ):
-                                rd.pop(_rm, None)
-                            cleaned_rss.append(rd)
-                        pd_dict["recovery_service_subnets"] = cleaned_rss
-                except Exception:
-                    # best-effort enrichment
-                    pass
-
-                # Populate metrics from full GET to align with CLI list output (no derivations/fallbacks)
-                try:
-                    pdid = pd_dict.get("id") or getattr(pd_summary, "id", None)
-                    if pdid:
                         try:
-                            g = client.get_protected_database(protected_database_id=pdid)
-                            full_pd = map_protected_database(getattr(g, "data", None))
-                            mobj = getattr(full_pd, "metrics", None)
-                            md = None
-                            if mobj is not None:
-                                try:
-                                    md = mobj.model_dump(exclude_none=False)
-                                except Exception:
-                                    try:
-                                        md = mobj.dict(exclude_none=False)
-                                    except Exception:
-                                        md = None
-
-                            def _pick(d: dict | None, key: str):
-                                if not isinstance(d, dict):
-                                    return None
-                                return d.get(key)
-
-                            metrics_out = {
-                                "backup-space-estimate-in-gbs": _pick(md, "backup_space_estimate_in_gbs"),
-                                "backup-space-used-in-gbs": _pick(md, "backup_space_used_in_gbs"),
-                                "current-retention-period-in-seconds": _pick(
-                                    md, "current_retention_period_in_seconds"
-                                ),
-                                "db-size-in-gbs": _pick(md, "database_size_in_gbs"),
-                                "is-redo-logs-enabled": _pick(md, "is_redo_logs_enabled"),
-                                "minimum-recovery-needed-in-days": _pick(
-                                    md, "minimum_recovery_needed_in_days"
-                                ),
-                                "retention-period-in-days": _pick(md, "retention_period_in_days"),
-                                "unprotected-window-in-seconds": _pick(md, "unprotected_window_in_seconds"),
-                            }
-                            pd_dict["metrics"] = metrics_out
+                            pd_dict = pd_summary.dict(exclude_none=True)
                         except Exception:
-                            # If GET fails, do not set metrics (avoid misleading partials)
-                            pass
-                except Exception:
-                    pass
+                            pd_dict = dict(getattr(pd_summary, "__dict__", {}))
 
-                results.append(pd_dict)
+                    # Keep retention-lock visibility explicit for clients:
+                    # include camelCase key even when value is None.
+                    pd_dict["policyLockedDateTime"] = getattr(pd_summary, "policy_locked_date_time", None)
+
+                    # Enrich/clean Recovery Service Subnet details similarly to get_protected_database
+                    try:
+                        rss_list = getattr(pd_summary, "recovery_service_subnets", None)
+                        if rss_list:
+                            enriched = []
+                            for det in rss_list:
+                                if det is None:
+                                    continue
+                                rss_id = getattr(det, "id", None)
+                                needs_enrich = bool(
+                                    rss_id
+                                    and (
+                                        getattr(det, "vcn_id", None) is None
+                                        or getattr(det, "subnet_id", None) is None
+                                        or getattr(det, "display_name", None) is None
+                                        or getattr(det, "compartment_id", None) is None
+                                    )
+                                )
+                                if needs_enrich:
+                                    try:
+                                        rss_resp: oci.response.Response = client.get_recovery_service_subnet(
+                                            recovery_service_subnet_id=rss_id
+                                        )
+                                        full_rss = rss_resp.data
+                                        mapped_det = map_recovery_service_subnet_details(full_rss)
+                                        enriched.append(mapped_det or det)
+                                    except Exception:
+                                        enriched.append(det)
+                                else:
+                                    enriched.append(det)
+                            # Clean and serialize RSS list, dropping noisy fields to match get_protected_database
+                            cleaned_rss = []
+                            for ed in enriched:
+                                if isinstance(ed, dict):
+                                    rd = dict(ed)
+                                else:
+                                    try:
+                                        rd = ed.model_dump(exclude_none=True)
+                                    except Exception:
+                                        try:
+                                            rd = ed.dict(exclude_none=True)
+                                        except Exception:
+                                            rd = dict(getattr(ed, "__dict__", {}))
+                                for _rm in (
+                                    "lifecycle_details",
+                                    "time_created",
+                                    "time_updated",
+                                    "freeform_tags",
+                                    "defined_tags",
+                                    "system_tags",
+                                ):
+                                    rd.pop(_rm, None)
+                                cleaned_rss.append(rd)
+                            pd_dict["recovery_service_subnets"] = cleaned_rss
+                    except Exception:
+                        # best-effort enrichment
+                        pass
+
+                    # Populate metrics from full GET to align with CLI list output (no derivations/fallbacks)
+                    try:
+                        pdid = pd_dict.get("id") or getattr(pd_summary, "id", None)
+                        if pdid:
+                            try:
+                                g = client.get_protected_database(protected_database_id=pdid)
+                                full_pd = map_protected_database(getattr(g, "data", None))
+                                mobj = getattr(full_pd, "metrics", None)
+                                md = None
+                                if mobj is not None:
+                                    try:
+                                        md = mobj.model_dump(exclude_none=False)
+                                    except Exception:
+                                        try:
+                                            md = mobj.dict(exclude_none=False)
+                                        except Exception:
+                                            md = None
+
+                                def _pick(d: dict | None, key: str):
+                                    if not isinstance(d, dict):
+                                        return None
+                                    return d.get(key)
+
+                                metrics_out = {
+                                    "backup-space-estimate-in-gbs": _pick(md, "backup_space_estimate_in_gbs"),
+                                    "backup-space-used-in-gbs": _pick(md, "backup_space_used_in_gbs"),
+                                    "current-retention-period-in-seconds": _pick(
+                                        md, "current_retention_period_in_seconds"
+                                    ),
+                                    "db-size-in-gbs": _pick(md, "database_size_in_gbs"),
+                                    "is-redo-logs-enabled": _pick(md, "is_redo_logs_enabled"),
+                                    "minimum-recovery-needed-in-days": _pick(
+                                        md, "minimum_recovery_needed_in_days"
+                                    ),
+                                    "retention-period-in-days": _pick(md, "retention_period_in_days"),
+                                    "unprotected-window-in-seconds": _pick(
+                                        md, "unprotected_window_in_seconds"
+                                    ),
+                                }
+
+                                # Keep real-time protection status explicit in list output.
+                                # Prefer top-level PD flag; fallback to metrics flag.
+                                redo_shipped = getattr(full_pd, "is_redo_logs_shipped", None)
+                                if redo_shipped is None:
+                                    redo_shipped = _pick(md, "is_redo_logs_enabled")
+
+                                # Emit both key variants for client compatibility.
+                                pd_dict["is_redo_logs_shipped"] = redo_shipped
+                                pd_dict["isRedoLogsShipped"] = redo_shipped
+
+                                pd_dict["metrics"] = metrics_out
+                            except Exception:
+                                # If GET fails, do not set metrics (avoid misleading partials)
+                                pass
+                    except Exception:
+                        pass
+
+                    results.append(pd_dict)
+
+        # De-dupe by OCID when scanning multiple compartments
+        if fetch_for_child_compartment:
+            uniq: dict[str, Any] = {}
+            for r in results:
+                try:
+                    rid = r.get("id") if isinstance(r, dict) else getattr(r, "id", None)
+                except Exception:
+                    rid = None
+                if rid and rid not in uniq:
+                    uniq[rid] = r
+            results = list(uniq.values())
 
         logger.info(f"Found {len(results)} Protected Databases")
         return results
@@ -1088,8 +1618,11 @@ def list_protected_databases(
     description=(
         "Gets a protected database by OCID and presents a clean, easy‑to‑read view. "
         "It includes Recovery Service Subnet details, hides noisy fields, and adds "
-        "core metrics. The result is one protected database as a plain dictionary "
-        "with subnet info and a simple metrics section."
+        "core metrics. It also includes policyLockedDateTime so retention-lock "
+        "status is explicit (null means lock is disabled for the attached "
+        "protection policy; a timestamp means lock is configured/effective). "
+        "The result is one protected database as a plain dictionary with subnet "
+        "info and a simple metrics section."
     )
 )
 @_tool_logger("get_protected_database")
@@ -1167,6 +1700,10 @@ def get_protected_database(
                 pd_dict = pd.dict(exclude_none=True)  # pydantic v1 fallback
             except Exception:
                 pd_dict = dict(getattr(pd, "__dict__", {}))
+
+        # Keep retention-lock visibility explicit for clients:
+        # include camelCase key even when value is None.
+        pd_dict["policyLockedDateTime"] = getattr(pd, "policy_locked_date_time", None)
 
         # Remove top-level fields not desired in response
         for _k in ("change_rate", "compression_ratio"):
@@ -1251,6 +1788,10 @@ def summarize_protected_database_health(
         Optional[str],
         "Compartment OCID or compartment display name. If omitted, defaults to the tenancy OCID from your OCI profile.",
     ] = None,
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns aggregated counts plus per-compartment breakdown.",
+    ] = False,
     region: Annotated[Optional[str], "OCI region to execute the request in (e.g., us-ashburn-1)"] = None,
 ) -> ProtectedDatabaseHealthCounts:
     """
@@ -1262,7 +1803,12 @@ def summarize_protected_database_health(
     try:
         request_id = uuid.uuid4().hex
         client = get_recovery_client(region, request_id=request_id)
-        comp_id = _resolve_compartment_id(compartment_id, default_to_tenancy=True)
+        comp_id = compartment_id or get_tenancy()
+        comp_ids = _compartment_ids_for_tool(
+            comp_id,
+            fetch_for_child_compartment=fetch_for_child_compartment,
+            request_id=request_id,
+        )
 
         protected = 0
         warning = 0
@@ -1270,71 +1816,100 @@ def summarize_protected_database_health(
         unknown = 0
         scanned = 0
 
+        per_compartment: list[dict] = []
+
         has_next_page = True
         next_page: Optional[str] = None
 
-        while has_next_page:
-            # Fetch ACTIVE PDs page by page
-            list_kwargs = {
-                "compartment_id": comp_id,
-                "page": next_page,
-                "lifecycle_state": "ACTIVE",
-            }
-            response: oci.response.Response = client.list_protected_databases(**list_kwargs)
-            has_next_page = response.has_next_page
-            next_page = response.next_page if hasattr(response, "next_page") else None
+        for each_comp in comp_ids:
+            c_protected = 0
+            c_warning = 0
+            c_alert = 0
+            c_unknown = 0
+            c_scanned = 0
 
-            data = response.data
-            items = getattr(data, "items", data)
-            for item in items or []:
-                # Try to read health from list summary; shape can vary by SDK versions
-                health = getattr(item, "health", None)
-                if not health and hasattr(item, "__dict__"):
-                    try:
-                        health = item.__dict__.get("health")
-                    except Exception:
-                        health = None
+            has_next_page = True
+            next_page = None
 
-                # Robustly extract PD OCID to allow follow-up GET if required
-                pd_id = getattr(item, "id", None) or (
-                    getattr(item, "data", None) and getattr(item.data, "id", None)
-                )
-                logger.info(f"Item structure: {item}")
-                if pd_id is None:
-                    try:
-                        item_dict = getattr(item, "__dict__", None) or {}
-                        pd_id = item_dict.get("id")
-                    except Exception:
-                        pd_id = None
-                if not pd_id:
-                    # Can't fetch details; skip counting this entry
-                    continue
+            while has_next_page:
+                # Fetch ACTIVE PDs page by page
+                list_kwargs = {
+                    "compartment_id": each_comp,
+                    "page": next_page,
+                    "lifecycle_state": "ACTIVE",
+                }
+                response: oci.response.Response = client.list_protected_databases(**list_kwargs)
+                has_next_page = response.has_next_page
+                next_page = response.next_page if hasattr(response, "next_page") else None
 
-                scanned += 1
+                data = response.data
+                items = getattr(data, "items", data)
+                for item in items or []:
+                    # Try to read health from list summary; shape can vary by SDK versions
+                    health = getattr(item, "health", None)
+                    if not health and hasattr(item, "__dict__"):
+                        try:
+                            health = item.__dict__.get("health")
+                        except Exception:
+                            health = None
 
-                # If health is not on the summary, fetch the full resource
-                if not health:
-                    try:
-                        pd_resp: oci.response.Response = client.get_protected_database(
-                            protected_database_id=pd_id
-                        )
-                        pd = pd_resp.data
-                        health = getattr(pd, "health", None)
-                        if not health and hasattr(pd, "__dict__"):
-                            health = pd.__dict__.get("health")
-                    except Exception:
-                        health = None
+                    # Robustly extract PD OCID to allow follow-up GET if required
+                    pd_id = getattr(item, "id", None) or (
+                        getattr(item, "data", None) and getattr(item.data, "id", None)
+                    )
+                    logger.debug(f"Item structure: {item}")
+                    if pd_id is None:
+                        try:
+                            item_dict = getattr(item, "__dict__", None) or {}
+                            pd_id = item_dict.get("id")
+                        except Exception:
+                            pd_id = None
+                    if not pd_id:
+                        # Can't fetch details; skip counting this entry
+                        continue
 
-                # Increment appropriate counters
-                if health == "PROTECTED":
-                    protected += 1
-                elif health == "WARNING":
-                    warning += 1
-                elif health == "ALERT":
-                    alert += 1
-                else:
-                    # unknown/None health
-                    unknown += 1
+                    scanned += 1
+                    c_scanned += 1
+
+                    # If health is not on the summary, fetch the full resource
+                    if not health:
+                        try:
+                            pd_resp: oci.response.Response = client.get_protected_database(
+                                protected_database_id=pd_id
+                            )
+                            pd = pd_resp.data
+                            health = getattr(pd, "health", None)
+                            if not health and hasattr(pd, "__dict__"):
+                                health = pd.__dict__.get("health")
+                        except Exception:
+                            health = None
+
+                    # Increment appropriate counters
+                    if health == "PROTECTED":
+                        protected += 1
+                        c_protected += 1
+                    elif health == "WARNING":
+                        warning += 1
+                        c_warning += 1
+                    elif health == "ALERT":
+                        alert += 1
+                        c_alert += 1
+                    else:
+                        # unknown/None health
+                        unknown += 1
+                        c_unknown += 1
+
+            per_compartment.append(
+                {
+                    "compartmentId": each_comp,
+                    "region": region,
+                    "protected": c_protected,
+                    "warning": c_warning,
+                    "alert": c_alert,
+                    "unknown": c_unknown,
+                    "total": c_scanned,
+                }
+            )
 
         total = scanned
         logger.info(
@@ -1350,7 +1925,7 @@ def summarize_protected_database_health(
         )
         # NOTE: construct using the alias key (compartmentId) to avoid any
         # pydantic alias population edge-cases that can result in null output.
-        result = ProtectedDatabaseHealthCounts(
+        aggregated = ProtectedDatabaseHealthCounts(
             compartmentId=comp_id,
             region=region,
             protected=protected,
@@ -1360,12 +1935,12 @@ def summarize_protected_database_health(
             total=total,
         )
         try:
-            return result.model_dump(exclude_none=False, by_alias=True)
+            agg_dict = aggregated.model_dump(exclude_none=False, by_alias=True)
         except Exception:
             try:
-                return result.dict(exclude_none=False, by_alias=True)
+                agg_dict = aggregated.dict(exclude_none=False, by_alias=True)
             except Exception:
-                return {
+                agg_dict = {
                     "compartmentId": comp_id,
                     "region": region,
                     "protected": protected,
@@ -1374,6 +1949,12 @@ def summarize_protected_database_health(
                     "unknown": unknown,
                     "total": total,
                 }
+
+        return {
+            "aggregated": agg_dict,
+            "per_compartment": per_compartment,
+            "compartmentIdsScanned": comp_ids,
+        }
     except Exception as e:
         logger.error(f"Error in summarize_protected_database_health tool: {str(e)}")
         raise
@@ -1394,6 +1975,10 @@ def summarize_protected_database_redo_status(
         Optional[str],
         "Compartment OCID or compartment display name. If omitted, defaults to the tenancy OCID from your OCI profile.",
     ] = None,
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns aggregated counts plus per-compartment breakdown.",
+    ] = False,
     region: Annotated[Optional[str], "OCI region to execute the request in (e.g., us-ashburn-1)"] = None,
 ) -> ProtectedDatabaseRedoCounts:
     """
@@ -1404,70 +1989,101 @@ def summarize_protected_database_redo_status(
     try:
         request_id = uuid.uuid4().hex
         client = get_recovery_client(region, request_id=request_id)
-        comp_id = _resolve_compartment_id(compartment_id, default_to_tenancy=True)
+        comp_id = compartment_id or get_tenancy()
+        comp_ids = _compartment_ids_for_tool(
+            comp_id,
+            fetch_for_child_compartment=fetch_for_child_compartment,
+            request_id=request_id,
+        )
 
         enabled = 0
         disabled = 0
+        per_compartment: list[dict] = []
 
         has_next_page = True
         next_page: Optional[str] = None
 
-        while has_next_page:
-            # List ACTIVE PDs to assess redo status via GET per PD
-            list_kwargs = {
-                "compartment_id": comp_id,
-                "page": next_page,
-                "lifecycle_state": "ACTIVE",
-            }
-            response: oci.response.Response = client.list_protected_databases(**list_kwargs)
-            has_next_page = response.has_next_page
-            next_page = response.next_page if hasattr(response, "next_page") else None
+        for each_comp in comp_ids:
+            c_enabled = 0
+            c_disabled = 0
 
-            data = response.data
-            items = getattr(data, "items", data)
-            for item in items or []:
-                # Robustly get the PD OCID from summary item
-                pd_id = getattr(item, "id", None) or (
-                    getattr(item, "data", None) and getattr(item.data, "id", None)
-                )
-                if pd_id is None:
-                    try:
-                        item_dict = getattr(item, "__dict__", None) or {}
-                        pd_id = item_dict.get("id")
-                    except Exception:
-                        pd_id = None
-                if not pd_id:
-                    continue
+            has_next_page = True
+            next_page = None
 
-                # Fetch full Protected Database to read is_redo_logs_shipped (primary)
-                pd_resp: oci.response.Response = client.get_protected_database(protected_database_id=pd_id)
-                pd = pd_resp.data
-                redo_enabled = getattr(pd, "is_redo_logs_shipped", None)
-                if redo_enabled is None and hasattr(pd, "__dict__"):
-                    redo_enabled = pd.__dict__.get("is_redo_logs_shipped") or pd.__dict__.get(
-                        "isRedoLogsShipped"
+            while has_next_page:
+                # List ACTIVE PDs to assess redo status via GET per PD
+                list_kwargs = {
+                    "compartment_id": each_comp,
+                    "page": next_page,
+                    "lifecycle_state": "ACTIVE",
+                }
+                response: oci.response.Response = client.list_protected_databases(**list_kwargs)
+                has_next_page = response.has_next_page
+                next_page = response.next_page if hasattr(response, "next_page") else None
+
+                data = response.data
+                items = getattr(data, "items", data)
+                for item in items or []:
+                    # Robustly get the PD OCID from summary item
+                    pd_id = getattr(item, "id", None) or (
+                        getattr(item, "data", None) and getattr(item.data, "id", None)
                     )
-                # Fallback: some SDK/reporting expose Real-time protection
-                # under metrics as is_redo_logs_enabled
-                if redo_enabled is None:
+                    if pd_id is None:
+                        try:
+                            item_dict = getattr(item, "__dict__", None) or {}
+                            pd_id = item_dict.get("id")
+                        except Exception:
+                            pd_id = None
+                    if not pd_id:
+                        continue
+
+                    # Fetch full Protected Database to read is_redo_logs_shipped (primary)
+                    redo_enabled = None
                     try:
-                        m = getattr(pd, "metrics", None)
-                        if m is not None:
-                            redo_enabled = getattr(m, "is_redo_logs_enabled", None)
-                            if redo_enabled is None and hasattr(m, "__dict__"):
-                                redo_enabled = m.__dict__.get("is_redo_logs_enabled") or m.__dict__.get(
-                                    "isRedoLogsEnabled"
-                                )
+                        pd_resp: oci.response.Response = client.get_protected_database(
+                            protected_database_id=pd_id
+                        )
+                        pd = pd_resp.data
+                        redo_enabled = getattr(pd, "is_redo_logs_shipped", None)
+                        if redo_enabled is None and hasattr(pd, "__dict__"):
+                            redo_enabled = pd.__dict__.get("is_redo_logs_shipped") or pd.__dict__.get(
+                                "isRedoLogsShipped"
+                            )
+                        # Fallback: some SDK/reporting expose Real-time protection
+                        # under metrics as is_redo_logs_enabled
+                        if redo_enabled is None:
+                            try:
+                                m = getattr(pd, "metrics", None)
+                                if m is not None:
+                                    redo_enabled = getattr(m, "is_redo_logs_enabled", None)
+                                    if redo_enabled is None and hasattr(m, "__dict__"):
+                                        redo_enabled = m.__dict__.get(
+                                            "is_redo_logs_enabled"
+                                        ) or m.__dict__.get("isRedoLogsEnabled")
+                            except Exception:
+                                pass
                     except Exception:
+                        redo_enabled = None
+
+                    if redo_enabled is True:
+                        enabled += 1
+                        c_enabled += 1
+                    elif redo_enabled is False:
+                        disabled += 1
+                        c_disabled += 1
+                    else:
+                        # None/unknown -> do not count
                         pass
 
-                if redo_enabled is True:
-                    enabled += 1
-                elif redo_enabled is False:
-                    disabled += 1
-                else:
-                    # None/unknown -> do not count
-                    pass
+            per_compartment.append(
+                {
+                    "compartmentId": each_comp,
+                    "region": region,
+                    "enabled": c_enabled,
+                    "disabled": c_disabled,
+                    "total": c_enabled + c_disabled,
+                }
+            )
 
         total = enabled + disabled
         logger.info(
@@ -1480,7 +2096,7 @@ def summarize_protected_database_redo_status(
         )
         # NOTE: construct using the alias key (compartmentId) to avoid any
         # pydantic alias population edge-cases that can result in null output.
-        result = ProtectedDatabaseRedoCounts(
+        aggregated = ProtectedDatabaseRedoCounts(
             compartmentId=comp_id,
             region=region,
             enabled=enabled,
@@ -1488,18 +2104,24 @@ def summarize_protected_database_redo_status(
             total=total,
         )
         try:
-            return result.model_dump(exclude_none=False, by_alias=True)
+            agg_dict = aggregated.model_dump(exclude_none=False, by_alias=True)
         except Exception:
             try:
-                return result.dict(exclude_none=False, by_alias=True)
+                agg_dict = aggregated.dict(exclude_none=False, by_alias=True)
             except Exception:
-                return {
+                agg_dict = {
                     "compartmentId": comp_id,
                     "region": region,
                     "enabled": enabled,
                     "disabled": disabled,
                     "total": total,
                 }
+
+        return {
+            "aggregated": agg_dict,
+            "per_compartment": per_compartment,
+            "compartmentIdsScanned": comp_ids,
+        }
     except Exception as e:
         logger.error(f"Error in summarize_protected_database_redo_status tool: {e}")
         raise
@@ -1521,6 +2143,10 @@ def summarize_backup_space_used(
         Optional[str],
         "Compartment OCID or compartment display name. If omitted, defaults to the tenancy OCID from your OCI profile.",
     ] = None,
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns aggregated sum plus per-compartment breakdown.",
+    ] = False,
     region: Annotated[
         Optional[str],
         "Canonical OCI region (e.g., us-ashburn-1) to execute the request in.",
@@ -1535,104 +2161,132 @@ def summarize_backup_space_used(
     """
     try:
         request_id = uuid.uuid4().hex
-        client = get_recovery_client(region, request_id=request_id)
         comp_id = _resolve_compartment_id(compartment_id, default_to_tenancy=True)
+        client = get_recovery_client(region, request_id=request_id)
+        comp_ids = _compartment_ids_for_tool(
+            comp_id,
+            fetch_for_child_compartment=fetch_for_child_compartment,
+            request_id=request_id,
+        )
+
         sum_gb = 0.0
         scanned = 0
         missing_metrics = 0
-        has_next_page = True
-        next_page: Optional[str] = None
+        per_compartment: list[dict] = []
 
-        while has_next_page:
-            list_kwargs = {
-                "compartment_id": comp_id,
-                "page": next_page,
-            }
-            response: oci.response.Response = client.list_protected_databases(**list_kwargs)
-            has_next_page = response.has_next_page
-            next_page = response.next_page if hasattr(response, "next_page") else None
+        for each_comp in comp_ids:
+            c_sum_gb = 0.0
+            c_scanned = 0
+            c_missing_metrics = 0
 
-            data = response.data
-            items = getattr(data, "items", data)
+            has_next_page = True
+            next_page = None
 
-            for item in items or []:
-                # Filter by lifecycle state: include only ACTIVE or DELETE_SCHEDULED
-                # (exclude DELETED and others)
-                try:
-                    lifecycle_state = getattr(item, "lifecycle_state", None)
-                    if not lifecycle_state and hasattr(item, "__dict__"):
-                        lifecycle_state = (getattr(item, "__dict__", {}) or {}).get("lifecycle_state") or (
-                            getattr(item, "__dict__", {}) or {}
-                        ).get("lifecycleState")
-                except Exception:
-                    lifecycle_state = None
-                if lifecycle_state not in ("ACTIVE", "DELETE_SCHEDULED"):
-                    # Skip PDs that are not ACTIVE or DELETE_SCHEDULED (e.g., DELETED, CREATING, etc.)
-                    continue
+            while has_next_page:
+                list_kwargs = {
+                    "compartment_id": each_comp,
+                    "page": next_page,
+                }
+                response: oci.response.Response = client.list_protected_databases(**list_kwargs)
+                has_next_page = response.has_next_page
+                next_page = response.next_page if hasattr(response, "next_page") else None
 
-                # Robustly get the PD OCID from summary item (same as redo status tool)
-                pd_id = getattr(item, "id", None) or (
-                    getattr(item, "data", None) and getattr(item.data, "id", None)
-                )
-                logger.info(f"Item structure: {item}")
-                if pd_id is None:
+                data = response.data
+                items = getattr(data, "items", data)
+
+                for item in items or []:
+                    # Filter by lifecycle state: include only ACTIVE or DELETE_SCHEDULED
+                    # (exclude DELETED and others)
                     try:
-                        item_dict = getattr(item, "__dict__", None) or {}
-                        pd_id = item_dict.get("id")
+                        lifecycle_state = getattr(item, "lifecycle_state", None)
+                        if not lifecycle_state and hasattr(item, "__dict__"):
+                            lifecycle_state = (getattr(item, "__dict__", {}) or {}).get(
+                                "lifecycle_state"
+                            ) or (getattr(item, "__dict__", {}) or {}).get("lifecycleState")
                     except Exception:
-                        pd_id = None
-                if not pd_id:
-                    continue
+                        lifecycle_state = None
+                    if lifecycle_state not in ("ACTIVE", "DELETE_SCHEDULED"):
+                        # Skip PDs that are not ACTIVE or DELETE_SCHEDULED (e.g., DELETED, CREATING, etc.)
+                        continue
 
-                scanned += 1
-
-                # Always fetch the full Protected Database to read metrics reliably
-                gb_val = None
-                try:
-                    pd_resp: oci.response.Response = client.get_protected_database(
-                        protected_database_id=pd_id
+                    # Robustly get the PD OCID from summary item (same as redo status tool)
+                    pd_id = getattr(item, "id", None) or (
+                        getattr(item, "data", None) and getattr(item.data, "id", None)
                     )
-                    pd_obj = pd_resp.data
-                    metrics = getattr(pd_obj, "metrics", None)
-                    if metrics is None and hasattr(pd_obj, "__dict__"):
-                        metrics = getattr(pd_obj, "__dict__", {}).get("metrics")
-                    # metrics may be a model or a dict; normalise access
-                    if metrics is not None:
-                        if hasattr(metrics, "backup_space_used_in_gbs"):
-                            gb_val = getattr(metrics, "backup_space_used_in_gbs", None)
-                        if gb_val is None and hasattr(metrics, "__dict__"):
-                            gb_val = metrics.__dict__.get("backup_space_used_in_gbs") or metrics.__dict__.get(
-                                "backupSpaceUsedInGbs"
-                            )
-                        if gb_val is None and isinstance(metrics, dict):
-                            gb_val = metrics.get("backup_space_used_in_gbs") or metrics.get(
-                                "backupSpaceUsedInGbs"
-                            )
-                except Exception:
-                    # If GET fails, fall back to any summary metrics representation
+                    logger.debug(f"Item structure: {item}")
+                    if pd_id is None:
+                        try:
+                            item_dict = getattr(item, "__dict__", None) or {}
+                            pd_id = item_dict.get("id")
+                        except Exception:
+                            pd_id = None
+                    if not pd_id:
+                        continue
+
+                    scanned += 1
+                    c_scanned += 1
+
+                    # Always fetch the full Protected Database to read metrics reliably
+                    gb_val = None
                     try:
-                        m = getattr(item, "metrics", None)
-                        if m is not None:
-                            gb_val = getattr(m, "backup_space_used_in_gbs", None)
-                            if gb_val is None and hasattr(m, "__dict__"):
-                                gb_val = m.__dict__.get("backup_space_used_in_gbs") or m.__dict__.get(
+                        pd_resp: oci.response.Response = client.get_protected_database(
+                            protected_database_id=pd_id
+                        )
+                        pd_obj = pd_resp.data
+                        metrics = getattr(pd_obj, "metrics", None)
+                        if metrics is None and hasattr(pd_obj, "__dict__"):
+                            metrics = getattr(pd_obj, "__dict__", {}).get("metrics")
+                        # metrics may be a model or a dict; normalise access
+                        if metrics is not None:
+                            if hasattr(metrics, "backup_space_used_in_gbs"):
+                                gb_val = getattr(metrics, "backup_space_used_in_gbs", None)
+                            if gb_val is None and hasattr(metrics, "__dict__"):
+                                gb_val = metrics.__dict__.get(
+                                    "backup_space_used_in_gbs"
+                                ) or metrics.__dict__.get("backupSpaceUsedInGbs")
+                            if gb_val is None and isinstance(metrics, dict):
+                                gb_val = metrics.get("backup_space_used_in_gbs") or metrics.get(
                                     "backupSpaceUsedInGbs"
                                 )
-                            if gb_val is None and isinstance(m, dict):
-                                gb_val = m.get("backup_space_used_in_gbs") or m.get("backupSpaceUsedInGbs")
                     except Exception:
-                        gb_val = None
+                        # If GET fails, fall back to any summary metrics representation
+                        try:
+                            m = getattr(item, "metrics", None)
+                            if m is not None:
+                                gb_val = getattr(m, "backup_space_used_in_gbs", None)
+                                if gb_val is None and hasattr(m, "__dict__"):
+                                    gb_val = m.__dict__.get("backup_space_used_in_gbs") or m.__dict__.get(
+                                        "backupSpaceUsedInGbs"
+                                    )
+                                if gb_val is None and isinstance(m, dict):
+                                    gb_val = m.get("backup_space_used_in_gbs") or m.get(
+                                        "backupSpaceUsedInGbs"
+                                    )
+                        except Exception:
+                            gb_val = None
 
-                if gb_val is None:
-                    missing_metrics += 1
+                    if gb_val is None:
+                        missing_metrics += 1
+                        c_missing_metrics += 1
 
-                # Ensure numeric value; treat missing/non-numeric as 0.0
-                try:
-                    gb = float(gb_val) if gb_val is not None else 0.0
-                except Exception:
-                    gb = 0.0
+                    # Ensure numeric value; treat missing/non-numeric as 0.0
+                    try:
+                        gb = float(gb_val) if gb_val is not None else 0.0
+                    except Exception:
+                        gb = 0.0
 
-                sum_gb += gb
+                    sum_gb += gb
+                    c_sum_gb += gb
+
+            per_compartment.append(
+                {
+                    "compartmentId": each_comp,
+                    "region": region,
+                    "totalDatabasesScanned": c_scanned,
+                    "sumBackupSpaceUsedInGBs": round(c_sum_gb, 2),
+                    "missingMetricsCount": c_missing_metrics,
+                }
+            )
 
         logger.info(
             "Backup space used summary for compartment %s (region=%s): "
@@ -1643,17 +2297,159 @@ def summarize_backup_space_used(
             sum_gb,
             missing_metrics,
         )
-        return ProtectedDatabaseBackupSpaceSum(
+        aggregated = ProtectedDatabaseBackupSpaceSum(
             compartmentId=comp_id,
             region=region,
             totalDatabasesScanned=scanned,
             sumBackupSpaceUsedInGBs=round(sum_gb, 2),
         )
+        try:
+            agg_dict = aggregated.model_dump(exclude_none=False, by_alias=True)
+        except Exception:
+            try:
+                agg_dict = aggregated.dict(exclude_none=False, by_alias=True)
+            except Exception:
+                agg_dict = {
+                    "compartmentId": comp_id,
+                    "region": region,
+                    "totalDatabasesScanned": scanned,
+                    "sumBackupSpaceUsedInGBs": round(sum_gb, 2),
+                }
+
+        return {
+            "aggregated": agg_dict,
+            "per_compartment": per_compartment,
+            "compartmentIdsScanned": comp_ids,
+            "missingMetricsCount": missing_metrics,
+        }
         # logger.info(f"Returning dict result: {result}")
         # return result
     except Exception as e:
         logger.error(f"Error in summarize_backup_space_used tool: {str(e)}")
         raise
+
+
+@mcp.tool(
+    description=(
+        "Checks OCI service limits for Autonomous Recovery Service using tenancy context from config profile."
+        "It fetches resource availability for protected database backup storage (GB) "
+        "and protected database count, then returns both values in a simple JSON "
+        "response with tenancy compartment and configured region context."
+    )
+)
+@_tool_logger("check_recovery_service_limits")
+def check_recovery_service_limits(
+    compartment_id: Annotated[
+        Optional[str],
+        "(Ignored; accepted for backward compatibility). Limits are always checked against tenancy from config.",
+    ] = None,
+    region: Annotated[
+        Optional[str],
+        "(Ignored; accepted for backward compatibility). Region is always taken from OCI config.",
+    ] = None,
+    opc_request_id: Annotated[Optional[str], "Unique identifier for the request"] = None,
+) -> dict:
+    """
+    Returns resource availability from OCI Limits API for:
+      - autonomous-recovery-service / protected-database-backup-storage-gb
+      - autonomous-recovery-service / protected-database-count
+
+    Scope/region behavior:
+      - Compartment is always the tenancy OCID from server config
+      - Region is always the configured profile region
+      - `compartment_id` and `region` inputs are accepted only for backward compatibility
+
+    API shape corresponds to:
+      GET /20190729/services/autonomous-recovery-service/limits/<limitName>/resourceAvailability
+    """
+    try:
+        request_id = uuid.uuid4().hex
+        config = _load_oci_config_for_server()
+        resolved_compartment_id = get_tenancy()
+        target_region = (config.get("region") or "us-ashburn-1").strip()
+        client = get_limits_client(target_region, request_id=request_id)
+
+        service_name = "autonomous-recovery-service"
+        limit_map = {
+            "protectedDatabaseBackupStorageGb": "protected-database-backup-storage-gb",
+            "protectedDatabaseCount": "protected-database-count",
+        }
+
+        def _as_dict(obj: Any) -> dict[str, Any]:
+            if obj is None:
+                return {}
+            if isinstance(obj, dict):
+                return dict(obj)
+            try:
+                return oci.util.to_dict(obj)
+            except Exception:
+                pass
+            if hasattr(obj, "__dict__"):
+                try:
+                    return dict(obj.__dict__)
+                except Exception:
+                    pass
+            return {}
+
+        limits_out: dict[str, Any] = {}
+
+        for out_key, limit_name in limit_map.items():
+            kwargs: dict[str, Any] = {
+                "service_name": service_name,
+                "limit_name": limit_name,
+                "compartment_id": resolved_compartment_id,
+            }
+            if opc_request_id is not None:
+                kwargs["opc_request_id"] = opc_request_id
+
+            resp: oci.response.Response = client.get_resource_availability(**kwargs)
+            data_dict = _as_dict(getattr(resp, "data", None))
+
+            # Keep response explicit and stable for dashboard/tooling usage
+            limits_out[out_key] = {
+                "serviceName": service_name,
+                "limitName": limit_name,
+                "scopeType": data_dict.get("scope_type"),
+                "available": data_dict.get("available"),
+                "used": data_dict.get("used"),
+                "fractionalAvailability": data_dict.get("fractional_availability"),
+                "fractionalUsage": data_dict.get("fractional_usage"),
+                "effectiveQuotaValue": data_dict.get("effective_quota_value"),
+                "policyName": data_dict.get("policy_name"),
+            }
+
+        return {
+            "compartmentId": resolved_compartment_id,
+            "region": target_region,
+            "serviceName": service_name,
+            "limits": limits_out,
+        }
+    except Exception as e:
+        logger.error(f"Error in check_recovery_service_limits tool: {str(e)}")
+        raise
+
+
+@mcp.tool(
+    description=(
+        "Lists the tenancy's subscribed regions and their status using "
+        "IdentityClient.list_region_subscriptions(). "
+        "NOTE: The 'service' parameter is accepted for backward compatibility but is "
+        "not used, because IAM region subscriptions are tenancy-wide, not service-specific."
+    )
+)
+@_tool_logger("fetch_regions_subscribed")
+def fetch_regions_subscribed(
+    tenancy_id: Annotated[Optional[str], "OCID of the compartment to scope the search."] = None,
+) -> dict:
+    request_id = uuid.uuid4().hex
+    if not tenancy_id:
+        tenancy_id = get_tenancy()
+    regions = _iam_subscribed_regions_with_status(request_id=request_id)
+    return {
+        "tenancyId": tenancy_id,
+        "regions": regions,
+        "total": len(regions),
+    }
 
 
 @mcp.tool(
@@ -1667,6 +2463,10 @@ def summarize_backup_space_used(
 @_tool_logger("list_protection_policies")
 def list_protection_policies(
     compartment_id: Annotated[str, "The compartment OCID or compartment display name"],
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns the combined results.",
+    ] = False,
     lifecycle_state: Annotated[
         Optional[str],
         'Filter by lifecycle state (e.g., "ACTIVE", "DELETED")',
@@ -1690,44 +2490,60 @@ def list_protection_policies(
     try:
         request_id = uuid.uuid4().hex
         client = get_recovery_client(region, request_id=request_id)
-        compartment_id = _resolve_compartment_id(compartment_id)
 
         results: list[ProtectionPolicy] = []
-        has_next_page = True
-        next_page: Optional[str] = page
 
-        while has_next_page:
-            # Collect filters/controls into kwargs
-            kwargs = {
-                "compartment_id": compartment_id,
-                "page": next_page,
-            }
-            if lifecycle_state is not None:
-                kwargs["lifecycle_state"] = lifecycle_state
-            if display_name is not None:
-                kwargs["display_name"] = display_name
-            if id is not None:
-                kwargs["id"] = id
-            if limit is not None:
-                kwargs["limit"] = limit
-            if sort_order is not None:
-                kwargs["sort_order"] = sort_order
-            if sort_by is not None:
-                kwargs["sort_by"] = sort_by
-            if opc_request_id is not None:
-                kwargs["opc_request_id"] = opc_request_id
+        comp_ids = _compartment_ids_for_tool(
+            compartment_id,
+            fetch_for_child_compartment=fetch_for_child_compartment,
+            request_id=request_id,
+        )
 
-            response: oci.response.Response = client.list_protection_policies(**kwargs)
-            has_next_page = response.has_next_page
-            next_page = response.next_page if hasattr(response, "next_page") else None
+        for comp_id in comp_ids:
+            has_next_page = True
+            next_page: Optional[str] = page
 
-            data = response.data
-            items = getattr(data, "items", data)  # collection.items or raw list
-            for d in items:
-                logger.info(f"Item structure: {d}")
-                pp = map_protection_policy(d)
-                if pp is not None:
-                    results.append(pp)
+            while has_next_page:
+                # Collect filters/controls into kwargs
+                kwargs = {
+                    "compartment_id": comp_id,
+                    "page": next_page,
+                }
+                if lifecycle_state is not None:
+                    kwargs["lifecycle_state"] = lifecycle_state
+                if display_name is not None:
+                    kwargs["display_name"] = display_name
+                if id is not None:
+                    kwargs["id"] = id
+                if limit is not None:
+                    kwargs["limit"] = limit
+                if sort_order is not None:
+                    kwargs["sort_order"] = sort_order
+                if sort_by is not None:
+                    kwargs["sort_by"] = sort_by
+                if opc_request_id is not None:
+                    kwargs["opc_request_id"] = opc_request_id
+
+                response: oci.response.Response = client.list_protection_policies(**kwargs)
+                has_next_page = response.has_next_page
+                next_page = response.next_page if hasattr(response, "next_page") else None
+
+                data = response.data
+                items = getattr(data, "items", data)  # collection.items or raw list
+                for d in items:
+                    logger.debug(f"Item structure: {d}")
+                    pp = map_protection_policy(d)
+                    if pp is not None:
+                        results.append(pp)
+
+        # De-dupe by OCID when scanning multiple compartments
+        if fetch_for_child_compartment:
+            uniq: dict[str, Any] = {}
+            for r in results:
+                rid = getattr(r, "id", None) if r is not None else None
+                if rid and rid not in uniq:
+                    uniq[rid] = r
+            results = list(uniq.values())
 
         logger.info(f"Found {len(results)} Protection Policies")
         return results
@@ -1782,6 +2598,10 @@ def get_protection_policy(
 @_tool_logger("list_recovery_service_subnets")
 def list_recovery_service_subnets(
     compartment_id: Annotated[str, "The compartment OCID or compartment display name"],
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns the combined results.",
+    ] = False,
     lifecycle_state: Annotated[
         Optional[str],
         (
@@ -1809,68 +2629,84 @@ def list_recovery_service_subnets(
     try:
         request_id = uuid.uuid4().hex
         client = get_recovery_client(region, request_id=request_id)
-        compartment_id = _resolve_compartment_id(compartment_id)
 
         results: list[RecoveryServiceSubnet] = []
-        has_next_page = True
-        next_page: Optional[str] = page
 
-        while has_next_page:
-            kwargs = {
-                "compartment_id": compartment_id,
-                "page": next_page,
-            }
-            if lifecycle_state is not None:
-                kwargs["lifecycle_state"] = lifecycle_state
-            if display_name is not None:
-                kwargs["display_name"] = display_name
-            if id is not None:
-                kwargs["id"] = id
-            if vcn_id is not None:
-                kwargs["vcn_id"] = vcn_id
-            if limit is not None:
-                kwargs["limit"] = limit
-            if sort_order is not None:
-                kwargs["sort_order"] = sort_order
-            if sort_by is not None:
-                kwargs["sort_by"] = sort_by
-            if opc_request_id is not None:
-                kwargs["opc_request_id"] = opc_request_id
+        comp_ids = _compartment_ids_for_tool(
+            compartment_id,
+            fetch_for_child_compartment=fetch_for_child_compartment,
+            request_id=request_id,
+        )
 
-            response: oci.response.Response = client.list_recovery_service_subnets(**kwargs)
-            has_next_page = response.has_next_page
-            next_page = response.next_page if hasattr(response, "next_page") else None
+        for comp_id in comp_ids:
+            has_next_page = True
+            next_page: Optional[str] = page
 
-            data = response.data
-            items = getattr(data, "items", data)  # collection.items or raw list
-            for d in items:
-                logger.info(f"Item structure: {d}")
-                rss = map_recovery_service_subnet(d)
-                if rss is None:
-                    continue
-                # Enrich with subnets list if missing by fetching the full resource
-                try:
-                    missing_subnets = getattr(rss, "subnets", None) is None
-                    rss_id = getattr(rss, "id", None)
-                    if missing_subnets and rss_id:
-                        try:
-                            g = client.get_recovery_service_subnet(recovery_service_subnet_id=rss_id)
-                            full = map_recovery_service_subnet(getattr(g, "data", None))
-                            if full and getattr(full, "subnets", None):
-                                rss.subnets = full.subnets
-                        except Exception:
-                            pass
-                except Exception:
-                    pass
-                # Final fallback: if still missing, derive from subnet_id when available
-                try:
-                    if getattr(rss, "subnets", None) is None:
-                        sid = getattr(rss, "subnet_id", None)
-                        if sid:
-                            rss.subnets = [sid]
-                except Exception:
-                    pass
-                results.append(rss)
+            while has_next_page:
+                kwargs = {
+                    "compartment_id": comp_id,
+                    "page": next_page,
+                }
+                if lifecycle_state is not None:
+                    kwargs["lifecycle_state"] = lifecycle_state
+                if display_name is not None:
+                    kwargs["display_name"] = display_name
+                if id is not None:
+                    kwargs["id"] = id
+                if vcn_id is not None:
+                    kwargs["vcn_id"] = vcn_id
+                if limit is not None:
+                    kwargs["limit"] = limit
+                if sort_order is not None:
+                    kwargs["sort_order"] = sort_order
+                if sort_by is not None:
+                    kwargs["sort_by"] = sort_by
+                if opc_request_id is not None:
+                    kwargs["opc_request_id"] = opc_request_id
+
+                response: oci.response.Response = client.list_recovery_service_subnets(**kwargs)
+                has_next_page = response.has_next_page
+                next_page = response.next_page if hasattr(response, "next_page") else None
+
+                data = response.data
+                items = getattr(data, "items", data)  # collection.items or raw list
+                for d in items:
+                    logger.debug(f"Item structure: {d}")
+                    rss = map_recovery_service_subnet(d)
+                    if rss is None:
+                        continue
+                    # Enrich with subnets list if missing by fetching the full resource
+                    try:
+                        missing_subnets = getattr(rss, "subnets", None) is None
+                        rss_id = getattr(rss, "id", None)
+                        if missing_subnets and rss_id:
+                            try:
+                                g = client.get_recovery_service_subnet(recovery_service_subnet_id=rss_id)
+                                full = map_recovery_service_subnet(getattr(g, "data", None))
+                                if full and getattr(full, "subnets", None):
+                                    rss.subnets = full.subnets
+                            except Exception:
+                                pass
+                    except Exception:
+                        pass
+                    # Final fallback: if still missing, derive from subnet_id when available
+                    try:
+                        if getattr(rss, "subnets", None) is None:
+                            sid = getattr(rss, "subnet_id", None)
+                            if sid:
+                                rss.subnets = [sid]
+                    except Exception:
+                        pass
+                    results.append(rss)
+
+        # De-dupe by OCID when scanning multiple compartments
+        if fetch_for_child_compartment:
+            uniq: dict[str, Any] = {}
+            for r in results:
+                rid = getattr(r, "id", None) if r is not None else None
+                if rid and rid not in uniq:
+                    uniq[rid] = r
+            results = list(uniq.values())
 
         logger.info(f"Found {len(results)} Recovery Service Subnets")
         return results
@@ -1941,6 +2777,10 @@ def get_recovery_service_metrics(
     compartment_id: Annotated[str, "The compartment OCID or compartment display name to query metrics for."],
     start_time: Annotated[str, "Start time for the metric query. Provide a RFC3339/ISO-8601 timestamp."],
     end_time: Annotated[str, "End time for the metric query. Provide a RFC3339/ISO-8601 timestamp."],
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns the combined results.",
+    ] = False,
     metricName: Annotated[
         str,
         "The metric that the user wants to fetch. Currently we only support:"
@@ -1956,54 +2796,60 @@ def get_recovery_service_metrics(
         "The aggregation for the metric. Currently we only support: mean, sum, max, min, count. Default: max",
     ] = "max",
     protected_database_id: Annotated[
-        str,
+        Optional[str],
         "Optional protected database OCID to filter by (maps to resourceId dimension)",
     ] = None,
 ) -> list[dict]:
     # Build Monitoring query against Recovery metrics namespace
     request_id = uuid.uuid4().hex
     monitoring_client = get_monitoring_client(request_id=request_id)
-    compartment_id = _resolve_compartment_id(compartment_id)
     namespace = "oci_recovery_service"
     filter_clause = f'{{resourceId="{protected_database_id}"}}' if protected_database_id else ""
     # Query format: MetricName[resolution]{filters}.aggregation()
     query = f"{metricName}[{resolution}]{filter_clause}.{aggregation}()"
 
-    # Fetch time series data for the metric and time window
-    series_list = monitoring_client.summarize_metrics_data(
-        compartment_id=compartment_id,
-        summarize_metrics_data_details=SummarizeMetricsDataDetails(
-            namespace=namespace,
-            query=query,
-            start_time=start_time,
-            end_time=end_time,
-            resolution=resolution,
-        ),
-    ).data
+    comp_ids = _compartment_ids_for_tool(
+        compartment_id,
+        fetch_for_child_compartment=fetch_for_child_compartment,
+        request_id=request_id,
+    )
 
-    # Convert SDK series into a simple dict of dimensions + aggregated datapoints
-    result: list[dict] = []
-    for series in series_list:
-        logger.info(f"Item structure: {series}")
-        dims = getattr(series, "dimensions", None)
-        points = []
-        for p in getattr(series, "aggregated_datapoints", []):
-            points.append(
+    results: list[dict] = []
+
+    for comp_id in comp_ids:
+        # Fetch time series data for the metric and time window
+        series_list = monitoring_client.summarize_metrics_data(
+            compartment_id=comp_id,
+            summarize_metrics_data_details=SummarizeMetricsDataDetails(
+                namespace=namespace,
+                query=query,
+                start_time=start_time,
+                end_time=end_time,
+                resolution=resolution,
+            ),
+        ).data
+
+        # Convert SDK series into a simple dict of dimensions + aggregated datapoints
+        for series in series_list:
+            logger.debug(f"Item structure: {series}")
+            dims = getattr(series, "dimensions", None)
+            points = []
+            for p in getattr(series, "aggregated_datapoints", []):
+                points.append(
+                    {
+                        "timestamp": getattr(p, "timestamp", None),
+                        "value": getattr(p, "value", None),
+                    }
+                )
+            results.append(
                 {
-                    "timestamp": getattr(p, "timestamp", None),
-                    "value": getattr(p, "value", None),
+                    "compartmentId": comp_id,
+                    "dimensions": dims,
+                    "datapoints": points,
                 }
             )
-        result.append(
-            {
-                "dimensions": dims,
-                "datapoints": points,
-            }
-        )
-    return result
 
-
-# ---------------- Database Service Tools ----------------
+    return results
 
 
 @mcp.tool(
@@ -2019,9 +2865,12 @@ def get_recovery_service_metrics(
 @_tool_logger("list_databases")
 def list_databases(
     compartment_id: Annotated[
-        Optional[str],
-        "The compartment OCID or compartment display name. Required if db_home_id is not provided.",
+        Optional[str], "The compartment OCID or display name. Required if db_home_id is not provided."
     ] = None,
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns the combined results.",
+    ] = False,
     db_home_id: Annotated[
         Optional[str],
         "A Database Home OCID. If omitted, all DB Homes in the compartment will be used.",
@@ -2040,59 +2889,70 @@ def list_databases(
     try:
         request_id = uuid.uuid4().hex
         client = get_database_client(region, request_id=request_id)
-        resolved_compartment_id = _resolve_compartment_id(compartment_id) if compartment_id else None
+        if compartment_id:
+            compartment_id = _resolve_compartment_id(compartment_id)
 
-        # Determine DB Home scope:
-        # - If db_home_id not provided, discover all DB Homes in the compartment.
-        # - If provided, just use that one.
+        # Determine compartment scope
+        comp_ids: list[str] = []
         if db_home_id is None:
             if not compartment_id:
                 raise ValueError(
                     "Either db_home_id must be provided or compartment_id must be set to derive DB Homes."
                 )
-            home_ids = _fetch_db_home_ids_for_compartment(resolved_compartment_id, region=region)
+            comp_ids = _compartment_ids_for_tool(
+                compartment_id,
+                fetch_for_child_compartment=fetch_for_child_compartment,
+                request_id=request_id,
+            )
         else:
-            home_ids = [db_home_id]
+            # db_home_id is explicit: keep existing behavior and don't expand compartments
+            comp_ids = [compartment_id] if compartment_id else []
 
-        if not home_ids:
-            return []
+        results: list[DatabaseSummary] = []
 
         # Try to correlate database_id -> protection_policy_id via Recovery PDs (best-effort)
+        # If we're scanning child compartments, include PDs from each scanned compartment.
         pd_policy_by_dbid: dict[str, str] = {}
-        if resolved_compartment_id:
+        if compartment_id:
             try:
                 rec_client = get_recovery_client(region, request_id=request_id)
-                has_next = True
-                next_page = None
-                while has_next:
-                    lp = rec_client.list_protected_databases(
-                        compartment_id=resolved_compartment_id, page=next_page
+                pd_comp_ids = (
+                    _compartment_ids_for_tool(
+                        compartment_id,
+                        fetch_for_child_compartment=fetch_for_child_compartment,
+                        request_id=request_id,
                     )
-                    has_next = lp.has_next_page
-                    next_page = getattr(lp, "next_page", None)
-                    pdata = lp.data
-                    pitems = getattr(pdata, "items", pdata)
-                    for it in pitems or []:
-                        logger.info(f"Item structure: {it}")
-                        try:
-                            if hasattr(oci, "util") and hasattr(oci.util, "to_dict"):
-                                d = oci.util.to_dict(it)
-                            else:
+                    if fetch_for_child_compartment
+                    else [compartment_id]
+                )
+
+                for pd_comp_id in pd_comp_ids:
+                    has_next = True
+                    next_page = None
+                    while has_next:
+                        lp = rec_client.list_protected_databases(compartment_id=pd_comp_id, page=next_page)
+                        has_next = lp.has_next_page
+                        next_page = getattr(lp, "next_page", None)
+                        pdata = lp.data
+                        pitems = getattr(pdata, "items", pdata)
+                        for it in pitems or []:
+                            logger.debug(f"Item structure: {it}")
+                            try:
+                                if hasattr(oci, "util") and hasattr(oci.util, "to_dict"):
+                                    d = oci.util.to_dict(it)
+                                else:
+                                    d = getattr(it, "__dict__", {}) or {}
+                            except Exception:
                                 d = getattr(it, "__dict__", {}) or {}
-                        except Exception:
-                            d = getattr(it, "__dict__", {}) or {}
-                        dbid = d.get("databaseId") or d.get("database_id")
-                        ppid = d.get("protectionPolicyId") or d.get("protection_policy_id")
-                        if dbid and ppid and dbid not in pd_policy_by_dbid:
-                            pd_policy_by_dbid[dbid] = ppid
+                            dbid = d.get("databaseId") or d.get("database_id")
+                            ppid = d.get("protectionPolicyId") or d.get("protection_policy_id")
+                            if dbid and ppid and dbid not in pd_policy_by_dbid:
+                                pd_policy_by_dbid[dbid] = ppid
             except Exception:
                 pd_policy_by_dbid = {}
 
-        results: list[DatabaseSummary] = []
         # Common list_databases filters shared across DB Homes
         common_kwargs: dict = {}
-        if resolved_compartment_id is not None:
-            common_kwargs["compartment_id"] = resolved_compartment_id
         if system_id is not None:
             common_kwargs["system_id"] = system_id
         if limit is not None:
@@ -2108,16 +2968,34 @@ def list_databases(
         if db_name is not None:
             common_kwargs["db_name"] = db_name
 
-        # For each DB Home, list databases and map summaries
-        for hid in home_ids:
-            kwargs = dict(common_kwargs)
-            kwargs["db_home_id"] = hid
-            response: oci.response.Response = client.list_databases(**kwargs)
-            raw = getattr(response.data, "items", response.data)
-            for item in raw or []:
-                logger.info(f"Item structure: {item}")
-                mapped = map_database_summary(item)
-                if mapped is not None:
+        # Iterate compartments -> DB homes -> list databases
+        for each_comp in comp_ids or [compartment_id] if compartment_id else []:
+            # Determine DB Home scope for this compartment:
+            # - If db_home_id not provided, discover all DB Homes in the compartment.
+            # - If provided, just use that one.
+            if db_home_id is None:
+                home_ids = _fetch_db_home_ids_for_compartment(each_comp, region=region)
+            else:
+                home_ids = [db_home_id]
+
+            if not home_ids:
+                continue
+
+            # For each DB Home, list databases and map summaries
+            for hid in home_ids:
+                kwargs = dict(common_kwargs)
+                kwargs["db_home_id"] = hid
+                if db_home_id is None:
+                    kwargs["compartment_id"] = each_comp
+
+                response: oci.response.Response = client.list_databases(**kwargs)
+                raw = getattr(response.data, "items", response.data)
+                for item in raw or []:
+                    logger.debug(f"Item structure: {item}")
+                    mapped = map_database_summary(item)
+                    if mapped is None:
+                        continue
+
                     # Enrich db_backup_config lazily by fetching full Database only if missing
                     try:
                         if getattr(mapped, "db_backup_config", None) is None:
@@ -2151,13 +3029,22 @@ def list_databases(
                     except Exception:
                         # Best-effort enrichment; ignore failures and still return the summary
                         pass
+
                     # Enrich with protection policy id if we correlated via Recovery PDs earlier
                     try:
-                        if resolved_compartment_id is not None:
-                            mapped.protection_policy_id = pd_policy_by_dbid.get(mapped.id)
+                        mapped.protection_policy_id = pd_policy_by_dbid.get(mapped.id)
                     except Exception:
                         pass
                     results.append(mapped)
+
+        # De-dupe by DB OCID when scanning multiple compartments / homes
+        if fetch_for_child_compartment and db_home_id is None:
+            uniq: dict[str, DatabaseSummary] = {}
+            for r in results:
+                rid = getattr(r, "id", None) if r is not None else None
+                if rid and rid not in uniq:
+                    uniq[rid] = r
+            results = list(uniq.values())
 
         return results
     except Exception as e:
@@ -2232,6 +3119,109 @@ def get_database(
 
 @mcp.tool(
     description=(
+        "Finds database restore requests and returns only active or historical restore jobs."
+        "Use this when answering customer questions about database restore status, "
+        "restore history, or whether a restore request exists."
+    )
+)
+@_tool_logger("list_restore")
+def list_restore(
+    compartment_id: Annotated[str, "Compartment OCID or compartment display name to scope work requests."],
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns the combined results.",
+    ] = False,
+    resource_id: Annotated[
+        Optional[str], "Optional resource OCID to scope work requests (e.g., Database OCID)."
+    ] = None,
+    status: Annotated[
+        Optional[str], "Optional work request status filter (e.g., IN_PROGRESS, SUCCEEDED, FAILED)."
+    ] = None,
+    limit: Annotated[Optional[int], "Maximum number of items per backend page."] = None,
+    page: Annotated[Optional[str], "Pagination token (opc-next-page) when aggregate_pages=false."] = None,
+    sort_order: Annotated[Optional[str], 'Sort order: "ASC" or "DESC".'] = None,
+    sort_by: Annotated[Optional[str], "Sort by field when supported by the API."] = None,
+    opc_request_id: Annotated[Optional[str], "Unique identifier for the request"] = None,
+    region: Annotated[Optional[str], "Canonical OCI region (e.g., us-phoenix-1)."] = None,
+    aggregate_pages: Annotated[bool, "When true (default), retrieves all pages."] = True,
+) -> list[WorkRequest]:
+    try:
+        request_id = uuid.uuid4().hex
+        client = get_work_request_client(region, request_id=request_id)
+
+        def _is_restore_operation(operation: Optional[str]) -> bool:
+            if operation is None:
+                return False
+            raw = str(operation).strip()
+            if raw == "Restore Database":
+                return True
+            normalized = raw.replace("_", " ").replace("-", " ").lower()
+            normalized = " ".join(normalized.split())
+            return normalized == "restore database"
+
+        comp_ids = _compartment_ids_for_tool(
+            compartment_id,
+            fetch_for_child_compartment=fetch_for_child_compartment,
+            request_id=request_id,
+        )
+
+        results: list[WorkRequest] = []
+
+        for each_comp in comp_ids or [compartment_id]:
+            next_page = page
+            while True:
+                kwargs: dict[str, Any] = {
+                    "compartment_id": each_comp,
+                }
+                if resource_id is not None:
+                    kwargs["resource_id"] = resource_id
+                if status is not None:
+                    kwargs["status"] = status
+                if sort_order is not None:
+                    kwargs["sort_order"] = sort_order
+                if sort_by is not None:
+                    kwargs["sort_by"] = sort_by
+                if opc_request_id is not None:
+                    kwargs["opc_request_id"] = opc_request_id
+                if limit is not None:
+                    kwargs["limit"] = limit
+                elif aggregate_pages:
+                    kwargs["limit"] = 1000
+                if next_page is not None:
+                    kwargs["page"] = next_page
+
+                response = client.list_work_requests(**kwargs)
+                items = getattr(response.data, "items", response.data) or []
+                raw_items = items if isinstance(items, list) else [items]
+
+                for item in raw_items:
+                    mapped = map_work_request(item)
+                    if mapped is None:
+                        continue
+                    if _is_restore_operation(getattr(mapped, "operation_type", None)):
+                        results.append(mapped)
+
+                has_next = bool(getattr(response, "has_next_page", False))
+                next_page = getattr(response, "next_page", None) if has_next else None
+                if not (aggregate_pages and has_next and next_page):
+                    break
+
+        if fetch_for_child_compartment:
+            uniq: dict[str, WorkRequest] = {}
+            for r in results:
+                rid = getattr(r, "id", None) if r is not None else None
+                if rid and rid not in uniq:
+                    uniq[rid] = r
+            results = list(uniq.values())
+
+        return results
+    except Exception as e:
+        logger.error("Error in list_restore tool: %s", e)
+        raise
+
+
+@mcp.tool(
+    description=(
         "Lists database backups with flexible filters and optional auto-paging. If "
         "database_id is provided, lists all backups for that database. If compartment_id "
         "is provided, it may be either a compartment OCID or a compartment display name, "
@@ -2246,6 +3236,10 @@ def list_backups(
     compartment_id: Annotated[
         Optional[str], "Compartment OCID or compartment display name to scope the search."
     ] = None,
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns the combined results.",
+    ] = False,
     database_id: Annotated[Optional[str], "OCID of the Database to filter backups for."] = None,
     lifecycle_state: Annotated[Optional[str], "Filter by lifecycle state."] = None,
     type: Annotated[Optional[str], "Backup type filter (e.g., INCREMENTAL, FULL)."] = None,
@@ -2260,7 +3254,6 @@ def list_backups(
     try:
         request_id = uuid.uuid4().hex
         client = get_database_client(region, request_id=request_id)
-        resolved_compartment_id = _resolve_compartment_id(compartment_id) if compartment_id else None
 
         def _to_dict(o):
             try:
@@ -2319,7 +3312,7 @@ def list_backups(
                 items = getattr(resp.data, "items", resp.data) or []
                 raw_list = items if isinstance(items, list) else [items]
                 for obj in raw_list:
-                    logger.info(f"Item structure: {obj}")
+                    logger.debug(f"Item structure: {obj}")
                     mapped = map_backup_summary(obj)
                     if mapped is None:
                         continue
@@ -2398,66 +3391,87 @@ def list_backups(
             return backups
 
         # Branch 2: compartment_id and region provided
-        if resolved_compartment_id:
-            # find DB Homes then list AVAILABLE databases
-            home_ids = _fetch_db_home_ids_for_compartment(resolved_compartment_id, region=region)
+        if compartment_id:
+            comp_ids = _compartment_ids_for_tool(
+                compartment_id,
+                fetch_for_child_compartment=fetch_for_child_compartment,
+                request_id=request_id,
+            )
+
+            # find DB Homes then list AVAILABLE databases (per compartment)
             eligible_db_ids: list[str] = []
             db_unique_cache: dict[str, Optional[str]] = {}
-            for hid in home_ids or []:
-                next_db_page = None
-                while True:
-                    kwargs_db = {
-                        "compartment_id": resolved_compartment_id,
-                        "db_home_id": hid,
-                        "lifecycle_state": "AVAILABLE",
-                        "limit": 1000,
-                    }
-                    if next_db_page:
-                        kwargs_db["page"] = next_db_page
-                    dresp = client.list_databases(**kwargs_db)
-                    ditems = getattr(dresp.data, "items", dresp.data) or []
-                    for d in ditems:
-                        logger.info(f"Item structure: {d}")
-                        d_dict = _to_dict(d)
-                        dbid = d_dict.get("id") or getattr(d, "id", None)
-                        dun = (
-                            d_dict.get("dbUniqueName")
-                            or d_dict.get("db_unique_name")
-                            or getattr(d, "db_unique_name", None)
-                        )
-                        is_auto = _is_auto_backup_enabled_from_dict(d_dict)
-                        if is_auto is False and dbid:
-                            # fallback to GET for authoritative value and db_unique_name
-                            try:
-                                g = client.get_database(database_id=dbid)
-                                gdd = _to_dict(getattr(g, "data", None))
-                                is_auto = _is_auto_backup_enabled_from_dict(gdd)
-                                if dun is None:
-                                    dun = gdd.get("dbUniqueName") or gdd.get("db_unique_name")
-                            except Exception:
-                                is_auto = False
-                        if dbid:
-                            if dun is not None:
-                                db_unique_cache[dbid] = dun
-                            if is_auto:
-                                eligible_db_ids.append(dbid)
-                    has_next = bool(getattr(dresp, "has_next_page", False))
-                    next_db_page = getattr(dresp, "next_page", None) if has_next else None
-                    if not has_next:
-                        break
+            for each_comp in comp_ids:
+                home_ids = _fetch_db_home_ids_for_compartment(each_comp, region=region)
+                for hid in home_ids or []:
+                    next_db_page = None
+                    while True:
+                        kwargs_db = {
+                            "compartment_id": each_comp,
+                            "db_home_id": hid,
+                            "lifecycle_state": "AVAILABLE",
+                            "limit": 1000,
+                        }
+                        if next_db_page:
+                            kwargs_db["page"] = next_db_page
+                        dresp = client.list_databases(**kwargs_db)
+                        ditems = getattr(dresp.data, "items", dresp.data) or []
+                        for d in ditems:
+                            logger.debug(f"Item structure: {d}")
+                            d_dict = _to_dict(d)
+                            dbid = d_dict.get("id") or getattr(d, "id", None)
+                            dun = (
+                                d_dict.get("dbUniqueName")
+                                or d_dict.get("db_unique_name")
+                                or getattr(d, "db_unique_name", None)
+                            )
+                            is_auto = _is_auto_backup_enabled_from_dict(d_dict)
+                            if is_auto is False and dbid:
+                                # fallback to GET for authoritative value and db_unique_name
+                                try:
+                                    g = client.get_database(database_id=dbid)
+                                    gdd = _to_dict(getattr(g, "data", None))
+                                    is_auto = _is_auto_backup_enabled_from_dict(gdd)
+                                    if dun is None:
+                                        dun = gdd.get("dbUniqueName") or gdd.get("db_unique_name")
+                                except Exception:
+                                    is_auto = False
+                            if dbid:
+                                if dun is not None:
+                                    db_unique_cache[dbid] = dun
+                                if is_auto:
+                                    eligible_db_ids.append(dbid)
+                        has_next = bool(getattr(dresp, "has_next_page", False))
+                        next_db_page = getattr(dresp, "next_page", None) if has_next else None
+                        if not has_next:
+                            break
+
             # Aggregate backups for eligible DBs
             all_results: list[dict] = []
+            seen_backup_ids: set[str] = set()
             for dbid in eligible_db_ids:
                 backups = _list_all_backups_for_db(dbid)
                 # Set db_unique_name from cache
                 for bk in backups:
                     if "db_unique_name" not in bk or bk["db_unique_name"] is None:
                         bk["db_unique_name"] = db_unique_cache.get(dbid)
-                all_results.extend(backups)
+
+                if fetch_for_child_compartment:
+                    # de-dupe by backup OCID across DBs/compartments
+                    for bk in backups:
+                        bid = bk.get("id") if isinstance(bk, dict) else None
+                        if bid and bid in seen_backup_ids:
+                            continue
+                        if bid:
+                            seen_backup_ids.add(bid)
+                        all_results.append(bk)
+                else:
+                    all_results.extend(backups)
+
             return all_results
 
-        # Neither database_id nor (compartment_id and region) provided
-        raise ValueError("Provide database_id, or compartment_id.")
+        # Neither database_id nor compartment_id provided
+        raise ValueError("Provide database_id or compartment_id.")
 
     except Exception as e:
         logger.error("Error in list_backups tool: %s", e)
@@ -2636,6 +3650,10 @@ def summarize_protected_database_backup_destination(
         Optional[str],
         "Compartment OCID or compartment display name. If omitted, defaults to the tenancy/DEFAULT profile.",
     ] = None,
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns aggregated summary plus per-compartment breakdown.",
+    ] = False,
     region: Annotated[Optional[str], "Canonical OCI region (e.g., us-ashburn-1)."] = None,
     db_home_id: Annotated[
         Optional[str],
@@ -2643,7 +3661,7 @@ def summarize_protected_database_backup_destination(
     ] = None,
     include_last_backup_time: Annotated[
         bool, "If true, compute last backup time per DB (extra API calls)."
-    ] = False,
+    ] = True,
     db_name: Annotated[Optional[str], "Exact database name filter (case-insensitive)."] = None,
     limit_per_home: Annotated[Optional[int], "Max databases to fetch per DB Home."] = None,
     max_db_homes: Annotated[Optional[int], "Max number of DB Homes to scan."] = None,
@@ -2652,20 +3670,32 @@ def summarize_protected_database_backup_destination(
     try:
         request_id = uuid.uuid4().hex
         db_client = get_database_client(region, request_id=request_id)
-        compartment_id = _resolve_compartment_id(compartment_id, default_to_tenancy=True)
+        if not compartment_id:
+            compartment_id = get_tenancy()
+
+        comp_ids = _compartment_ids_for_tool(
+            compartment_id,
+            fetch_for_child_compartment=fetch_for_child_compartment,
+            request_id=request_id,
+        )
 
         # Discover DB Homes if not specified, then list databases with lifecycle_state=AVAILABLE
-        home_ids: list[str] = (
-            [db_home_id] if db_home_id else _fetch_db_home_ids_for_compartment(compartment_id, region=region)
-        )
+        # NOTE: db_home_id is a single home; we do NOT expand it across compartments.
+        home_ids_by_comp: dict[str, list[str]] = {}
+        for each_comp in comp_ids:
+            home_ids_by_comp[each_comp] = (
+                [db_home_id] if db_home_id else _fetch_db_home_ids_for_compartment(each_comp, region=region)
+            )
 
         # Explicitly bind the SDK method to avoid any accidental reference to the MCP tool
         list_dbs_method = getattr(db_client, "list_databases")
         db_summaries: list[Any] = []
-        if home_ids:
+        for each_comp, home_ids in home_ids_by_comp.items():
+            if not home_ids:
+                continue
             for hid in home_ids[:max_db_homes] if (max_db_homes is not None) else home_ids:
                 call_kwargs = {
-                    "compartment_id": compartment_id,
+                    "compartment_id": each_comp,
                     "db_home_id": hid,
                     "lifecycle_state": "AVAILABLE",
                 }
@@ -2834,7 +3864,7 @@ def summarize_protected_database_backup_destination(
                 sid = _get(s, "id")
                 if not sid:
                     continue
-                db_name = _get(s, "db_name", "dbName")
+                db_name_val = _get(s, "db_name", "dbName")
 
                 # Prefer backup config from summary item to avoid per-DB GET when possible
                 d_obj = None
@@ -2905,7 +3935,7 @@ def summarize_protected_database_backup_destination(
                     pass
 
                 # Aggregate summary counters and name lists by status/destination
-                name_for_lists = db_name or sid
+                name_for_lists = db_name_val or sid
                 if status == "CONFIGURED":
                     # Select a single effective destination type: DBRS preferred over OBJECT_STORE
                     eff_type = (
@@ -2924,7 +3954,7 @@ def summarize_protected_database_backup_destination(
                 items.append(
                     ProtectedDatabaseBackupDestinationItem(
                         database_id=sid,
-                        db_name=db_name,
+                        db_name=db_name_val,
                         status=status,
                         destination_types=dest_types,
                         destination_ids=dest_ids,
@@ -2962,6 +3992,15 @@ def summarize_protected_database_backup_destination(
         unconfigured_names = _uniq_sorted(unconfigured_names)
         has_backups_names = _uniq_sorted(has_backups_names)
 
+        # De-dupe by DB OCID when scanning multiple compartments
+        if fetch_for_child_compartment:
+            uniq_items: dict[str, ProtectedDatabaseBackupDestinationItem] = {}
+            for it in items:
+                did = getattr(it, "database_id", None)
+                if did and did not in uniq_items:
+                    uniq_items[did] = it
+            items = list(uniq_items.values())
+
         return ProtectedDatabaseBackupDestinationSummary(
             compartment_id=compartment_id,
             region=region,
@@ -2991,6 +4030,10 @@ def list_db_homes(
     compartment_id: Annotated[
         Optional[str], "Compartment OCID or compartment display name to scope the search."
     ] = None,
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns the combined results.",
+    ] = False,
     db_system_id: Annotated[
         Optional[str], "The OCID of the Exadata DB system to filter the DB homes by."
     ] = None,
@@ -3002,29 +4045,48 @@ def list_db_homes(
     try:
         request_id = uuid.uuid4().hex
         client = get_database_client(region, request_id=request_id)
-        if compartment_id:
-            compartment_id = _resolve_compartment_id(compartment_id)
-        elif not db_system_id:
+        if not compartment_id and not db_system_id:
             compartment_id = get_tenancy()
+
+        comp_ids = (
+            _compartment_ids_for_tool(
+                compartment_id,
+                fetch_for_child_compartment=fetch_for_child_compartment,
+                request_id=request_id,
+            )
+            if compartment_id
+            else []
+        )
+
         results: list[DatabaseHomeSummary] = []
-        has_next = True
-        next_page = page
-        while has_next:
-            kwargs: dict = {"page": next_page}
-            if compartment_id:
-                kwargs["compartment_id"] = compartment_id
-            if db_system_id:
-                kwargs["db_system_id"] = db_system_id
-            if limit is not None:
-                kwargs["limit"] = limit
-            resp = client.list_db_homes(**kwargs)
-            data = getattr(resp.data, "items", resp.data)
-            for it in data or []:
-                m = map_database_home_summary(it)
-                if m is not None:
-                    results.append(m)
-            has_next = resp.has_next_page
-            next_page = resp.next_page if hasattr(resp, "next_page") else None
+        for each_comp in comp_ids or [compartment_id] if compartment_id else []:
+            has_next = True
+            next_page = page
+            while has_next:
+                kwargs: dict = {"page": next_page}
+                if each_comp:
+                    kwargs["compartment_id"] = each_comp
+                if db_system_id:
+                    kwargs["db_system_id"] = db_system_id
+                if limit is not None:
+                    kwargs["limit"] = limit
+                resp = client.list_db_homes(**kwargs)
+                data = getattr(resp.data, "items", resp.data)
+                for it in data or []:
+                    m = map_database_home_summary(it)
+                    if m is not None:
+                        results.append(m)
+                has_next = resp.has_next_page
+                next_page = resp.next_page if hasattr(resp, "next_page") else None
+
+        if fetch_for_child_compartment:
+            uniq: dict[str, DatabaseHomeSummary] = {}
+            for r in results:
+                rid = getattr(r, "id", None) if r is not None else None
+                if rid and rid not in uniq:
+                    uniq[rid] = r
+            results = list(uniq.values())
+
         return results
     except Exception as e:
         logger.error(f"Error in list_db_homes tool: {e}")
@@ -3064,6 +4126,10 @@ def list_db_systems(
     compartment_id: Annotated[
         Optional[str], "Compartment OCID or compartment display name to scope the search."
     ] = None,
+    fetch_for_child_compartment: Annotated[
+        bool,
+        "When true, scans the full subtree under compartment_id (including child compartments) and returns the combined results.",
+    ] = False,
     lifecycle_state: Annotated[Optional[str], "Filter by lifecycle state."] = None,
     limit: Annotated[Optional[int], "Maximum number of items per page."] = None,
     page: Annotated[Optional[str], "Pagination token (opc-next-page)."] = None,
@@ -3072,26 +4138,48 @@ def list_db_systems(
     try:
         request_id = uuid.uuid4().hex
         client = get_database_client(region, request_id=request_id)
-        compartment_id = _resolve_compartment_id(compartment_id, default_to_tenancy=True)
+        if not compartment_id:
+            compartment_id = get_tenancy()
+
+        comp_ids = (
+            _compartment_ids_for_tool(
+                compartment_id,
+                fetch_for_child_compartment=fetch_for_child_compartment,
+                request_id=request_id,
+            )
+            if compartment_id
+            else []
+        )
+
         results: list[DbSystemSummary] = []
-        has_next = True
-        next_page = page
-        while has_next:
-            kwargs: dict = {"page": next_page}
-            if compartment_id:
-                kwargs["compartment_id"] = compartment_id
-            if lifecycle_state:
-                kwargs["lifecycle_state"] = lifecycle_state
-            if limit is not None:
-                kwargs["limit"] = limit
-            resp = client.list_db_systems(**kwargs)
-            data = getattr(resp.data, "items", resp.data)
-            for it in data or []:
-                m = map_db_system_summary(it)
-                if m is not None:
-                    results.append(m)
-            has_next = resp.has_next_page
-            next_page = resp.next_page if hasattr(resp, "next_page") else None
+        for each_comp in comp_ids or [compartment_id] if compartment_id else []:
+            has_next = True
+            next_page = page
+            while has_next:
+                kwargs: dict = {"page": next_page}
+                if each_comp:
+                    kwargs["compartment_id"] = each_comp
+                if lifecycle_state:
+                    kwargs["lifecycle_state"] = lifecycle_state
+                if limit is not None:
+                    kwargs["limit"] = limit
+                resp = client.list_db_systems(**kwargs)
+                data = getattr(resp.data, "items", resp.data)
+                for it in data or []:
+                    m = map_db_system_summary(it)
+                    if m is not None:
+                        results.append(m)
+                has_next = resp.has_next_page
+                next_page = resp.next_page if hasattr(resp, "next_page") else None
+
+        if fetch_for_child_compartment:
+            uniq: dict[str, DbSystemSummary] = {}
+            for r in results:
+                rid = getattr(r, "id", None) if r is not None else None
+                if rid and rid not in uniq:
+                    uniq[rid] = r
+            results = list(uniq.values())
+
         return results
     except Exception as e:
         logger.error(f"Error in list_db_systems tool: {e}")

--- a/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/tests/test_recovery_database_tools.py
+++ b/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/tests/test_recovery_database_tools.py
@@ -174,66 +174,7 @@ class TestRecoveryDatabaseTools:
         assert result[0]["id"] == "wr1"
         assert result[0]["operation_type"] == "Restore Database"
 
-    @pytest.mark.asyncio
-    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
-    async def test_create_backup(self, mock_get_db_client):
-        mock_client = MagicMock()
-        mock_get_db_client.return_value = mock_client
-
-        create_resp = create_autospec(oci.response.Response)
-        create_resp.data = {
-            "id": "b-created",
-            "database_id": "db1",
-            "display_name": "Manual Backup",
-            "type": "FULL",
-        }
-        mock_client.create_backup.return_value = create_resp
-
-        async with Client(mcp) as client:
-            call_tool_result = await client.call_tool(
-                "create_backup",
-                {
-                    "database_id": "db1",
-                    "display_name": "Manual Backup",
-                    "retention_period_in_days": 14,
-                },
-            )
-            result = call_tool_result.structured_content
-
-        assert result["id"] == "b-created"
-        kwargs = mock_client.create_backup.call_args.kwargs
-        assert kwargs["create_backup_details"].database_id == "db1"
-        assert kwargs["create_backup_details"].retention_period_in_days == 14
-
-    @pytest.mark.asyncio
-    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
-    async def test_update_backup(self, mock_get_db_client):
-        mock_client = MagicMock()
-        mock_get_db_client.return_value = mock_client
-
-        update_resp = create_autospec(oci.response.Response)
-        update_resp.data = {
-            "id": "b1",
-            "database_id": "db1",
-            "retention_period_in_days": 30,
-        }
-        mock_client.update_backup.return_value = update_resp
-
-        async with Client(mcp) as client:
-            call_tool_result = await client.call_tool(
-                "update_backup",
-                {
-                    "backup_id": "b1",
-                    "retention_period_in_days": 30,
-                },
-            )
-            result = call_tool_result.structured_content
-
-        assert result["id"] == "b1"
-        kwargs = mock_client.update_backup.call_args.kwargs
-        assert kwargs["backup_id"] == "b1"
-        assert kwargs["update_backup_details"].retention_period_in_days == 30
-
+ 
     @pytest.mark.asyncio
     @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
     async def test_summarize_protected_database_backup_destination(self, mock_get_db_client):
@@ -527,19 +468,6 @@ class TestRecoveryDatabaseTools:
             result = call_tool_result.structured_content["result"]
 
         assert result == []
-
-    @pytest.mark.asyncio
-    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
-    async def test_update_backup_no_fields_raises(self, mock_get_db_client):
-        mock_client = MagicMock()
-        mock_get_db_client.return_value = mock_client
-
-        with pytest.raises(Exception, match="No update fields provided"):
-            async with Client(mcp) as client:
-                await client.call_tool(
-                    "update_backup",
-                    {"backup_id": "b1"},
-                )
 
     @pytest.mark.asyncio
     @patch("oracle.oci_recovery_mcp_server.server.get_database_client")

--- a/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/tests/test_recovery_database_tools.py
+++ b/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/tests/test_recovery_database_tools.py
@@ -23,6 +23,8 @@ class TestRecoveryDatabaseTools:
         # list_databases() returns a Response with .data.items
         list_resp = create_autospec(oci.response.Response)
         list_resp.data = SimpleNamespace(items=[{"id": "db1", "db_name": "DB1"}])
+        list_resp.has_next_page = False
+        list_resp.next_page = None
         mock_client.list_databases.return_value = list_resp
 
         # Enrichment path: get_database() to fill db_backup_config if missing
@@ -36,7 +38,10 @@ class TestRecoveryDatabaseTools:
         async with Client(mcp) as client:
             call_tool_result = await client.call_tool(
                 "list_databases",
-                {"db_home_id": "home1"},
+                {
+                    "compartment_id": "ocid1.compartment.oc1..test",
+                    "db_home_id": "home1",
+                },
             )
             result = call_tool_result.structured_content["result"]
 
@@ -90,7 +95,13 @@ class TestRecoveryDatabaseTools:
 
         list_resp = create_autospec(oci.response.Response)
         list_resp.data = SimpleNamespace(items=[{"id": "b1", "database_id": "db1"}])
+        list_resp.has_next_page = False
+        list_resp.next_page = None
         mock_client.list_backups.return_value = list_resp
+
+        get_db_resp = create_autospec(oci.response.Response)
+        get_db_resp.data = {"id": "db1", "db_unique_name": "DB1_UNQ"}
+        mock_client.get_database.return_value = get_db_resp
 
         async with Client(mcp) as client:
             call_tool_result = await client.call_tool(
@@ -102,6 +113,7 @@ class TestRecoveryDatabaseTools:
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["id"] == "b1"
+        assert result[0]["db_unique_name"] == "DB1_UNQ"
 
     @pytest.mark.asyncio
     @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
@@ -113,6 +125,16 @@ class TestRecoveryDatabaseTools:
         get_resp.data = {"id": "b1", "database_id": "db1"}
         mock_client.get_backup.return_value = get_resp
 
+        get_db_resp = create_autospec(oci.response.Response)
+        get_db_resp.data = {
+            "id": "db1",
+            "db_unique_name": "DB1_UNQ",
+            "db_backup_config": {
+                "backup_destination_details": [{"type": "OBJECT_STORE"}]
+            },
+        }
+        mock_client.get_database.return_value = get_db_resp
+
         async with Client(mcp) as client:
             call_tool_result = await client.call_tool(
                 "get_backup",
@@ -121,3 +143,485 @@ class TestRecoveryDatabaseTools:
             result = call_tool_result.structured_content
 
         assert result["id"] == "b1"
+        assert result["db_unique_name"] == "DB1_UNQ"
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_work_request_client")
+    async def test_list_restore(self, mock_get_wr_client):
+        mock_client = MagicMock()
+        mock_get_wr_client.return_value = mock_client
+
+        list_resp = create_autospec(oci.response.Response)
+        list_resp.data = SimpleNamespace(
+            items=[
+                {"id": "wr1", "operation_type": "Restore Database", "status": "SUCCEEDED"},
+                {"id": "wr2", "operation_type": "Create Backup", "status": "SUCCEEDED"},
+            ]
+        )
+        list_resp.has_next_page = False
+        list_resp.next_page = None
+        mock_client.list_work_requests.return_value = list_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "list_restore",
+                {"compartment_id": "ocid1.compartment.oc1..test"},
+            )
+            result = call_tool_result.structured_content["result"]
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "wr1"
+        assert result[0]["operation_type"] == "Restore Database"
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_create_backup(self, mock_get_db_client):
+        mock_client = MagicMock()
+        mock_get_db_client.return_value = mock_client
+
+        create_resp = create_autospec(oci.response.Response)
+        create_resp.data = {
+            "id": "b-created",
+            "database_id": "db1",
+            "display_name": "Manual Backup",
+            "type": "FULL",
+        }
+        mock_client.create_backup.return_value = create_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "create_backup",
+                {
+                    "database_id": "db1",
+                    "display_name": "Manual Backup",
+                    "retention_period_in_days": 14,
+                },
+            )
+            result = call_tool_result.structured_content
+
+        assert result["id"] == "b-created"
+        kwargs = mock_client.create_backup.call_args.kwargs
+        assert kwargs["create_backup_details"].database_id == "db1"
+        assert kwargs["create_backup_details"].retention_period_in_days == 14
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_update_backup(self, mock_get_db_client):
+        mock_client = MagicMock()
+        mock_get_db_client.return_value = mock_client
+
+        update_resp = create_autospec(oci.response.Response)
+        update_resp.data = {
+            "id": "b1",
+            "database_id": "db1",
+            "retention_period_in_days": 30,
+        }
+        mock_client.update_backup.return_value = update_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "update_backup",
+                {
+                    "backup_id": "b1",
+                    "retention_period_in_days": 30,
+                },
+            )
+            result = call_tool_result.structured_content
+
+        assert result["id"] == "b1"
+        kwargs = mock_client.update_backup.call_args.kwargs
+        assert kwargs["backup_id"] == "b1"
+        assert kwargs["update_backup_details"].retention_period_in_days == 30
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_summarize_protected_database_backup_destination(self, mock_get_db_client):
+        mock_client = MagicMock()
+        mock_get_db_client.return_value = mock_client
+
+        list_db_resp = create_autospec(oci.response.Response)
+        list_db_resp.data = [
+            {
+                "id": "db1",
+                "db_name": "DB1",
+                "db_backup_config": {
+                    "is_auto_backup_enabled": True,
+                    "backup_destination_details": [
+                        {"type": "RECOVERY_SERVICE", "id": "dest1"}
+                    ],
+                },
+            },
+            {
+                "id": "db2",
+                "db_name": "DB2",
+                "db_backup_config": {"is_auto_backup_enabled": False},
+            },
+        ]
+        list_db_resp.has_next_page = False
+        list_db_resp.next_page = None
+        mock_client.list_databases.return_value = list_db_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "summarize_protected_database_backup_destination",
+                {
+                    "compartment_id": "ocid1.compartment.oc1..test",
+                    "db_home_id": "home1",
+                },
+            )
+            result = call_tool_result.structured_content
+
+        assert result["total_databases"] == 2
+        assert result["unconfigured_count"] == 1
+        assert result["counts_by_destination_type"]["DBRS"] == 1
+        assert len(result["items"]) == 2
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_list_db_homes(self, mock_get_db_client):
+        mock_client = MagicMock()
+        mock_get_db_client.return_value = mock_client
+
+        list_resp = create_autospec(oci.response.Response)
+        list_resp.data = [
+            {"id": "home1", "display_name": "Home 1", "lifecycle_state": "AVAILABLE"}
+        ]
+        list_resp.has_next_page = False
+        list_resp.next_page = None
+        mock_client.list_db_homes.return_value = list_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "list_db_homes",
+                {"compartment_id": "ocid1.compartment.oc1..test"},
+            )
+            result = call_tool_result.structured_content["result"]
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "home1"
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_get_db_home(self, mock_get_db_client):
+        mock_client = MagicMock()
+        mock_get_db_client.return_value = mock_client
+
+        get_resp = create_autospec(oci.response.Response)
+        get_resp.data = {"id": "home1", "display_name": "Home 1"}
+        mock_client.get_db_home.return_value = get_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "get_db_home",
+                {"db_home_id": "home1"},
+            )
+            result = call_tool_result.structured_content
+
+        assert result["id"] == "home1"
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_list_db_systems(self, mock_get_db_client):
+        mock_client = MagicMock()
+        mock_get_db_client.return_value = mock_client
+
+        list_resp = create_autospec(oci.response.Response)
+        list_resp.data = [
+            {"id": "dbs1", "display_name": "DB System 1", "lifecycle_state": "AVAILABLE"}
+        ]
+        list_resp.has_next_page = False
+        list_resp.next_page = None
+        mock_client.list_db_systems.return_value = list_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "list_db_systems",
+                {"compartment_id": "ocid1.compartment.oc1..test"},
+            )
+            result = call_tool_result.structured_content["result"]
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "dbs1"
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_get_db_system(self, mock_get_db_client):
+        mock_client = MagicMock()
+        mock_get_db_client.return_value = mock_client
+
+        get_resp = create_autospec(oci.response.Response)
+        get_resp.data = {"id": "dbs1", "display_name": "DB System 1"}
+        mock_client.get_db_system.return_value = get_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "get_db_system",
+                {"db_system_id": "dbs1"},
+            )
+            result = call_tool_result.structured_content
+
+        assert result["id"] == "dbs1"
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_recovery_client")
+    @patch("oracle.oci_recovery_mcp_server.server._fetch_db_home_ids_for_compartment")
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_list_databases_compartment_only_discovers_homes(
+        self, mock_get_db_client, mock_fetch_homes, mock_get_rec_client
+    ):
+        db_client = MagicMock()
+        rec_client = MagicMock()
+        mock_get_db_client.return_value = db_client
+        mock_get_rec_client.return_value = rec_client
+        mock_fetch_homes.return_value = ["home1"]
+
+        # Recovery PD list returns empty (no policy enrichment needed)
+        pd_list_resp = create_autospec(oci.response.Response)
+        pd_list_resp.data = SimpleNamespace(items=[])
+        pd_list_resp.has_next_page = False
+        pd_list_resp.next_page = None
+        rec_client.list_protected_databases.return_value = pd_list_resp
+
+        list_resp = create_autospec(oci.response.Response)
+        list_resp.data = SimpleNamespace(items=[{"id": "db1", "db_name": "DB1"}])
+        list_resp.has_next_page = False
+        list_resp.next_page = None
+        db_client.list_databases.return_value = list_resp
+
+        get_db_resp = create_autospec(oci.response.Response)
+        get_db_resp.data = {"id": "db1", "db_backup_config": {"is_auto_backup_enabled": True}}
+        db_client.get_database.return_value = get_db_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "list_databases",
+                {"compartment_id": "ocid1.compartment.oc1..test"},
+            )
+            result = call_tool_result.structured_content["result"]
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "db1"
+        mock_fetch_homes.assert_called_once_with("ocid1.compartment.oc1..test", region=None)
+        # list_databases must be called with the discovered home id
+        call_kwargs = db_client.list_databases.call_args.kwargs
+        assert call_kwargs.get("db_home_id") == "home1"
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server._fetch_db_home_ids_for_compartment")
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_list_backups_compartment_path(
+        self, mock_get_db_client, mock_fetch_homes
+    ):
+        db_client = MagicMock()
+        mock_get_db_client.return_value = db_client
+        mock_fetch_homes.return_value = ["home1"]
+
+        # list_databases returns one AVAILABLE DB with auto-backup enabled
+        list_db_resp = create_autospec(oci.response.Response)
+        list_db_resp.data = SimpleNamespace(
+            items=[
+                {
+                    "id": "db1",
+                    "db_unique_name": "DB1_UNQ",
+                    "db_backup_config": {"is_auto_backup_enabled": True},
+                }
+            ]
+        )
+        list_db_resp.has_next_page = False
+        list_db_resp.next_page = None
+
+        list_bk_resp = create_autospec(oci.response.Response)
+        list_bk_resp.data = SimpleNamespace(items=[{"id": "b1", "database_id": "db1"}])
+        list_bk_resp.has_next_page = False
+        list_bk_resp.next_page = None
+
+        get_db_resp = create_autospec(oci.response.Response)
+        get_db_resp.data = {"id": "db1", "db_unique_name": "DB1_UNQ"}
+
+        db_client.list_databases.return_value = list_db_resp
+        db_client.list_backups.return_value = list_bk_resp
+        db_client.get_database.return_value = get_db_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "list_backups",
+                {"compartment_id": "ocid1.compartment.oc1..test"},
+            )
+            result = call_tool_result.structured_content["result"]
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "b1"
+        assert result[0]["db_unique_name"] == "DB1_UNQ"
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server._fetch_db_home_ids_for_compartment")
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_list_backups_compartment_skips_db_without_autobackup(
+        self, mock_get_db_client, mock_fetch_homes
+    ):
+        db_client = MagicMock()
+        mock_get_db_client.return_value = db_client
+        mock_fetch_homes.return_value = ["home1"]
+
+        # DB has auto-backup disabled -> no backups should be listed
+        list_db_resp = create_autospec(oci.response.Response)
+        list_db_resp.data = SimpleNamespace(
+            items=[
+                {
+                    "id": "db1",
+                    "db_unique_name": "DB1_UNQ",
+                    "db_backup_config": {"is_auto_backup_enabled": False},
+                }
+            ]
+        )
+        list_db_resp.has_next_page = False
+        list_db_resp.next_page = None
+
+        get_db_resp = create_autospec(oci.response.Response)
+        get_db_resp.data = {
+            "id": "db1",
+            "db_unique_name": "DB1_UNQ",
+            "db_backup_config": {"is_auto_backup_enabled": False},
+        }
+
+        db_client.list_databases.return_value = list_db_resp
+        db_client.get_database.return_value = get_db_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "list_backups",
+                {"compartment_id": "ocid1.compartment.oc1..test"},
+            )
+            result = call_tool_result.structured_content["result"]
+
+        assert result == []
+        db_client.list_backups.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_work_request_client")
+    async def test_list_restore_empty_when_no_restore_ops(self, mock_get_wr_client):
+        mock_client = MagicMock()
+        mock_get_wr_client.return_value = mock_client
+
+        list_resp = create_autospec(oci.response.Response)
+        list_resp.data = SimpleNamespace(
+            items=[
+                {"id": "wr1", "operation_type": "Create Backup", "status": "SUCCEEDED"},
+                {"id": "wr2", "operation_type": "DELETE_PROTECTED_DATABASE", "status": "SUCCEEDED"},
+            ]
+        )
+        list_resp.has_next_page = False
+        list_resp.next_page = None
+        mock_client.list_work_requests.return_value = list_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "list_restore",
+                {"compartment_id": "ocid1.compartment.oc1..test"},
+            )
+            result = call_tool_result.structured_content["result"]
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_update_backup_no_fields_raises(self, mock_get_db_client):
+        mock_client = MagicMock()
+        mock_get_db_client.return_value = mock_client
+
+        with pytest.raises(Exception, match="No update fields provided"):
+            async with Client(mcp) as client:
+                await client.call_tool(
+                    "update_backup",
+                    {"backup_id": "b1"},
+                )
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_summarize_backup_destination_with_last_backup_time(
+        self, mock_get_db_client
+    ):
+        mock_client = MagicMock()
+        mock_get_db_client.return_value = mock_client
+
+        list_db_resp = create_autospec(oci.response.Response)
+        list_db_resp.data = [
+            {
+                "id": "db1",
+                "db_name": "DB1",
+                "db_backup_config": {
+                    "is_auto_backup_enabled": True,
+                    "backup_destination_details": [
+                        {"type": "OBJECT_STORE", "id": "dest1"}
+                    ],
+                },
+            }
+        ]
+        list_db_resp.has_next_page = False
+        list_db_resp.next_page = None
+        mock_client.list_databases.return_value = list_db_resp
+
+        bk_resp = create_autospec(oci.response.Response)
+        bk_resp.data = SimpleNamespace(
+            items=[SimpleNamespace(time_ended="2024-06-01T10:00:00Z")]
+        )
+        bk_resp.has_next_page = False
+        mock_client.list_backups.return_value = bk_resp
+
+        async with Client(mcp) as client:
+            call_tool_result = await client.call_tool(
+                "summarize_protected_database_backup_destination",
+                {
+                    "compartment_id": "ocid1.compartment.oc1..test",
+                    "db_home_id": "home1",
+                    "include_last_backup_time": True,
+                },
+            )
+            result = call_tool_result.structured_content
+
+        assert result["total_databases"] == 1
+        assert result["counts_by_destination_type"]["OBJECT_STORE"] == 1
+        items = result["items"]
+        assert len(items) == 1
+        assert items[0]["last_backup_time"] == "2024-06-01T10:00:00Z"
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_recovery_mcp_server.server.get_database_client")
+    async def test_list_db_homes_fetch_child_compartments_dedup(
+        self, mock_get_db_client
+    ):
+        mock_client = MagicMock()
+        mock_get_db_client.return_value = mock_client
+
+        # Same home returned from two list calls (simulating two compartments)
+        list_resp = create_autospec(oci.response.Response)
+        list_resp.data = [
+            {"id": "home1", "display_name": "Home 1", "lifecycle_state": "AVAILABLE"}
+        ]
+        list_resp.has_next_page = False
+        list_resp.next_page = None
+        mock_client.list_db_homes.return_value = list_resp
+
+        with patch(
+            "oracle.oci_recovery_mcp_server.server._compartment_ids_for_tool",
+            return_value=["comp1", "comp2"],
+        ):
+            async with Client(mcp) as client:
+                call_tool_result = await client.call_tool(
+                    "list_db_homes",
+                    {
+                        "compartment_id": "ocid1.compartment.oc1..test",
+                        "fetch_for_child_compartment": True,
+                    },
+                )
+                result = call_tool_result.structured_content["result"]
+
+        # Dedup should collapse the duplicate home1 from two compartments to one
+        assert len(result) == 1
+        assert result[0]["id"] == "home1"
+

--- a/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/tests/test_recovery_tools.py
+++ b/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/tests/test_recovery_tools.py
@@ -183,6 +183,20 @@ def test_model_mappers_capture_nested_and_variant_fields():
     assert metrics.is_redo_logs_enabled is False
     assert metrics.retention_period_in_days == 14
 
+    work_request = models.map_work_request(
+        {
+            "id": "wr1",
+            "compartmentId": "compartment",
+            "operationType": "RESTORE_DATABASE",
+            "percentComplete": 75.5,
+            "resourceId": "db1",
+        }
+    )
+    assert work_request.id == "wr1"
+    assert work_request.operation_type == "RESTORE_DATABASE"
+    assert work_request.percent_complete == 75.5
+    assert work_request.resource_id == "db1"
+
 
 def test_model_mappers_cover_unusual_iterables_and_attribute_sources(monkeypatch):
     class BadIterable:
@@ -472,6 +486,74 @@ def test_http_config_and_client_factories_cover_auth_paths(monkeypatch):
     assert database_client.call_args.kwargs["signer"] == "session-signer"
 
 
+def test_new_client_factories_cover_limits_work_requests_and_subscription(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_get_http_config_and_signer",
+        lambda region=None: (None, None),
+    )
+    monkeypatch.setattr(
+        server,
+        "_load_oci_config_for_server",
+        lambda: {"region": "home-region"},
+    )
+    monkeypatch.setattr(server, "_effective_auth_method", lambda: "apikey")
+    monkeypatch.setattr(
+        server,
+        "_wrap_oci_client",
+        lambda client, **kwargs: (client, kwargs["client_name"]),
+    )
+
+    limits_client = MagicMock(return_value="limits-client")
+    work_request_client = MagicMock(return_value="work-request-client")
+    subscribed_service_client = MagicMock(return_value="subscription-client")
+    monkeypatch.setattr(server.oci.limits, "LimitsClient", limits_client)
+    monkeypatch.setattr(
+        server.oci.work_requests, "WorkRequestClient", work_request_client
+    )
+    monkeypatch.setattr(
+        server.oci.onesubscription,
+        "SubscribedServiceClient",
+        subscribed_service_client,
+    )
+
+    assert server.get_limits_client(region="us-phoenix-1")[1] == "limits"
+    assert (
+        server.get_work_request_client(region="us-chicago-1")[1] == "work_requests"
+    )
+    assert (
+        server.get_onesubscription_client(region="us-ashburn-1")[1]
+        == "onesubscription"
+    )
+    assert limits_client.call_args.args[0]["region"] == "us-phoenix-1"
+    assert work_request_client.call_args.args[0]["region"] == "us-chicago-1"
+    assert subscribed_service_client.call_args.args[0]["region"] == "us-ashburn-1"
+    assert "signer" not in limits_client.call_args.kwargs
+
+    monkeypatch.setattr(server, "_effective_auth_method", lambda: "session")
+    monkeypatch.setattr(
+        server, "_build_signer_for_session", lambda _config: "session-signer"
+    )
+    assert server.get_limits_client()[1] == "limits"
+    assert limits_client.call_args.kwargs["signer"] == "session-signer"
+
+    http_signer = object()
+    monkeypatch.setattr(
+        server,
+        "_get_http_config_and_signer",
+        lambda region=None: ({"region": region or "home-region"}, http_signer),
+    )
+    assert server.get_work_request_client(region="us-sanjose-1")[1] == "work_requests"
+    assert server.get_limits_client(region="us-sanjose-1")[1] == "limits"
+    assert (
+        server.get_onesubscription_client(region="us-sanjose-1")[1]
+        == "onesubscription"
+    )
+    assert work_request_client.call_args.kwargs["signer"] is http_signer
+    assert limits_client.call_args.kwargs["signer"] is http_signer
+    assert subscribed_service_client.call_args.kwargs["signer"] is http_signer
+
+
 def test_compartment_and_database_home_helpers_cover_resolution(monkeypatch):
     compartments = [
         SimpleNamespace(id="compartment-a", name="Dev"),
@@ -546,6 +628,213 @@ def test_compartment_and_database_home_helpers_cover_resolution(monkeypatch):
     ]
     db_client.list_db_homes.side_effect = RuntimeError("service unavailable")
     assert server._fetch_db_home_ids_for_compartment("compartment-a") == []
+
+
+def test_region_subscription_and_limit_tools_cover_current_contracts(monkeypatch):
+    region_cache = {"fetched_at": 0.0, "ttl_seconds": 3600, "items": {}}
+    monkeypatch.setattr(server, "_REGION_CACHE", region_cache)
+    monkeypatch.setattr(server, "get_tenancy", lambda: "tenancy")
+
+    identity_client = MagicMock()
+    identity_client.list_region_subscriptions.return_value = _response(
+        [
+            SimpleNamespace(region_name="us-phoenix-1", status="READY"),
+            SimpleNamespace(regionName="us-ashburn-1", status="READY"),
+            SimpleNamespace(status="IGNORED"),
+        ]
+    )
+    monkeypatch.setattr(
+        server, "get_identity_client", lambda request_id=None: identity_client
+    )
+
+    regions = server._iam_subscribed_regions_with_status(request_id="rid")
+    assert regions == [
+        {"region": "us-ashburn-1", "status": "READY"},
+        {"region": "us-phoenix-1", "status": "READY"},
+    ]
+    assert server._iam_subscribed_regions_with_status(request_id="rid2") == regions
+    identity_client.list_region_subscriptions.assert_called_once_with(
+        tenancy_id="tenancy"
+    )
+    assert server.fetch_regions_subscribed()["total"] == 2
+
+    limits_client = MagicMock()
+    monkeypatch.setattr(
+        server.oci.util,
+        "to_dict",
+        lambda _obj: _raise(RuntimeError("no SDK conversion")),
+    )
+    limits_client.get_resource_availability.side_effect = [
+        _response(
+            SimpleNamespace(
+                scope_type="REGION",
+                available=90,
+                used=10,
+                fractional_availability=0.9,
+                fractional_usage=0.1,
+                effective_quota_value=100,
+                policy_name="storage-policy",
+            )
+        ),
+        _response(
+            {
+                "scope_type": "AD",
+                "available": 4,
+                "used": 1,
+                "fractional_availability": 0.8,
+                "fractional_usage": 0.2,
+                "effective_quota_value": 5,
+                "policy_name": "count-policy",
+            }
+        ),
+    ]
+    monkeypatch.setattr(
+        server,
+        "_load_oci_config_for_server",
+        lambda: {"region": "us-phoenix-1"},
+    )
+    monkeypatch.setattr(
+        server,
+        "get_limits_client",
+        lambda region, request_id=None: limits_client,
+    )
+
+    limits = server.check_recovery_service_limits(
+        compartment_id="ignored",
+        region="ignored",
+        opc_request_id="opc",
+    )
+    assert limits["compartmentId"] == "tenancy"
+    assert limits["region"] == "us-phoenix-1"
+    assert limits["limits"]["protectedDatabaseBackupStorageGb"]["available"] == 90
+    assert limits["limits"]["protectedDatabaseCount"]["policyName"] == "count-policy"
+    assert [
+        call.kwargs["limit_name"]
+        for call in limits_client.get_resource_availability.call_args_list
+    ] == [
+        "protected-database-backup-storage-gb",
+        "protected-database-count",
+    ]
+    assert all(
+        call.kwargs["opc_request_id"] == "opc"
+        for call in limits_client.get_resource_availability.call_args_list
+    )
+
+
+def test_child_compartment_helpers_cover_cache_fast_path_and_fallback(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_COMPARTMENT_CACHE",
+        {"fetched_at": 0.0, "ttl_seconds": 300, "items": None},
+    )
+    monkeypatch.setattr(server.time, "time", lambda: 100.0)
+    monkeypatch.setattr(server, "get_tenancy", lambda: "tenancy")
+    monkeypatch.setattr(
+        server,
+        "list_all_compartments_internal",
+        lambda _only_one_page: [
+            SimpleNamespace(id="child", compartment_id="tenancy"),
+            SimpleNamespace(id="child", compartment_id="tenancy"),
+            SimpleNamespace(name="missing id"),
+        ],
+    )
+    identity_client = MagicMock()
+    identity_client.get_compartment.return_value = _response(
+        SimpleNamespace(id="tenancy", name="Root")
+    )
+    monkeypatch.setattr(
+        server, "get_identity_client", lambda request_id=None: identity_client
+    )
+
+    cached = server._list_all_compartments_cached(request_id="rid")
+    assert [compartment.id for compartment in cached] == ["child", "tenancy"]
+    assert server._list_all_compartments_cached(request_id="rid2") is cached
+
+    compartments = [
+        SimpleNamespace(id="root", compartment_id="tenancy"),
+        SimpleNamespace(id="child", compartment_id="root"),
+        SimpleNamespace(id="grandchild", compartmentId="child"),
+        SimpleNamespace(id="orphan"),
+    ]
+    assert server._build_children_index(compartments) == {
+        "tenancy": ["root"],
+        "root": ["child"],
+        "child": ["grandchild"],
+    }
+    monkeypatch.setattr(
+        server,
+        "_list_all_compartments_cached",
+        lambda request_id=None: compartments,
+    )
+    assert server._expand_compartment_scope(
+        "root", include_child_compartments=True
+    ) == ["root", "child", "grandchild"]
+    assert server._expand_compartment_scope(
+        "root", include_child_compartments=False
+    ) == ["root"]
+
+    fallback_identity = MagicMock()
+    fallback_identity.list_compartments.side_effect = [
+        _response([SimpleNamespace(id="child")], has_next_page=True, next_page="p2"),
+        _response([SimpleNamespace(id="sibling")]),
+        _response([]),
+        _response([]),
+    ]
+    monkeypatch.setattr(server, "_list_all_compartments_cached", lambda **_: [])
+    monkeypatch.setattr(
+        server, "get_identity_client", lambda request_id=None: fallback_identity
+    )
+    assert server._expand_compartment_scope(
+        "root", include_child_compartments=True
+    ) == ["root", "child", "sibling"]
+
+    monkeypatch.setattr(
+        server, "_resolve_compartment_id", lambda value, **_kwargs: f"resolved-{value}"
+    )
+    monkeypatch.setattr(
+        server,
+        "_expand_compartment_scope",
+        MagicMock(side_effect=RuntimeError("identity unavailable")),
+    )
+    assert server._compartment_ids_for_tool(
+        "Dev", fetch_for_child_compartment=True
+    ) == ["resolved-Dev"]
+
+
+def test_fetch_child_compartments_crawls_and_applies_output_options(monkeypatch):
+    identity_client = MagicMock()
+    identity_client.list_compartments.side_effect = [
+        _response([SimpleNamespace(id="child")]),
+        _response([]),
+    ]
+    monkeypatch.setattr(
+        server,
+        "_resolve_compartment_id",
+        lambda compartment_id: f"resolved-{compartment_id}",
+    )
+    monkeypatch.setattr(
+        server,
+        "_expand_compartment_scope",
+        lambda *_args, **_kwargs: ["resolved-Root"],
+    )
+    monkeypatch.setattr(
+        server, "get_identity_client", lambda request_id=None: identity_client
+    )
+
+    result = server.fetch_child_compartments("Root", include_self=False)
+    assert result == {
+        "rootCompartmentId": "resolved-Root",
+        "total": 1,
+        "compartmentIds": ["child"],
+    }
+
+    monkeypatch.setattr(
+        server,
+        "_expand_compartment_scope",
+        lambda *_args, **_kwargs: ["resolved-Root", "child", "grandchild"],
+    )
+    result = server.fetch_child_compartments("Root", include_self=True, limit=2)
+    assert result["compartmentIds"] == ["resolved-Root", "child"]
 
 
 class TestRecoveryTools:
@@ -755,10 +1044,13 @@ class TestRecoveryTools:
             )
             result = call_tool_result.structured_content
 
-            assert result["protected"] == 1
-            assert result["warning"] == 1
-            assert result["alert"] == 0
-            assert result["total"] == 2
+            aggregated = result["aggregated"]
+            assert aggregated["protected"] == 1
+            assert aggregated["warning"] == 1
+            assert aggregated["alert"] == 0
+            assert aggregated["total"] == 2
+            assert result["compartmentIdsScanned"] == ["ocid1.compartment.oc1..test"]
+            assert result["per_compartment"][0]["warning"] == 1
 
     @pytest.mark.asyncio
     @patch("oracle.oci_recovery_mcp_server.server.get_tenancy")
@@ -801,9 +1093,12 @@ class TestRecoveryTools:
             )
             result = call_tool_result.structured_content
 
-            assert result["enabled"] == 1
-            assert result["disabled"] == 1
-            assert result["total"] == 2
+            aggregated = result["aggregated"]
+            assert aggregated["enabled"] == 1
+            assert aggregated["disabled"] == 1
+            assert aggregated["total"] == 2
+            assert result["compartmentIdsScanned"] == ["ocid1.compartment.oc1..test"]
+            assert result["per_compartment"][0]["enabled"] == 1
 
     @pytest.mark.asyncio
     @patch("oracle.oci_recovery_mcp_server.server.get_tenancy")
@@ -854,14 +1149,16 @@ class TestRecoveryTools:
             )
             result = call_tool_result.structured_content
 
-        total_scanned = result.get("total_databases_scanned") or result.get(
+        aggregated = result["aggregated"]
+        total_scanned = aggregated.get("total_databases_scanned") or aggregated.get(
             "totalDatabasesScanned"
         )
-        sum_gb = result.get("sum_backup_space_used_in_gbs") or result.get(
+        sum_gb = aggregated.get("sum_backup_space_used_in_gbs") or aggregated.get(
             "sumBackupSpaceUsedInGBs"
         )
         assert abs(sum_gb - 15.0) < 1e-9
         assert total_scanned == 2
+        assert result["missingMetricsCount"] == 0
 
     @pytest.mark.asyncio
     @patch("oracle.oci_recovery_mcp_server.server.get_monitoring_client")
@@ -900,6 +1197,155 @@ class TestRecoveryTools:
             assert result[0]["dimensions"]["resourceId"] == "pd1"
             assert len(result[0]["datapoints"]) == 2
             assert result[0]["datapoints"][0]["value"] == 1.0
+
+
+def test_child_scope_tools_cover_dedup_and_filter_kwargs(monkeypatch):
+    recovery_client = MagicMock()
+    monitoring_client = MagicMock()
+    work_request_client = MagicMock()
+    monkeypatch.setattr(
+        models.oci.util,
+        "to_dict",
+        lambda obj: obj if isinstance(obj, dict) else getattr(obj, "__dict__", obj),
+    )
+    monkeypatch.setattr(
+        server,
+        "get_recovery_client",
+        lambda region=None, request_id=None: recovery_client,
+    )
+    monkeypatch.setattr(
+        server,
+        "get_monitoring_client",
+        lambda request_id=None: monitoring_client,
+    )
+    monkeypatch.setattr(
+        server,
+        "get_work_request_client",
+        lambda region=None, request_id=None: work_request_client,
+    )
+    monkeypatch.setattr(
+        server,
+        "_compartment_ids_for_tool",
+        lambda compartment_id, fetch_for_child_compartment, request_id=None: [
+            "compartment-a",
+            "compartment-b",
+        ],
+    )
+
+    recovery_client.list_protected_databases.side_effect = [
+        _response([SimpleNamespace(id="pd1", display_name="PD 1")]),
+        _response([SimpleNamespace(id="pd1", display_name="PD 1 duplicate")]),
+    ]
+    recovery_client.get_protected_database.return_value = _response(
+        SimpleNamespace(
+            metrics=SimpleNamespace(backup_space_used_in_gbs=1.5),
+            is_redo_logs_shipped=True,
+        )
+    )
+    protected_databases = server.list_protected_databases(
+        "root", fetch_for_child_compartment=True
+    )
+    assert [pd["id"] for pd in protected_databases] == ["pd1"]
+
+    recovery_client.list_protection_policies.side_effect = [
+        _response([SimpleNamespace(id="policy1")]),
+        _response([SimpleNamespace(id="policy1"), SimpleNamespace(id="policy2")]),
+    ]
+    policies = server.list_protection_policies(
+        "root", fetch_for_child_compartment=True
+    )
+    assert [policy.id for policy in policies] == ["policy1", "policy2"]
+
+    recovery_client.list_recovery_service_subnets.side_effect = [
+        _response([SimpleNamespace(id="rss1", subnet_id="subnet1")]),
+        _response([SimpleNamespace(id="rss1"), SimpleNamespace(id="rss2")]),
+    ]
+    recovery_client.get_recovery_service_subnet.side_effect = RuntimeError(
+        "optional full lookup failed"
+    )
+    subnets = server.list_recovery_service_subnets(
+        "root", fetch_for_child_compartment=True
+    )
+    assert [subnet.id for subnet in subnets] == ["rss1", "rss2"]
+    assert subnets[0].subnets == ["subnet1"]
+
+    series_a = SimpleNamespace(
+        dimensions={"resourceId": "pd1"},
+        aggregated_datapoints=[SimpleNamespace(timestamp="t1", value=1)],
+    )
+    series_b = SimpleNamespace(
+        dimensions={"resourceId": "pd2"},
+        aggregated_datapoints=[SimpleNamespace(timestamp="t2", value=2)],
+    )
+    monitoring_client.summarize_metrics_data.side_effect = [
+        _response([series_a]),
+        _response([series_b]),
+    ]
+    metrics = server.get_recovery_service_metrics(
+        compartment_id="root",
+        start_time="2024-01-01T00:00:00Z",
+        end_time="2024-01-01T01:00:00Z",
+        fetch_for_child_compartment=True,
+        metricName="DataLossExposure",
+        resolution="5m",
+        aggregation="sum",
+        protected_database_id="pd1",
+    )
+    assert [item["compartmentId"] for item in metrics] == [
+        "compartment-a",
+        "compartment-b",
+    ]
+    details = monitoring_client.summarize_metrics_data.call_args_list[0].kwargs[
+        "summarize_metrics_data_details"
+    ]
+    assert details.query == 'DataLossExposure[5m]{resourceId="pd1"}.sum()'
+
+    work_request_client.list_work_requests.side_effect = [
+        _response(
+            SimpleNamespace(
+                items=[
+                    {
+                        "id": "wr1",
+                        "operationType": "RESTORE_DATABASE",
+                        "status": "IN_PROGRESS",
+                    },
+                    {"id": "skip", "operationType": "Create Backup"},
+                ]
+            ),
+            has_next_page=True,
+            next_page="wr-page-2",
+        ),
+        _response([{"id": "wr1", "operation_type": "Restore Database"}]),
+        _response([{"id": "wr2", "operation_type": "restore-database"}]),
+    ]
+    restore_requests = server.list_restore(
+        "root",
+        fetch_for_child_compartment=True,
+        resource_id="db1",
+        status="IN_PROGRESS",
+        limit=2,
+        page="wr-page-1",
+        sort_order="DESC",
+        sort_by="timeAccepted",
+        opc_request_id="opc",
+        region="us-ashburn-1",
+    )
+    assert [request.id for request in restore_requests] == ["wr1", "wr2"]
+    first_restore_call = work_request_client.list_work_requests.call_args_list[0].kwargs
+    assert first_restore_call == {
+        "compartment_id": "compartment-a",
+        "resource_id": "db1",
+        "status": "IN_PROGRESS",
+        "sort_order": "DESC",
+        "sort_by": "timeAccepted",
+        "opc_request_id": "opc",
+        "limit": 2,
+        "page": "wr-page-1",
+    }
+    assert (
+        work_request_client.list_work_requests.call_args_list[1].kwargs["page"]
+        == "wr-page-2"
+    )
 
 
 def test_recovery_resource_tools_cover_filters_pagination_and_enrichment(monkeypatch):
@@ -1154,6 +1600,7 @@ def test_protected_database_tools_cover_serialization_fallbacks(monkeypatch):
     assert protected_databases == [
         {
             "id": "pd-fallback",
+            "policyLockedDateTime": None,
             "recovery_service_subnets": [{"id": "rss-fallback"}],
         }
     ]
@@ -1219,6 +1666,7 @@ def test_summary_tools_cover_fallback_counts_and_metrics(monkeypatch):
         "_resolve_compartment_id",
         lambda compartment_id, **_kwargs: compartment_id or "tenancy",
     )
+    monkeypatch.setattr(server, "get_tenancy", lambda: "tenancy")
 
     recovery_client.list_protected_databases.return_value = _response(
         [
@@ -1236,7 +1684,7 @@ def test_summary_tools_cover_fallback_counts_and_metrics(monkeypatch):
     health = server.summarize_protected_database_health(
         compartment_id=None, region="us-ashburn-1"
     )
-    assert health == {
+    assert health["aggregated"] == {
         "compartmentId": "tenancy",
         "region": "us-ashburn-1",
         "protected": 1,
@@ -1245,6 +1693,17 @@ def test_summary_tools_cover_fallback_counts_and_metrics(monkeypatch):
         "unknown": 1,
         "total": 3,
     }
+    assert health["per_compartment"] == [
+        {
+            "compartmentId": "tenancy",
+            "region": "us-ashburn-1",
+            "protected": 1,
+            "warning": 0,
+            "alert": 1,
+            "unknown": 1,
+            "total": 3,
+        }
+    ]
 
     recovery_client.list_protected_databases.return_value = _response(
         [
@@ -1263,13 +1722,14 @@ def test_summary_tools_cover_fallback_counts_and_metrics(monkeypatch):
     redo = server.summarize_protected_database_redo_status(
         compartment_id="compartment", region="us-ashburn-1"
     )
-    assert redo == {
+    assert redo["aggregated"] == {
         "compartmentId": "compartment",
         "region": "us-ashburn-1",
         "enabled": 2,
         "disabled": 1,
         "total": 3,
     }
+    assert redo["per_compartment"][0]["total"] == 3
 
     recovery_client.list_protected_databases.return_value = _response(
         [
@@ -1287,15 +1747,16 @@ def test_summary_tools_cover_fallback_counts_and_metrics(monkeypatch):
     recovery_client.get_protected_database.side_effect = [
         RuntimeError("fall back to summary metrics"),
         _response(SimpleNamespace(metrics={"backupSpaceUsedInGbs": 3.5})),
-        _response(SimpleNamespace(metrics={"backup_space_used_in_gbs": "not numeric"})),
+        _response(SimpleNamespace(metrics={})),
     ]
 
     backup_space = server.summarize_backup_space_used(
         compartment_id="compartment", region="us-ashburn-1"
     )
-    assert backup_space.compartment_id == "compartment"
-    assert backup_space.total_databases_scanned == 3
-    assert backup_space.sum_backup_space_used_in_gbs == 6.0
+    assert backup_space["aggregated"]["compartmentId"] == "compartment"
+    assert backup_space["aggregated"]["totalDatabasesScanned"] == 3
+    assert backup_space["aggregated"]["sumBackupSpaceUsedInGBs"] == 6.0
+    assert backup_space["missingMetricsCount"] == 1
 
 
 def test_database_tools_cover_compartment_paths_and_backup_enrichment(monkeypatch):
@@ -1479,6 +1940,187 @@ def test_database_tools_cover_compartment_paths_and_backup_enrichment(monkeypatc
     assert summary.items[0].last_backup_time.isoformat() == "2024-01-02T00:00:00+00:00"
 
 
+def test_database_child_scope_tools_cover_deduplication(monkeypatch):
+    db_client = MagicMock()
+    recovery_client = MagicMock()
+    monkeypatch.setattr(
+        models.oci.util,
+        "to_dict",
+        lambda obj: obj if isinstance(obj, dict) else getattr(obj, "__dict__", obj),
+    )
+    monkeypatch.setattr(
+        server,
+        "get_database_client",
+        lambda region=None, request_id=None: db_client,
+    )
+    monkeypatch.setattr(
+        server,
+        "get_recovery_client",
+        lambda region=None, request_id=None: recovery_client,
+    )
+    monkeypatch.setattr(
+        server, "_resolve_compartment_id", lambda value, **_kwargs: value
+    )
+    monkeypatch.setattr(
+        server,
+        "_compartment_ids_for_tool",
+        lambda compartment_id, fetch_for_child_compartment, request_id=None: [
+            "compartment-a",
+            "compartment-b",
+        ],
+    )
+    monkeypatch.setattr(
+        server,
+        "_fetch_db_home_ids_for_compartment",
+        lambda compartment_id, region=None: ["home1"],
+    )
+    recovery_client.list_protected_databases.return_value = _response([])
+
+    db_client.list_databases.side_effect = [
+        _response(
+            SimpleNamespace(
+                items=[
+                    {
+                        "id": "db1",
+                        "dbName": "DB1",
+                        "dbBackupConfig": {"isAutoBackupEnabled": True},
+                    }
+                ]
+            )
+        ),
+        _response(
+            SimpleNamespace(
+                items=[
+                    {
+                        "id": "db1",
+                        "dbName": "DB1 Duplicate",
+                        "dbBackupConfig": {"isAutoBackupEnabled": True},
+                    },
+                    {
+                        "id": "db2",
+                        "dbName": "DB2",
+                        "dbBackupConfig": {"isAutoBackupEnabled": True},
+                    },
+                ]
+            )
+        ),
+    ]
+    databases = server.list_databases(
+        compartment_id="root",
+        fetch_for_child_compartment=True,
+    )
+    assert [database.id for database in databases] == ["db1", "db2"]
+
+    db_client.reset_mock()
+    db_client.list_databases.side_effect = [
+        _response(
+            SimpleNamespace(
+                items=[
+                    {
+                        "id": "db1",
+                        "dbUniqueName": "DB1_UNQ",
+                        "dbBackupConfig": {"isAutoBackupEnabled": True},
+                    }
+                ]
+            )
+        ),
+        _response(
+            SimpleNamespace(
+                items=[
+                    {
+                        "id": "db2",
+                        "dbUniqueName": "DB2_UNQ",
+                        "dbBackupConfig": {"isAutoBackupEnabled": True},
+                    }
+                ]
+            )
+        ),
+    ]
+    db_client.list_backups.side_effect = [
+        _response(SimpleNamespace(items=[{"id": "backup1", "databaseId": "db1"}])),
+        _response(
+            SimpleNamespace(
+                items=[
+                    {"id": "backup1", "databaseId": "db2"},
+                    {"id": "backup2", "databaseId": "db2"},
+                ]
+            )
+        ),
+    ]
+    backups = server.list_backups(
+        compartment_id="root",
+        fetch_for_child_compartment=True,
+    )
+    assert [backup["id"] for backup in backups] == ["backup1", "backup2"]
+
+    db_client.reset_mock()
+    db_client.list_databases.side_effect = [
+        _response(
+            [
+                {
+                    "id": "db1",
+                    "dbName": "DB1",
+                    "dbBackupConfig": {
+                        "isAutoBackupEnabled": True,
+                        "backupDestinationDetails": [
+                            {"type": "RECOVERY_SERVICE", "id": "dest1"}
+                        ],
+                    },
+                }
+            ]
+        ),
+        _response(
+            [
+                {
+                    "id": "db1",
+                    "dbName": "DB1 Duplicate",
+                    "dbBackupConfig": {
+                        "isAutoBackupEnabled": True,
+                        "backupDestinationDetails": [
+                            {"type": "RECOVERY_SERVICE", "id": "dest1"}
+                        ],
+                    },
+                },
+                {
+                    "id": "db2",
+                    "dbName": "DB2",
+                    "dbBackupConfig": {"isAutoBackupEnabled": False},
+                },
+            ]
+        ),
+    ]
+    summary = server.summarize_protected_database_backup_destination(
+        compartment_id="root",
+        fetch_for_child_compartment=True,
+        db_home_id="home1",
+        include_last_backup_time=False,
+    )
+    assert [item.database_id for item in summary.items] == ["db1", "db2"]
+    assert summary.total_databases == 3
+
+    db_client.reset_mock()
+    db_client.list_db_homes.side_effect = [
+        _response([SimpleNamespace(id="home1")]),
+        _response([SimpleNamespace(id="home1"), SimpleNamespace(id="home2")]),
+    ]
+    homes = server.list_db_homes(
+        compartment_id="root",
+        fetch_for_child_compartment=True,
+    )
+    assert [home.id for home in homes] == ["home1", "home2"]
+
+    db_client.reset_mock()
+    db_client.list_db_systems.side_effect = [
+        _response([SimpleNamespace(id="system1")]),
+        _response([SimpleNamespace(id="system1"), SimpleNamespace(id="system2")]),
+    ]
+    systems = server.list_db_systems(
+        compartment_id="root",
+        fetch_for_child_compartment=True,
+    )
+    assert [system.id for system in systems] == ["system1", "system2"]
+
+
 def test_database_home_and_system_tools_cover_pagination_and_defaults(monkeypatch):
     db_client = MagicMock()
     monkeypatch.setattr(
@@ -1515,7 +2157,8 @@ def test_database_home_and_system_tools_cover_pagination_and_defaults(monkeypatc
     )
     assert [home.id for home in homes] == ["home1", "home2"]
     assert (
-        db_client.list_db_homes.call_args_list[0].kwargs["compartment_id"] == "tenancy"
+        db_client.list_db_homes.call_args_list[0].kwargs["compartment_id"]
+        == "resolved-tenancy"
     )
     assert db_client.list_db_homes.call_args_list[1].kwargs["page"] == "home-page-2"
 
@@ -1655,7 +2298,7 @@ def test_summary_serialization_fallbacks_and_error_paths(monkeypatch):
         "dict",
         lambda self, **_kwargs: _raise(RuntimeError("dict failed")),
     )
-    assert server.summarize_protected_database_health("compartment") == {
+    assert server.summarize_protected_database_health("compartment")["aggregated"] == {
         "compartmentId": "compartment",
         "region": None,
         "protected": 0,
@@ -1675,7 +2318,7 @@ def test_summary_serialization_fallbacks_and_error_paths(monkeypatch):
         "dict",
         lambda self, **_kwargs: _raise(RuntimeError("dict failed")),
     )
-    assert server.summarize_protected_database_redo_status("compartment") == {
+    assert server.summarize_protected_database_redo_status("compartment")["aggregated"] == {
         "compartmentId": "compartment",
         "region": None,
         "enabled": 0,
@@ -1855,6 +2498,7 @@ def test_database_list_branches_and_tool_error_paths(monkeypatch):
         "_resolve_compartment_id",
         lambda compartment_id, **_kwargs: compartment_id or "tenancy",
     )
+    recovery_client.list_protected_databases.return_value = _response([])
 
     with pytest.raises(ValueError, match="Either db_home_id"):
         server.list_databases()
@@ -1888,7 +2532,7 @@ def test_database_list_branches_and_tool_error_paths(monkeypatch):
 
     db_client.list_databases.return_value = _response([{"id": "db2", "dbName": "DB2"}])
     db_client.get_database.side_effect = RuntimeError("backup config unavailable")
-    databases = server.list_databases(db_home_id="home1")
+    databases = server.list_databases(compartment_id="compartment", db_home_id="home1")
     assert databases[0].id == "db2"
     assert databases[0].db_backup_config is None
 


### PR DESCRIPTION
 # Description

  This change expands the Recovery MCP server’s read-oriented Recovery Service coverage.

  Summary of change:
  - Adds restore discovery support via `list_restore`.
  - Adds child-compartment traversal support to list/summarize flows so compartment-scoped queries can aggregate across the subtree when requested.
  - Makes retention-lock and redo-shipping fields explicit in responses for protected database reads.

  Motivation and context:
  - The branch adds better visibility into restore activity and related database inventory for Recovery MCP users.

  Dependencies required for this change:
  - No new package or module dependencies were added in this branch.
  - This change continues to rely on the existing OCI Python SDK and the repo’s existing test environment.

  Fixes #<issue-number>

  ## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] This change requires a documentation update

  # How Has This Been Tested?

  Validated with targeted pytest coverage for the two Recovery MCP test modules changed by this branch.

  Repro:
  `ORACLE_MCP_LOG_DIR=/private/tmp/oci-recovery-mcp-logs pytest src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/tests/test_recovery_database_tools.py src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/tests/test_recovery_tools.py`

  - [x] `test_recovery_database_tools.py`
  - [x] `test_recovery_tools.py`

  **Test Configuration**:
  * Firmware version: N/A
  * Hardware: Local macOS development machine
  * Toolchain: Python 3.13.5, pytest 9.0.2
  * SDK: Existing repo environment / OCI Python SDK

  # Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [ ] Any dependent changes have been merged and published in downstream modules