### PR TITLE
Adding resource principal and instance principal auth methods for OCI Database MCP server

### DIFF
--- a/src/oci-database-mcp-server/CHANGELOG.md
+++ b/src/oci-database-mcp-server/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to OCI Database MCP Server are documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Resource principal and instance principal authentication options for OCI Database service requests.
+
+### Changed
+
+- Added `cryptography` for RPST request signing and `requests` for RPST token exchange.
+
+### Fixed
+
+- Bound resource-principal token and session-token HTTP calls with explicit connect and read timeouts.

--- a/src/oci-database-mcp-server/README.md
+++ b/src/oci-database-mcp-server/README.md
@@ -14,7 +14,116 @@ uv run oracle.oci-database-mcp-server
 
 The server supports the following environment variables:
 
-- `OCI_CONFIG_PROFILE`: OCI configuration profile name (default: "DEFAULT")
+- `OCI_CONFIG_PROFILE`: OCI configuration profile name (default: `DEFAULT`) used with `AUTH_METHOD=token`
+- `OCI_CONFIG_FILE`: Path to OCI config file (default: OCI SDK/CLI default location) used with `AUTH_METHOD=token`
+
+When running from an MCP client (Cline/Cursor/MCPHost), these values can be set in the server's `env` block for **local/direct** launches.
+
+For **SSH-based remote execution** (for example: MCP server runs on a DB System, while Cline runs locally), pass the auth values as runtime args in the remote command.
+
+## Authentication Methods
+
+### 1) Security Token authentication (default)
+
+When `AUTH_METHOD` is unset or set to `token`, the server uses Security Token authentication from your OCI config profile.
+
+Expected config/profile contents include `security_token_file` and `key_file` (along with standard OCI config values such as tenancy and region).
+
+(Run `oci session authenticate` with your required profile to fetch this token)
+
+Example:
+
+```json
+{
+  "mcpServers": {
+    "oracle-oci-database-mcp-server": {
+      "command": "uvx",
+      "args": ["oracle.oci-database-mcp-server"],
+      "env": {
+        "OCI_CONFIG_PROFILE": "DEFAULT",
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    }
+  }
+}
+```
+
+### 2) Instance Principal authentication
+
+Use `--auth-method instance_principal` to select instance principal signer-based auth. This mode is intended for workloads running on OCI compute resources with appropriate dynamic group and IAM policies.
+
+> For SSH remote execution, do not rely only on `env.AUTH_METHOD`; pass `--auth-method instance_principal` in the launched command args.
+
+Example:
+
+```json
+{
+  "mcpServers": {
+    "oci-database-mcp-on-instance": {
+      "command": "ssh",
+      "args": [
+        "-i",
+        "/path/to/ssh-key.pem",
+        "opc@<instance-public-ip>",
+        "uvx oracle.oci-database-mcp-server",
+        " --auth-method instance_principal"
+      ],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    }
+  }
+}
+```
+
+### 3) Resource Principal authentication
+
+Use `--auth-method resource_principal` to use the server's RPST flow.
+
+#### RP values
+The following values are used for RP auth:
+
+| Runtime arg | Environment variable | Description                                                                                            |
+| --- | --- |--------------------------------------------------------------------------------------------------------|
+| `--database-endpoint` | `DATABASE_ENDPOINT` | OPTIONAL override for Database service endpoint used to obtain v2.1.2 resource principal tokens.       |
+| `--tenancy-ocid` | `TENANCY_OCID` | Tenancy OCID associated with the resource principal.                                                   |
+| `--private-key-path` | `PRIVATE_KEY_PATH` | Path to PEM private key used for request signing in the RPST bootstrap flow.                           |
+| `--resource-ocid` | `RESOURCE_OCID` | OCID of the resource acting as principal.                                                              |
+| `--rci` | `RCI` | Resource context identifier used to build the security context.                                        |
+| `--t0` | `T0` | Base timestamp (ISO-8601 UTC, for example `2025-01-01T00:00:00Z`) used in security context generation. |
+
+If any required RP value is missing, the server exits during startup with an error.
+
+#### SSH / DB System configuration (local Cline -> remote DB System)
+
+Pass RP auth selection and RP values as runtime args in your SSH MCP config:
+
+```json
+{
+  "mcpServers": {
+    "oci-database-mcp-on-dbsystem": {
+      "command": "ssh",
+      "args": [
+        "-i",
+        "/path/to/ssh-key.pem",
+        "opc@<db-system-public-ip>",
+        "uvx oracle.oci-database-mcp-server",
+        " --auth-method resource_principal",
+        " --tenancy-ocid ocid1.tenancy.oc1..<example_unique_id>",
+        " --private-key-path /path/to/wallet_PrivateKey.pem",
+        " --resource-ocid ocid1.dbsystem.oc1.<region>.<example_unique_id>",
+        " --rci <base64_resource_context_identifier>",
+        " --t0 2026-01-01T00:00:00.000Z"
+      ],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    }
+  }
+}
+```
+
+> In SSH mode, passing only `env.AUTH_METHOD`/RP env vars is not sufficient for the remote command context. Use runtime args as shown above.
 
 ## Tools
 

