### PR TITLE
fixes bug in command parsing to perserve quoted arguements

### DIFF
--- a/src/oci-api-mcp-server/CHANGELOG.md
+++ b/src/oci-api-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- OCI command parsing now preserves quoted arguments when retrieving command help or running OCI CLI commands. ([#100](https://github.com/oracle/mcp/issues/100))
+
 ## 2.0.0
 
 ### Breaking Changes

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/server.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/server.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 from logging import Logger
+import shlex
 from typing import Annotated
 
 import oci
@@ -110,7 +111,7 @@ def get_oci_command_help(command: str) -> str:
 
     try:
         result = subprocess.run(
-            ["oci"] + command.split() + ["--help"],
+            ["oci"] + shlex.split(command) + ["--help"],
             env=env_copy,
             capture_output=True,
             text=True,
@@ -163,7 +164,7 @@ def run_oci_command(
 
     try:
         result = subprocess.run(
-            ["oci", "--profile", profile, "--auth", "security_token"] + command.split(),
+            ["oci", "--profile", profile, "--auth", "security_token"] + shlex.split(command),
             env=env_copy,
             capture_output=True,
             text=True,

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
@@ -48,6 +48,40 @@ class TestOCITools:
 
     @pytest.mark.asyncio
     @patch("oracle.oci_api_mcp_server.server.subprocess.run")
+    async def test_get_oci_command_help_preserves_quoted_arguments(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.stdout = "Help output"
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "get_oci_command_help",
+                    {"command": 'compute instance list --display-name "Shared Services"'},
+                )
+            ).structured_content["result"]
+
+            assert result == "Help output"
+            mock_run.assert_called_once_with(
+                [
+                    "oci",
+                    "compute",
+                    "instance",
+                    "list",
+                    "--display-name",
+                    "Shared Services",
+                    "--help",
+                ],
+                env=ANY,
+                capture_output=True,
+                text=True,
+                check=True,
+                shell=False,
+            )
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_api_mcp_server.server.subprocess.run")
     async def test_get_oci_command_help_failure(self, mock_run):
         mock_result = MagicMock()
         mock_result.stdout = "Some output"
@@ -107,6 +141,46 @@ class TestOCITools:
                 "error": mock_result.stderr,
                 "returncode": mock_result.returncode,
             }
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_api_mcp_server.server.subprocess.run")
+    async def test_run_oci_command_preserves_quoted_arguments(self, mock_run):
+        command = 'compute instance list --display-name "Shared Services"'
+
+        mock_result = MagicMock()
+        mock_result.stdout = "This is not JSON"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        async with Client(mcp) as client:
+            result = (await client.call_tool("run_oci_command", {"command": command})).data
+
+            assert result == {
+                "command": command,
+                "output": mock_result.stdout,
+                "error": mock_result.stderr,
+                "returncode": mock_result.returncode,
+            }
+            mock_run.assert_called_once_with(
+                [
+                    "oci",
+                    "--profile",
+                    "DEFAULT",
+                    "--auth",
+                    "security_token",
+                    "compute",
+                    "instance",
+                    "list",
+                    "--display-name",
+                    "Shared Services",
+                ],
+                env=ANY,
+                capture_output=True,
+                text=True,
+                check=True,
+                shell=False,
+            )
 
     @pytest.mark.asyncio
     @patch("oracle.oci_api_mcp_server.server.subprocess.run")


### PR DESCRIPTION
# Description

Use `shlex.split` when building OCI CLI subprocess arguments so quoted values are preserved as a single argument. This fixes commands such as:

`compute instance list --display-name "Shared Services"`

Previously, plain `command.split()` broke quoted values into separate tokens.

Fixes [#100 ](https://github.com/oracle/mcp/issues/100)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (CHANGELOG.md)

# How Has This Been Tested?

- [x] `make test project=oci-api-mcp-server`
- [x] `make lint`

**Test Configuration**:
* Toolchain: Python 3.13.13, pytest 9.0.3, ruff via `uv tool run`
* SDK: `oci-cli==3.79.0`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