--- a/src/oci-database-mcp-server/oracle/oci_database_mcp_server/__init__.py
+++ b/src/oci-database-mcp-server/oracle/oci_database_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-database-mcp-server"
-__version__ = "1.0.7"
+__version__ = "1.1.0"

--- a/src/oci-database-mcp-server/oracle/oci_database_mcp_server/server.py
+++ b/src/oci-database-mcp-server/oracle/oci_database_mcp_server/server.py
@@ -4,11 +4,23 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import argparse
+import base64
+import datetime
+import hashlib
+import hmac
+import json
 import os
+import sys
 from logging import Logger
+from pathlib import Path
 from typing import Annotated, Any, Optional
+from urllib.parse import quote_plus, urlparse
 
 import oci
+import requests
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from fastmcp import FastMCP
 from oci.database.models import (
     CreatePluggableDatabaseFromLocalCloneDetails,
@@ -283,6 +295,260 @@ logger = Logger(__name__, level="INFO")
 mcp = FastMCP(name=__project__)
 
 
+# --- Global Variables for Auth ---
+AUTH_METHOD = "token"
+RPST_SIGNER = None
+CUSTOM_DATABASE_ENDPOINT = None
+DATABASE_ENDPOINT = None
+IMDS_INSTANCE_ENDPOINT = "http://169.254.169.254/opc/v2/instance/"
+RPST_HTTP_TIMEOUT = (5, 30)
+
+# --- Custom RPST Authentication Functions ---
+
+
+def load_private_key(path):
+    return serialization.load_pem_private_key(Path(path).read_bytes(), password=None)
+
+
+def build_java_style_auth_header(key_id, signature, headers_list):
+    return (
+        f'Signature headers="{headers_list}",'
+        f'keyId="{key_id}",'
+        f'algorithm="rsa-sha256",'
+        f'signature="{signature}",'
+        f'version="1"'
+    )
+
+
+def build_security_context(rci, t0, security_context_version, key_type):
+    t0_dt = datetime.datetime.fromisoformat(t0.replace("Z", "+00:00"))
+    now_dt = datetime.datetime.now(datetime.timezone.utc)
+
+    rci_key = base64.b64decode(rci)
+    t0_ms = int(t0_dt.timestamp() * 1000)
+    tn_ms = int(now_dt.timestamp() * 1000)
+    delta_ms = tn_ms - t0_ms
+    msg = delta_ms.to_bytes(8, byteorder="big", signed=False)
+
+    digest = hmac.new(rci_key, msg, hashlib.sha1).digest()
+    offset = digest[-1] & 0x0F
+    binary = (
+        ((digest[offset] & 0x7F) << 24)
+        | ((digest[offset + 1] & 0xFF) << 16)
+        | ((digest[offset + 2] & 0xFF) << 8)
+        | (digest[offset + 3] & 0xFF)
+    )
+    signature_code = f"{binary % 100000000:08d}"
+    current_utc_time = now_dt.isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+    return json.dumps(
+        {
+            "RPTSecurityContext": {
+                "contextVersion": security_context_version,
+                "keyType": key_type,
+                "securitySignature": {
+                    "currentUTCTime": current_utc_time,
+                    "Signature": signature_code,
+                },
+            }
+        },
+        indent=2,
+    )
+
+
+def fetch_tokens_v212(
+    database_endpoint, resource_ocid, tenancy_ocid, private_key, security_context
+):
+    key_id = f"resource/v2.1.2/{tenancy_ocid}/{resource_ocid}"
+    url = f"{database_endpoint}/20180711/resourcePrincipalTokenV212/{resource_ocid}"
+    host = urlparse(url).netloc
+    date_str = datetime.datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    headers = {
+        "date": date_str,
+        "host": host,
+        "security-context": quote_plus(security_context),
+    }
+
+    signing_string = (
+        f"date: {date_str}\n(request-target): get {urlparse(url).path}\nhost: {host}"
+    )
+    sig_bytes = private_key.sign(
+        signing_string.encode("utf-8"), padding.PKCS1v15(), hashes.SHA256()
+    )
+    headers["Authorization"] = build_java_style_auth_header(
+        key_id, base64.b64encode(sig_bytes).decode(), "date (request-target) host"
+    )
+
+    try:
+        resp = requests.get(url, headers=headers, timeout=RPST_HTTP_TIMEOUT)
+    except requests.exceptions.Timeout as error:
+        raise RuntimeError("Timed out fetching resource principal tokens") from error
+
+    if resp.status_code != 200:
+        params = {"securityContext": security_context}
+        req = requests.Request(
+            "GET", url, params=params, headers={"date": date_str, "host": host}
+        )
+        prep = req.prepare()
+
+        signing_string_query = (
+            f"date: {date_str}\n(request-target): get {prep.path_url}\nhost: {host}"
+        )
+        sig_query = private_key.sign(
+            signing_string_query.encode("utf-8"), padding.PKCS1v15(), hashes.SHA256()
+        )
+        prep.headers["Authorization"] = build_java_style_auth_header(
+            key_id, base64.b64encode(sig_query).decode(), "date (request-target) host"
+        )
+
+        try:
+            resp = requests.Session().send(prep, timeout=RPST_HTTP_TIMEOUT)
+        except requests.exceptions.Timeout as error:
+            raise RuntimeError("Timed out fetching resource principal tokens") from error
+
+    if resp.status_code != 200:
+        raise Exception(f"Token fetch failed: {resp.status_code} {resp.text}")
+
+    data = resp.json()
+    return data["resourcePrincipalToken"], data["servicePrincipalSessionToken"]
+
+
+def fetch_rpst_from_auth(
+    auth_endpoint, tenancy_ocid, resource_ocid, private_key, rpt, spst
+):
+    key_id = f"resource/v2.1.2/{tenancy_ocid}/{resource_ocid}"
+    url = f"{auth_endpoint}/v1/resourcePrincipalSessionToken"
+
+    session_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    session_public_der = session_private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    body = json.dumps(
+        {
+            "resourcePrincipalToken": rpt,
+            "servicePrincipalSessionToken": spst,
+            "sessionPublicKey": base64.b64encode(session_public_der).decode(),
+        },
+        separators=(",", ":"),
+    ).encode()
+
+    date_str = datetime.datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S GMT")
+    content_sha = base64.b64encode(hashlib.sha256(body).digest()).decode()
+
+    headers = {
+        "date": date_str,
+        "host": urlparse(url).netloc,
+        "content-type": "application/json",
+        "content-length": str(len(body)),
+        "x-content-sha256": content_sha,
+    }
+
+    signing_string = f"date: {date_str}\n(request-target): post {urlparse(url).path}\nhost: {headers['host']}\ncontent-length: {len(body)}\ncontent-type: application/json\nx-content-sha256: {content_sha}"
+    sig = private_key.sign(signing_string.encode(), padding.PKCS1v15(), hashes.SHA256())
+    headers["Authorization"] = build_java_style_auth_header(
+        key_id,
+        base64.b64encode(sig).decode(),
+        "date (request-target) host content-length content-type x-content-sha256",
+    )
+
+    try:
+        resp = requests.post(url, data=body, headers=headers, timeout=RPST_HTTP_TIMEOUT)
+    except requests.exceptions.Timeout as error:
+        raise RuntimeError("Timed out exchanging resource principal session token") from error
+    if resp.status_code != 200:
+        raise Exception(f"RPST exchange failed: {resp.status_code} {resp.text}")
+
+    return resp.json()["token"], session_private_key
+
+
+def _get_region_from_imds() -> str:
+    headers = {"Authorization": "Bearer Oracle"}
+    response = requests.get(IMDS_INSTANCE_ENDPOINT, headers=headers, timeout=5)
+    if response.status_code != 200:
+        raise Exception(f"IMDS lookup failed: {response.status_code} {response.text}")
+
+    payload = response.json()
+    region = payload.get("canonicalRegionName") or payload.get("region")
+    if not region:
+        raise Exception(
+            "Unable to determine region from IMDS payload (missing canonicalRegionName/region)"
+        )
+
+    return region
+
+
+def build_default_rp_endpoints(region: str) -> tuple[str, str]:
+    database_endpoint = f"https://database.{region}.oraclecloud.com"
+    auth_endpoint = f"https://auth.{region}.oraclecloud.com"
+    return database_endpoint, auth_endpoint
+
+
+def initialize_rpst_auth_from_env(
+    database_endpoint: Optional[str] = None,
+    tenancy_ocid: Optional[str] = None,
+    private_key_path: Optional[str] = None,
+    resource_ocid: Optional[str] = None,
+    rci: Optional[str] = None,
+    t0: Optional[str] = None,
+):
+    global RPST_SIGNER, DATABASE_ENDPOINT
+
+    resolved_values = {
+        "TENANCY_OCID": tenancy_ocid or os.getenv("TENANCY_OCID"),
+        "PRIVATE_KEY_PATH": private_key_path or os.getenv("PRIVATE_KEY_PATH"),
+        "RESOURCE_OCID": resource_ocid or os.getenv("RESOURCE_OCID"),
+        "RCI": rci or os.getenv("RCI"),
+        "T0": t0 or os.getenv("T0"),
+    }
+    missing_env_vars = [name for name, value in resolved_values.items() if not value]
+    if missing_env_vars:
+        print(
+            "Error: Missing required environment variables when using AUTH_METHOD=resource_principal:",
+            file=sys.stderr,
+        )
+        for name in missing_env_vars:
+            print(f"  {name}", file=sys.stderr)
+        sys.exit(1)
+
+    database_endpoint = database_endpoint or os.getenv("DATABASE_ENDPOINT")
+
+    try:
+        imds_region = _get_region_from_imds()
+        default_database_endpoint, auth_endpoint = build_default_rp_endpoints(
+            imds_region
+        )
+    except Exception as e:
+        print(f"Failed to resolve RP endpoints from IMDS: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    database_endpoint = database_endpoint or default_database_endpoint
+    tenancy_ocid = resolved_values["TENANCY_OCID"]
+    private_key_path = resolved_values["PRIVATE_KEY_PATH"]
+    resource_ocid = resolved_values["RESOURCE_OCID"]
+    rci = resolved_values["RCI"]
+    t0 = resolved_values["T0"]
+
+    print("--- Initializing RPST Authentication ---", file=sys.stderr)
+    try:
+        DATABASE_ENDPOINT = database_endpoint
+        private_key = load_private_key(private_key_path)
+        sec_ctx = build_security_context(rci, t0, "V1", "REGULAR_RPT")
+        rpt, spst = fetch_tokens_v212(
+            database_endpoint, resource_ocid, tenancy_ocid, private_key, sec_ctx
+        )
+        rpst, session_key = fetch_rpst_from_auth(
+            auth_endpoint, tenancy_ocid, resource_ocid, private_key, rpt, spst
+        )
+        RPST_SIGNER = oci.auth.signers.SecurityTokenSigner(rpst, session_key)
+        print("--- RPST Authentication Successful ---", file=sys.stderr)
+    except Exception as e:
+        print(f"Failed to initialize RPST Auth: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
 def _get_oci_client_kwargs(signer=None):
     kwargs = {
         "circuit_breaker_strategy": oci.circuit_breaker.CircuitBreakerStrategy(
@@ -299,22 +565,60 @@ def _get_oci_client_kwargs(signer=None):
 
 
 def get_database_client(region: str = None):
-    config = oci.config.from_file(
-        file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
-        profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
-    )
+
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
-    config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = config["security_token_file"]
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
-    if region is None:
-        return oci.database.DatabaseClient(config, **_get_oci_client_kwargs(signer))
-    regional_config = config.copy()
-    regional_config["region"] = region
-    return oci.database.DatabaseClient(regional_config, **_get_oci_client_kwargs(signer))
+
+    additional_user_agent = f"{user_agent_name}/{__version__}"
+
+    if AUTH_METHOD == "resource_principal":
+        client_config = {"additional_user_agent": additional_user_agent}
+
+        if region is not None:
+            logger.info(f"Using custom RPST authentication (Region: {region})")
+            client_config["region"] = region
+            return oci.database.DatabaseClient(
+                config=client_config, **_get_oci_client_kwargs(RPST_SIGNER)
+            )
+        else:
+            logger.info(
+                f"Using custom RPST authentication (Fallback Database Endpoint: {DATABASE_ENDPOINT})"
+            )
+            client_kwargs = _get_oci_client_kwargs(RPST_SIGNER)
+            client_kwargs["service_endpoint"] = DATABASE_ENDPOINT
+            return oci.database.DatabaseClient(
+                config=client_config,
+                **client_kwargs,
+            )
+    elif AUTH_METHOD == "instance_principal":
+        logger.info("Using Instance Principal authentication")
+        signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+        client_config = {"additional_user_agent": additional_user_agent}
+        if region is not None:
+            client_config["region"] = region
+        return oci.database.DatabaseClient(
+            client_config, **_get_oci_client_kwargs(signer)
+        )
+    else:
+        # Security Token / Config File Authentication
+        logger.info("Using standard Security Token authentication")
+        config = oci.config.from_file(
+            file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
+            profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
+        )
+        config["additional_user_agent"] = additional_user_agent
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        token_file = config["security_token_file"]
+        with open(token_file, "r") as f:
+            token = f.read()
+        signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+        client_config = config.copy()
+        if region is not None:
+            client_config["region"] = region
+
+        return oci.database.DatabaseClient(
+            client_config, **_get_oci_client_kwargs(signer)
+        )
 
 
 def call_create_pdb(client, details, opc_retry_token=None, opc_request_id=None):
@@ -7692,6 +7996,34 @@ def get_vm_cluster_update_history_entry(
 
 
 def main():
+    global AUTH_METHOD
+
+    parser = argparse.ArgumentParser(description="OCI Database MCP Server")
+    parser.add_argument(
+        "--auth-method",
+        choices=["token", "instance_principal", "resource_principal"],
+        help="Authentication method",
+    )
+    parser.add_argument("--database-endpoint", help="Database endpoint for RP auth")
+    parser.add_argument("--tenancy-ocid", help="Tenancy OCID for RP auth")
+    parser.add_argument("--private-key-path", help="Private key path for RP auth")
+    parser.add_argument("--resource-ocid", help="Resource OCID for RP auth")
+    parser.add_argument("--rci", help="RCI for RP auth")
+    parser.add_argument("--t0", help="T0 timestamp for RP auth")
+    args = parser.parse_args()
+
+    AUTH_METHOD = args.auth_method or os.getenv("AUTH_METHOD", "token")
+
+    if AUTH_METHOD == "resource_principal":
+        initialize_rpst_auth_from_env(
+            database_endpoint=args.database_endpoint,
+            tenancy_ocid=args.tenancy_ocid,
+            private_key_path=args.private_key_path,
+            resource_ocid=args.resource_ocid,
+            rci=args.rci,
+            t0=args.t0,
+        )
+
     mcp.run()
 
 

--- a/src/oci-database-mcp-server/oracle/oci_database_mcp_server/tests/test_database.py
+++ b/src/oci-database-mcp-server/oracle/oci_database_mcp_server/tests/test_database.py
@@ -1,4 +1,5 @@
 import inspect
+import sys
 from contextlib import ExitStack
 from types import SimpleNamespace
 from unittest.mock import MagicMock, create_autospec, mock_open, patch
@@ -47,6 +48,181 @@ class TestGetDatabaseClient:
         assert isinstance(kwargs["circuit_breaker_strategy"], oci.circuit_breaker.CircuitBreakerStrategy)
         assert callable(kwargs["circuit_breaker_callback"])
         assert result is mock_client.return_value
+
+
+def test_fetch_tokens_v212_uses_explicit_timeout_and_returns_tokens(monkeypatch):
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "resourcePrincipalToken": "rpt",
+        "servicePrincipalSessionToken": "spst",
+    }
+    get = MagicMock(return_value=response)
+    monkeypatch.setattr(server.requests, "get", get)
+
+    assert server.fetch_tokens_v212(
+        "https://database.example.com", "resource", "tenancy", private_key, "context"
+    ) == ("rpt", "spst")
+
+    assert get.call_args.kwargs["timeout"] == server.RPST_HTTP_TIMEOUT
+    assert get.call_args.kwargs["headers"]["security-context"] == "context"
+
+
+def test_fetch_tokens_v212_retries_with_query_and_timeout(monkeypatch):
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    first_response = MagicMock(status_code=401)
+    second_response = MagicMock(status_code=200)
+    second_response.json.return_value = {
+        "resourcePrincipalToken": "rpt",
+        "servicePrincipalSessionToken": "spst",
+    }
+    session = MagicMock()
+    session.send.return_value = second_response
+    monkeypatch.setattr(server.requests, "get", MagicMock(return_value=first_response))
+    monkeypatch.setattr(server.requests, "Session", MagicMock(return_value=session))
+
+    assert server.fetch_tokens_v212(
+        "https://database.example.com", "resource", "tenancy", private_key, "context"
+    ) == ("rpt", "spst")
+
+    prepared_request = session.send.call_args.args[0]
+    assert "securityContext=context" in prepared_request.path_url
+    assert session.send.call_args.kwargs["timeout"] == server.RPST_HTTP_TIMEOUT
+
+
+def test_fetch_tokens_v212_reports_timeouts(monkeypatch):
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    monkeypatch.setattr(
+        server.requests,
+        "get",
+        MagicMock(side_effect=server.requests.exceptions.Timeout),
+    )
+
+    with pytest.raises(RuntimeError, match="Timed out fetching resource principal tokens"):
+        server.fetch_tokens_v212(
+            "https://database.example.com", "resource", "tenancy", private_key, "context"
+        )
+
+
+def test_fetch_rpst_from_auth_uses_timeout_and_returns_signer_key(monkeypatch):
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    session_key = MagicMock()
+    session_key.public_key.return_value.public_bytes.return_value = b"public-key"
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"token": "rpst"}
+    post = MagicMock(return_value=response)
+    monkeypatch.setattr(server.rsa, "generate_private_key", MagicMock(return_value=session_key))
+    monkeypatch.setattr(server.requests, "post", post)
+
+    assert server.fetch_rpst_from_auth(
+        "https://auth.example.com", "tenancy", "resource", private_key, "rpt", "spst"
+    ) == ("rpst", session_key)
+
+    assert post.call_args.kwargs["timeout"] == server.RPST_HTTP_TIMEOUT
+    assert b'"resourcePrincipalToken":"rpt"' in post.call_args.kwargs["data"]
+
+
+def test_fetch_rpst_from_auth_reports_timeouts(monkeypatch):
+    private_key = MagicMock()
+    private_key.sign.return_value = b"signature"
+    session_key = MagicMock()
+    session_key.public_key.return_value.public_bytes.return_value = b"public-key"
+    monkeypatch.setattr(server.rsa, "generate_private_key", MagicMock(return_value=session_key))
+    monkeypatch.setattr(
+        server.requests,
+        "post",
+        MagicMock(side_effect=server.requests.exceptions.Timeout),
+    )
+
+    with pytest.raises(RuntimeError, match="Timed out exchanging resource principal session token"):
+        server.fetch_rpst_from_auth(
+            "https://auth.example.com", "tenancy", "resource", private_key, "rpt", "spst"
+        )
+
+
+def test_initialize_rpst_auth_uses_arguments_before_environment(monkeypatch):
+    monkeypatch.setattr(server, "_get_region_from_imds", MagicMock(return_value="us-phoenix-1"))
+    monkeypatch.setattr(server, "load_private_key", MagicMock(return_value="private-key"))
+    monkeypatch.setattr(server, "build_security_context", MagicMock(return_value="context"))
+    monkeypatch.setattr(server, "fetch_tokens_v212", MagicMock(return_value=("rpt", "spst")))
+    monkeypatch.setattr(server, "fetch_rpst_from_auth", MagicMock(return_value=("rpst", "session-key")))
+    signer = MagicMock()
+    monkeypatch.setattr(server.oci.auth.signers, "SecurityTokenSigner", signer)
+    monkeypatch.setattr(server, "RPST_SIGNER", None)
+
+    server.initialize_rpst_auth_from_env(
+        database_endpoint="https://database.override.example.com",
+        tenancy_ocid="argument-tenancy",
+        private_key_path="/argument/key.pem",
+        resource_ocid="argument-resource",
+        rci="Y29udGV4dA==",
+        t0="2025-01-01T00:00:00Z",
+    )
+
+    server.fetch_tokens_v212.assert_called_once_with(
+        "https://database.override.example.com",
+        "argument-resource",
+        "argument-tenancy",
+        "private-key",
+        "context",
+    )
+    signer.assert_called_once_with("rpst", "session-key")
+
+
+def test_initialize_rpst_auth_rejects_missing_values(monkeypatch, capsys):
+    for name in ("TENANCY_OCID", "PRIVATE_KEY_PATH", "RESOURCE_OCID", "RCI", "T0"):
+        monkeypatch.delenv(name, raising=False)
+
+    with pytest.raises(SystemExit) as error:
+        server.initialize_rpst_auth_from_env()
+
+    assert error.value.code == 1
+    assert "TENANCY_OCID" in capsys.readouterr().err
+
+
+def test_get_database_client_supports_resource_and_instance_principals(monkeypatch):
+    database_client = MagicMock()
+    monkeypatch.setattr(server.oci.database, "DatabaseClient", database_client)
+    monkeypatch.setattr(server, "AUTH_METHOD", "resource_principal")
+    monkeypatch.setattr(server, "RPST_SIGNER", "rpst-signer")
+    monkeypatch.setattr(server, "DATABASE_ENDPOINT", "https://database.example.com")
+
+    server.get_database_client()
+    assert database_client.call_args.kwargs["service_endpoint"] == "https://database.example.com"
+    assert database_client.call_args.kwargs["signer"] == "rpst-signer"
+    assert "additional_user_agent" in database_client.call_args.kwargs["config"]
+
+    instance_signer = MagicMock(return_value="instance-signer")
+    monkeypatch.setattr(server, "AUTH_METHOD", "instance_principal")
+    monkeypatch.setattr(server.oci.auth.signers, "InstancePrincipalsSecurityTokenSigner", instance_signer)
+    server.get_database_client(region="us-ashburn-1")
+
+    instance_signer.assert_called_once_with()
+    assert database_client.call_args.args[0]["region"] == "us-ashburn-1"
+    assert database_client.call_args.kwargs["signer"] == "instance-signer"
+
+
+def test_main_prefers_cli_auth_method_and_initializes_rpst(monkeypatch):
+    initialize = MagicMock()
+    run = MagicMock()
+    monkeypatch.setattr(server, "initialize_rpst_auth_from_env", initialize)
+    monkeypatch.setattr(server.mcp, "run", run)
+    monkeypatch.setenv("AUTH_METHOD", "token")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["server", "--auth-method", "resource_principal", "--tenancy-ocid", "cli-tenancy"],
+    )
+
+    server.main()
+
+    assert server.AUTH_METHOD == "resource_principal"
+    assert initialize.call_args.kwargs["tenancy_ocid"] == "cli-tenancy"
+    run.assert_called_once_with()
 
 
 def test_oci_base_model_from_oci(monkeypatch):

--- a/src/oci-database-mcp-server/pyproject.toml
+++ b/src/oci-database-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-database-mcp-server"
-version = "1.0.7"
+version = "1.1.0"
 description = "OCI Database Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -10,10 +10,12 @@ authors = [
     {name = "Oracle MCP", email = "237432095+oracle-mcp@users.noreply.github.com"},
 ]
 dependencies = [
+    "cryptography>=46.0.7",
     "fastmcp==3.4.2",
     "oci==2.179.0",
     "mcp>=1.27.0",
     "pytest-cov>=7.0.0",
+    "requests>=2.32.5",
 ]
 
 classifiers = [

--- a/src/oci-database-mcp-server/uv.lock
+++ b/src/oci-database-mcp-server/uv.lock
@@ -147,6 +147,54 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
 name = "circuitbreaker"
 version = "2.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -762,13 +810,15 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-database-mcp-server"
-version = "1.0.7"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "fastmcp" },
     { name = "mcp" },
     { name = "oci" },
     { name = "pytest-cov" },
+    { name = "requests" },
 ]
 
 [package.dev-dependencies]
@@ -779,10 +829,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cryptography", specifier = ">=46.0.7" },
     { name = "fastmcp", specifier = "==3.4.2" },
     { name = "mcp", specifier = ">=1.27.0" },
     { name = "oci", specifier = "==2.179.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "requests", specifier = ">=2.32.5" },
 ]
 
 [package.metadata.requires-dev]
@@ -1145,6 +1197,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Database MCP server

### Description

This change adds multiple authentication methods to the OCI Database MCP server:

- Existing security-token authentication (default)
- Instance Principal authentication (`--auth-method instance_principal`)
- Resource Principal authentication (`--auth-method resource_principal`) using the RPST flow

It adds CLI arguments for auth selection and resource-principal values, branches OCI client initialization by auth method, and documents local and SSH-remote configuration patterns.

Resource-principal token and RPST exchange HTTP calls now use explicit connect/read timeouts to prevent startup from hanging indefinitely.

Version is bumped from `1.0.7` to `1.1.0`.

### Motivation and context

Previously, the server relied on security-token config-file authentication. This limited OCI-native deployments where instance principal or resource principal authentication is preferable for automated workloads.

This update supports those deployment patterns while retaining token authentication as the default.

### Dependencies required for this change

- `cryptography` — required for RPST request signing and session-key generation.
- `requests` — required for resource-principal token retrieval and RPST exchange HTTP calls.

### Validation

- Added mocked unit coverage for token authentication, instance-principal signer construction, resource-principal initialization, RPST request construction, fallback behavior, endpoint failures, timeouts, missing inputs, and CLI/environment precedence.
- `make test project=oci-database-mcp-server` passes: 160 tests, 92.94% coverage.
- `make lint` passes.

Fixes #<issue-number>

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update