### PR TITLE
fix: support API key authentication across OCI MCP servers

### DIFF
--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/server.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import json
 import os
 import subprocess
@@ -28,6 +29,39 @@ initAuditLogger(logger)
 
 # Read and setup deny list
 denylist_manager = Denylist(logger)
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+
+def _auth_args(profile: str) -> list[str]:
+    """Return the CLI --auth flag matching the profile's auth type.
+
+    Session-token profiles declare a security_token_file in their own section;
+    API-key profiles do not. Forcing security_token on an API-key profile makes
+    the CLI block on an interactive re-auth prompt that never completes under MCP.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    a raw "security_token_file" in config check is true for an API-key profile
+    whenever [DEFAULT] happens to be a session profile -- which would force the wrong
+    auth. Re-read the file with that inheritance disabled and inspect the profile's
+    OWN section.
+
+    If the config file is missing or the profile has no section, return [] so the CLI
+    applies its own default (honouring OCI_CLI_AUTH) rather than us guessing wrong.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    config_path = os.path.expanduser(
+        os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)
+    )
+    if not parser.read(config_path):
+        return []
+    if not parser.has_section(profile):
+        return []
+    if parser.has_option(profile, "security_token_file"):
+        return ["--auth", "security_token"]
+    return ["--auth", "api_key"]
 
 # Initialize the MCP server
 mcp = FastMCP(
@@ -164,7 +198,7 @@ def run_oci_command(
 
     try:
         result = subprocess.run(
-            ["oci", "--profile", profile, "--auth", "security_token"] + shlex.split(command),
+            ["oci", "--profile", profile] + _auth_args(profile) + shlex.split(command),
             env=env_copy,
             capture_output=True,
             text=True,

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
@@ -143,8 +143,12 @@ class TestOCITools:
             }
 
     @pytest.mark.asyncio
+    @patch(
+        "oracle.oci_api_mcp_server.server._auth_args",
+        return_value=["--auth", "security_token"],
+    )
     @patch("oracle.oci_api_mcp_server.server.subprocess.run")
-    async def test_run_oci_command_preserves_quoted_arguments(self, mock_run):
+    async def test_run_oci_command_preserves_quoted_arguments(self, mock_run, _mock_auth):
         command = 'compute instance list --display-name "Shared Services"'
 
         mock_result = MagicMock()
@@ -181,6 +185,53 @@ class TestOCITools:
                 check=True,
                 shell=False,
             )
+
+    @pytest.mark.asyncio
+    @patch(
+        "oracle.oci_api_mcp_server.server._auth_args",
+        return_value=["--auth", "api_key"],
+    )
+    @patch("oracle.oci_api_mcp_server.server.subprocess.run")
+    async def test_run_oci_command_uses_api_key_auth_for_api_key_profile(
+        self, mock_run, _mock_auth
+    ):
+        command = "compute instance list"
+
+        mock_result = MagicMock()
+        mock_result.stdout = "{}"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        async with Client(mcp) as client:
+            await client.call_tool("run_oci_command", {"command": command})
+
+            argv = mock_run.call_args[0][0]
+            assert argv[:6] == ["oci", "--profile", "DEFAULT", "--auth", "api_key", "compute"]
+
+    @pytest.mark.asyncio
+    @patch(
+        "oracle.oci_api_mcp_server.server._auth_args",
+        return_value=[],
+    )
+    @patch("oracle.oci_api_mcp_server.server.subprocess.run")
+    async def test_run_oci_command_omits_auth_flag_when_profile_unreadable(
+        self, mock_run, _mock_auth
+    ):
+        command = "compute instance list"
+
+        mock_result = MagicMock()
+        mock_result.stdout = "{}"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        async with Client(mcp) as client:
+            await client.call_tool("run_oci_command", {"command": command})
+
+            argv = mock_run.call_args[0][0]
+            assert "--auth" not in argv
+            assert argv == ["oci", "--profile", "DEFAULT", "compute", "instance", "list"]
 
     @pytest.mark.asyncio
     @patch("oracle.oci_api_mcp_server.server.subprocess.run")
@@ -325,3 +376,62 @@ class TestServer:
 
         with pytest.raises(RuntimeError, match="stdio transport only"):
             server.main()
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    """Exercises the real _auth_args discriminator against a temp OCI config file."""
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_selects_security_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        assert server._auth_args("DEFAULT") == ["--auth", "security_token"]
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(
+        self, tmp_path, monkeypatch
+    ):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # forcing security_token would trigger an interactive re-auth that hangs under MCP.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+
+        import oci
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._auth_args("APIKEY") == ["--auth", "api_key"]
+
+    def test_unknown_profile_omits_auth_flag(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        assert server._auth_args("NOSUCH") == []
+
+    def test_missing_config_file_omits_auth_flag(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(tmp_path / "does-not-exist"))
+        assert server._auth_args("DEFAULT") == []

--- a/src/oci-cloud-guard-mcp-server/oracle/oci_cloud_guard_mcp_server/server.py
+++ b/src/oci-cloud-guard-mcp-server/oracle/oci_cloud_guard_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 from datetime import datetime, timedelta, timezone
 from logging import Logger
@@ -70,6 +71,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_cloud_guard_client():
     config, signer = _get_http_config_and_signer()
     if signer is not None:
@@ -82,12 +151,7 @@ def get_cloud_guard_client():
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
 
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return CloudGuardClient(config, **_get_oci_client_kwargs(signer))
 
 

--- a/src/oci-cloud-guard-mcp-server/oracle/oci_cloud_guard_mcp_server/tests/test_cloud_guard_tools.py
+++ b/src/oci-cloud-guard-mcp-server/oracle/oci_cloud_guard_mcp_server/tests/test_cloud_guard_tools.py
@@ -269,8 +269,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_cloud_guard_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_cloud_guard_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_cloud_guard_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_cloud_guard_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -321,8 +326,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_cloud_guard_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_cloud_guard_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_cloud_guard_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_cloud_guard_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -358,3 +368,131 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_cloud_guard_mcp_server.server.CloudGuardClient")
+    @patch("oracle.oci_cloud_guard_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_cloud_guard_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_cloud_guard_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_cloud_guard_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_cloud_guard_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_cloud_guard_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(self, tmp_path, monkeypatch):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_cloud_guard_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_cloud_guard_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_cloud_guard_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/server.py
+++ b/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import difflib
 import inspect
 import json
@@ -466,12 +467,43 @@ def _discover_client_classes() -> List[Tuple[str, Any]]:
     return sorted(discovered, key=lambda item: item[0])
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
 def _get_config_and_signer() -> Tuple[Dict[str, Any], Any]:
     """
     Load OCI config and build an appropriate signer.
 
     Preference order:
-    - If a security_token_file exists, use SecurityTokenSigner (session auth).
+    - If the selected profile declares a security_token_file, use SecurityTokenSigner
+      (session auth).
     - Otherwise, fall back to API key Signer from config.
     """
     domain = os.getenv("IDCS_DOMAIN")
@@ -508,39 +540,43 @@ def _get_config_and_signer() -> Tuple[Dict[str, Any], Any]:
     )
     config["additional_user_agent"] = _ADDITIONAL_UA
 
-    token_file = os.path.expanduser(config.get("security_token_file", "") or "")
-    try:
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
         private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    except Exception as e:
-        logger.error(f"Failed loading private key: {e}")
-        raise
+        with open(os.path.expanduser(config["security_token_file"]), "r", encoding="utf-8") as f:
+            token = f.read()
+        signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+        logger.info("Using SecurityTokenSigner from security_token_file.")
+        return config, signer
 
-    signer = None
-    if token_file and os.path.exists(token_file):
-        try:
-            with open(token_file, "r", encoding="utf-8") as f:
-                token = f.read()
-            signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
-            logger.info("Using SecurityTokenSigner from security_token_file.")
-        except Exception as e:
-            logger.warning(
-                f"Failed to build SecurityTokenSigner from token file, will try API key signer: {e}"
-            )
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
 
-    if signer is None:
-        try:
-            signer = oci.signer.Signer(
-                tenancy=config["tenancy"],
-                user=config["user"],
-                fingerprint=config["fingerprint"],
-                private_key_file_location=config["key_file"],
-                pass_phrase=config.get("pass_phrase"),
-            )
-            logger.info("Using API key Signer.")
-        except Exception as e:
-            logger.error(f"Failed to build API key Signer: {e}")
-            raise
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
 
+    signer = oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+    logger.info("Using API key Signer.")
     return config, signer
 
 

--- a/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_bootstrap_and_introspection.py
+++ b/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_bootstrap_and_introspection.py
@@ -41,7 +41,10 @@ class TestGetConfigAndSigner:
                 "security_token_file": "/no/token",
             },
         )
-        monkeypatch.setattr("oracle.oci_cloud_mcp_server.server.os.path.exists", lambda p: False)
+        monkeypatch.setattr(
+            "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+            lambda: False,
+        )
         monkeypatch.setattr(
             "oracle.oci_cloud_mcp_server.server.oci.signer.load_private_key_from_file",
             lambda p: "PK",
@@ -86,10 +89,10 @@ class TestGetConfigAndSigner:
             lambda **kwargs: dict(cfg),
         )
 
-        # patch exists to indicate token file present
+        # selected profile declares a session token
         monkeypatch.setattr(
-            "oracle.oci_cloud_mcp_server.server.os.path.exists",
-            lambda p: p == cfg["security_token_file"],
+            "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+            lambda: True,
         )
 
         # patch key loader
@@ -137,8 +140,11 @@ class TestGetConfigAndSigner:
             "oracle.oci_cloud_mcp_server.server.oci.config.from_file",
             lambda **kwargs: dict(cfg),
         )
-        # no token file
-        monkeypatch.setattr("oracle.oci_cloud_mcp_server.server.os.path.exists", lambda p: False)
+        # API-key profile: no session token declared
+        monkeypatch.setattr(
+            "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+            lambda: False,
+        )
         # key loader ok
         monkeypatch.setattr(
             "oracle.oci_cloud_mcp_server.server.oci.signer.load_private_key_from_file",
@@ -177,6 +183,10 @@ class TestGetConfigAndSigner:
         monkeypatch.setattr(
             "oracle.oci_cloud_mcp_server.server.oci.config.from_file",
             lambda **kwargs: dict(cfg),
+        )
+        monkeypatch.setattr(
+            "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+            lambda: True,
         )
 
         def boom(path):  # noqa: ARG001
@@ -308,7 +318,7 @@ class TestAlignParamsToSignature:
 
 
 class TestGetConfigAndSignerMoreBranches:
-    def test_token_signer_build_failure_falls_back_to_api_key(self, monkeypatch):
+    def test_session_token_signer_build_failure_is_propagated(self, monkeypatch):
         cfg = {
             "tenancy": "t",
             "user": "u",
@@ -316,14 +326,14 @@ class TestGetConfigAndSignerMoreBranches:
             "key_file": "/path/to/key.pem",
             "security_token_file": "/tmp/token",
         }
-        # config and file present
+        # config and session-token profile present
         monkeypatch.setattr(
             "oracle.oci_cloud_mcp_server.server.oci.config.from_file",
             lambda **kwargs: dict(cfg),
         )
         monkeypatch.setattr(
-            "oracle.oci_cloud_mcp_server.server.os.path.exists",
-            lambda p: p == cfg["security_token_file"],
+            "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+            lambda: True,
         )
         # key loader ok and token readable
         monkeypatch.setattr(
@@ -332,37 +342,18 @@ class TestGetConfigAndSignerMoreBranches:
         )
         monkeypatch.setattr("builtins.open", lambda *a, **k: StringIO("token"), raising=False)
 
-        # SecurityTokenSigner init fails to trigger warning path, then API key used
+        # SecurityTokenSigner init fails; there is no silent fallback to API key.
         class BoomSTS:
             def __init__(self, token, private_key):  # noqa: ARG002
                 raise Exception("sts boom")
-
-        class FakeSigner:
-            def __init__(
-                self,
-                tenancy,
-                user,
-                fingerprint,
-                private_key_file_location,
-                pass_phrase=None,
-            ):  # noqa: ARG002
-                self.tenancy = tenancy
-                self.pk_file = private_key_file_location
 
         monkeypatch.setattr(
             "oracle.oci_cloud_mcp_server.server.oci.auth.signers.SecurityTokenSigner",
             BoomSTS,
         )
-        monkeypatch.setattr(
-            "oracle.oci_cloud_mcp_server.server.oci.signer.Signer",
-            FakeSigner,
-        )
 
-        config, signer = _get_config_and_signer()
-        assert isinstance(signer, FakeSigner)
-        assert signer.tenancy == "t"
-        assert signer.pk_file == "/path/to/key.pem"
-        assert "additional_user_agent" in config
+        with pytest.raises(Exception, match="sts boom"):
+            _get_config_and_signer()
 
     def test_api_key_signer_raises_is_propagated(self, monkeypatch):
         cfg = {
@@ -376,8 +367,11 @@ class TestGetConfigAndSignerMoreBranches:
             "oracle.oci_cloud_mcp_server.server.oci.config.from_file",
             lambda **kwargs: dict(cfg),
         )
-        # token file not present
-        monkeypatch.setattr("oracle.oci_cloud_mcp_server.server.os.path.exists", lambda p: False)
+        # API-key profile: no session token declared
+        monkeypatch.setattr(
+            "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+            lambda: False,
+        )
         # key loader ok
         monkeypatch.setattr(
             "oracle.oci_cloud_mcp_server.server.oci.signer.load_private_key_from_file",

--- a/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_server_extras.py
+++ b/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_server_extras.py
@@ -11,6 +11,7 @@ import oci
 import pytest
 from fastmcp import Client
 from fastmcp.exceptions import ToolError
+from oracle.oci_cloud_mcp_server import server
 from oracle.oci_cloud_mcp_server.server import (
     _ADDITIONAL_UA,
     _align_params_to_signature,
@@ -41,7 +42,10 @@ class TestGetConfigAndSigner:
             patch("oracle.oci_cloud_mcp_server.server.oci.signer.load_private_key_from_file") as m_loadkey,
             patch("oracle.oci_cloud_mcp_server.server.oci.auth.signers.SecurityTokenSigner") as m_sts,
             patch("oracle.oci_cloud_mcp_server.server.oci.signer.Signer") as m_signer,
-            patch("oracle.oci_cloud_mcp_server.server.os.path.exists", return_value=True),
+            patch(
+                "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+                return_value=True,
+            ),
             patch("builtins.open", mock_open(read_data="TOKEN123")),
         ):
             m_from.return_value = dict(cfg)  # function mutates to add UA
@@ -70,7 +74,10 @@ class TestGetConfigAndSigner:
             patch("oracle.oci_cloud_mcp_server.server.oci.signer.load_private_key_from_file") as m_loadkey,
             patch("oracle.oci_cloud_mcp_server.server.oci.auth.signers.SecurityTokenSigner") as m_sts,
             patch("oracle.oci_cloud_mcp_server.server.oci.signer.Signer") as m_signer,
-            patch("oracle.oci_cloud_mcp_server.server.os.path.exists", return_value=False),
+            patch(
+                "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+                return_value=False,
+            ),
         ):
             m_from.return_value = dict(cfg)
             m_loadkey.return_value = object()
@@ -497,6 +504,10 @@ class TestGetConfigAndSignerErrors:
         with (
             patch("oracle.oci_cloud_mcp_server.server.oci.config.from_file") as m_from,
             patch(
+                "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+                return_value=True,
+            ),
+            patch(
                 "oracle.oci_cloud_mcp_server.server.oci.signer.load_private_key_from_file",
                 side_effect=Exception("bad key"),
             ),
@@ -506,8 +517,8 @@ class TestGetConfigAndSignerErrors:
                 _get_config_and_signer()
 
 
-class TestSignerFallbackOnStsFailure:
-    def test_token_present_but_sts_raises_falls_back_to_api_key(self):
+class TestSignerFailurePropagation:
+    def test_session_token_sts_failure_is_propagated(self):
         cfg = {
             "tenancy": "t",
             "user": "u",
@@ -523,17 +534,20 @@ class TestSignerFallbackOnStsFailure:
                 side_effect=Exception("boom"),
             ),
             patch("oracle.oci_cloud_mcp_server.server.oci.signer.Signer") as m_signer,
-            patch("oracle.oci_cloud_mcp_server.server.os.path.exists", return_value=True),
+            patch(
+                "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+                return_value=True,
+            ),
             patch("builtins.open", mock_open(read_data="TOKEN123")),
         ):
             m_from.return_value = dict(cfg)
             m_loadkey.return_value = object()
-            sentinel_signer = object()
-            m_signer.return_value = sentinel_signer
 
-            out_cfg, signer = _get_config_and_signer()
-            assert out_cfg["additional_user_agent"] == _ADDITIONAL_UA
-            assert signer is sentinel_signer
+            # A session profile whose token signer fails must NOT silently fall back
+            # to an API key signer -- the error is surfaced instead.
+            with pytest.raises(Exception, match="boom"):
+                _get_config_and_signer()
+            m_signer.assert_not_called()
 
 
 class TestParamCoercionAndAlignmentExtras:
@@ -715,7 +729,7 @@ class TestInvokeImportFailure:
 
 
 class TestSignerTokenReadFailure:
-    def test_token_file_exists_but_open_fails_falls_back(self):
+    def test_token_file_open_failure_is_propagated(self):
         cfg = {
             "tenancy": "t",
             "user": "u",
@@ -726,20 +740,23 @@ class TestSignerTokenReadFailure:
         with (
             patch("oracle.oci_cloud_mcp_server.server.oci.config.from_file") as m_from,
             patch("oracle.oci_cloud_mcp_server.server.oci.signer.load_private_key_from_file") as m_loadkey,
-            patch("oracle.oci_cloud_mcp_server.server.os.path.exists", return_value=True),
+            patch(
+                "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+                return_value=True,
+            ),
             patch("oracle.oci_cloud_mcp_server.server.oci.auth.signers.SecurityTokenSigner") as m_sts,
             patch("oracle.oci_cloud_mcp_server.server.oci.signer.Signer") as m_signer,
             patch("builtins.open", side_effect=Exception("io")),
         ):
             m_from.return_value = dict(cfg)
             m_loadkey.return_value = object()
-            sentinel_signer = object()
-            m_signer.return_value = sentinel_signer
 
-            out_cfg, signer = _get_config_and_signer()
-            assert out_cfg["additional_user_agent"] == _ADDITIONAL_UA
-            assert signer is sentinel_signer
+            # A session profile whose token file cannot be read must not silently fall
+            # back to an API key signer; the read error is surfaced instead.
+            with pytest.raises(Exception, match="io"):
+                _get_config_and_signer()
             m_sts.assert_not_called()
+            m_signer.assert_not_called()
 
 
 class TestAlignParamsSignatureRaises:
@@ -1266,3 +1283,99 @@ class TestConstructModelCtorSwaggerFilter:
         assert isinstance(inst, MyModel)
         # 'b' should be filtered out because it's not in swagger_types
         assert inst.kw == {"a": 1}
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(
+        self, tmp_path, monkeypatch
+    ):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    @patch("oracle.oci_cloud_mcp_server.server.oci.config.from_file")
+    def test_incomplete_api_key_profile_raises_actionable_error(
+        self, mock_from_file, _mock_declares
+    ):
+        mock_from_file.return_value = {"key_file": "/k.pem"}
+        with pytest.raises(RuntimeError) as excinfo:
+            _get_config_and_signer()
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_cloud_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_cloud_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    @patch("oracle.oci_cloud_mcp_server.server.oci.config.from_file")
+    def test_api_key_warning_is_emitted_once(
+        self, mock_from_file, _mock_declares, _mock_signer
+    ):
+        mock_from_file.return_value = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            _get_config_and_signer()
+            _get_config_and_signer()
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-compute-instance-agent-mcp-server/oracle/oci_compute_instance_agent_mcp_server/server.py
+++ b/src/oci-compute-instance-agent-mcp-server/oracle/oci_compute_instance_agent_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 from logging import Logger
 from typing import Optional
@@ -63,6 +64,7 @@ def _get_http_config_and_signer():
         region=config.get("region"),
     )
 
+
 def _get_oci_client_kwargs(signer=None):
     kwargs = {
         "circuit_breaker_strategy": oci.circuit_breaker.CircuitBreakerStrategy(
@@ -76,6 +78,74 @@ def _get_oci_client_kwargs(signer=None):
     if signer is not None:
         kwargs["signer"] = signer
     return kwargs
+
+
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
 
 
 def get_compute_instance_agent_client():
@@ -93,12 +163,7 @@ def get_compute_instance_agent_client():
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
 
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.compute_instance_agent.ComputeInstanceAgentClient(
         config, **_get_oci_client_kwargs(signer)
     )

--- a/src/oci-compute-instance-agent-mcp-server/oracle/oci_compute_instance_agent_mcp_server/tests/test_compute_instance_agent_tools.py
+++ b/src/oci-compute-instance-agent-mcp-server/oracle/oci_compute_instance_agent_mcp_server/tests/test_compute_instance_agent_tools.py
@@ -445,8 +445,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_compute_instance_agent_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_compute_instance_agent_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_compute_instance_agent_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_compute_instance_agent_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -499,8 +504,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_compute_instance_agent_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_compute_instance_agent_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_compute_instance_agent_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_compute_instance_agent_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -536,3 +546,133 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch(
+        "oracle.oci_compute_instance_agent_mcp_server.server.oci.compute_instance_agent.ComputeInstanceAgentClient"  # noqa
+    )
+    @patch("oracle.oci_compute_instance_agent_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_compute_instance_agent_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_compute_instance_agent_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_compute_instance_agent_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_compute_instance_agent_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_compute_instance_agent_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(self, tmp_path, monkeypatch):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_compute_instance_agent_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_compute_instance_agent_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_compute_instance_agent_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/server.py
+++ b/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 from logging import Logger
 from typing import Literal, Optional
@@ -80,6 +81,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_compute_client():
     logger.info("entering get_compute_client")
     config, signer = _get_http_config_and_signer()
@@ -92,12 +161,7 @@ def get_compute_client():
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
 
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.core.ComputeClient(config, **_get_oci_client_kwargs(signer))
 
 

--- a/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/tests/test_compute_tools.py
+++ b/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/tests/test_compute_tools.py
@@ -731,8 +731,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_compute_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_compute_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_compute_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_compute_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -783,8 +788,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_compute_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_compute_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_compute_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_compute_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -820,3 +830,131 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_compute_mcp_server.server.oci.core.ComputeClient")
+    @patch("oracle.oci_compute_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_compute_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_compute_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_compute_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_compute_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_compute_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(self, tmp_path, monkeypatch):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_compute_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_compute_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_compute_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-database-mcp-server/oracle/oci_database_mcp_server/server.py
+++ b/src/oci-database-mcp-server/oracle/oci_database_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 from logging import Logger
 from typing import Annotated, Any, Optional
@@ -298,6 +299,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_database_client(region: str = None):
     config = oci.config.from_file(
         file_location=os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION),
@@ -305,11 +374,7 @@ def get_database_client(region: str = None):
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = config["security_token_file"]
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     if region is None:
         return oci.database.DatabaseClient(config, **_get_oci_client_kwargs(signer))
     regional_config = config.copy()
@@ -379,11 +444,7 @@ def get_public_ip_for_database(
         config = oci.config.from_file(
             profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
         )
-        private_key = oci.signer.load_private_key_from_file(config["key_file"])
-        token_file = config["security_token_file"]
-        with open(token_file, "r") as f:
-            token = f.read()
-        signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+        signer = _build_signer(config)
 
         virtual_network_client = oci.core.VirtualNetworkClient(config, signer=signer)
         if region:

--- a/src/oci-database-mcp-server/oracle/oci_database_mcp_server/tests/test_database.py
+++ b/src/oci-database-mcp-server/oracle/oci_database_mcp_server/tests/test_database.py
@@ -22,8 +22,13 @@ class TestGetDatabaseClient:
     )
     @patch("oracle.oci_database_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_database_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_database_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_database_client_passes_circuit_breaker_and_region(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -3353,8 +3358,17 @@ async def test_get_vm_cluster_update_history_entry(mock_get_client):
 @patch("oci.config.from_file")
 @patch("oci.signer.load_private_key_from_file")
 @patch("builtins.open", new_callable=mock_open, read_data="dummy_token")
+@patch(
+    "oracle.oci_database_mcp_server.server._profile_declares_session_token",
+    return_value=True,
+)
 async def test_get_public_ip_for_database(
-    mock_file, mock_load_key, mock_config, mock_vcn_client_cls, mock_get_db_client
+    _mock_declares_session_token,
+    mock_file,
+    mock_load_key,
+    mock_config,
+    mock_vcn_client_cls,
+    mock_get_db_client,
 ):
     mock_db_client = MagicMock()
     mock_get_db_client.return_value = mock_db_client
@@ -3402,3 +3416,90 @@ async def test_get_public_ip_for_database(
 
         result_text = response.content[0].text
         assert result_text == "203.0.113.10"
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(self, tmp_path, monkeypatch):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_database_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_database_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_database_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-faaas-mcp-server/oracle/oci_faaas_mcp_server/server.py
+++ b/src/oci-faaas-mcp-server/oracle/oci_faaas_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 from logging import Logger
 from typing import Any, Literal, Optional
@@ -42,6 +43,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_faaas_client():
     """Initialize and return an OCI Fusion Applications client using security token auth."""
     logger.info("entering get_faaas_client")
@@ -54,12 +123,7 @@ def get_faaas_client():
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
 
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = config["security_token_file"]
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
 
     return oci.fusion_apps.FusionApplicationsClient(config, **_get_oci_client_kwargs(signer))
 

--- a/src/oci-faaas-mcp-server/oracle/oci_faaas_mcp_server/tests/test_faaas_tools.py
+++ b/src/oci-faaas-mcp-server/oracle/oci_faaas_mcp_server/tests/test_faaas_tools.py
@@ -315,8 +315,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_faaas_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_faaas_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_faaas_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_faaas_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -367,8 +372,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_faaas_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_faaas_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_faaas_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_faaas_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -404,3 +414,131 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_faaas_mcp_server.server.oci.fusion_apps.FusionApplicationsClient")
+    @patch("oracle.oci_faaas_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_faaas_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_faaas_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_faaas_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_faaas_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_faaas_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(self, tmp_path, monkeypatch):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_faaas_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_faaas_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_faaas_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-identity-mcp-server/oracle/oci_identity_mcp_server/server.py
+++ b/src/oci-identity-mcp-server/oracle/oci_identity_mcp_server/server.py
@@ -84,6 +84,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_identity_client():
     config, signer = _get_http_config_and_signer()
     if signer is not None:
@@ -94,11 +162,7 @@ def get_identity_client():
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.identity.IdentityClient(config, **_get_oci_client_kwargs(signer))
 
 

--- a/src/oci-identity-mcp-server/oracle/oci_identity_mcp_server/tests/test_identity_tools.py
+++ b/src/oci-identity-mcp-server/oracle/oci_identity_mcp_server/tests/test_identity_tools.py
@@ -736,8 +736,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_identity_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_identity_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_identity_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_identity_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -788,8 +793,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_identity_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_identity_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_identity_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_identity_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -825,3 +835,131 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_identity_mcp_server.server.oci.identity.IdentityClient")
+    @patch("oracle.oci_identity_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_identity_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_identity_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_identity_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_identity_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_identity_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(self, tmp_path, monkeypatch):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_identity_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_identity_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_identity_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-limits-mcp-server/oracle/oci_limits_mcp_server/server.py
+++ b/src/oci-limits-mcp-server/oracle/oci_limits_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 from logging import Logger
 from typing import Literal, Optional
@@ -45,6 +46,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_limits_client():
     """
     Build an OCI LimitsClient using Security Token auth (consistent with other servers in this repo).
@@ -56,12 +125,7 @@ def get_limits_client():
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
 
-    # Security token signer (same pattern as compute/identity)
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = config["security_token_file"]
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
 
     # Limits client
     return oci.limits.LimitsClient(config, **_get_oci_client_kwargs(signer))

--- a/src/oci-limits-mcp-server/oracle/oci_limits_mcp_server/tests/test_limit_tool.py
+++ b/src/oci-limits-mcp-server/oracle/oci_limits_mcp_server/tests/test_limit_tool.py
@@ -189,8 +189,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_limits_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_limits_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_limits_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_limits_client_passes_circuit_breaker(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -526,3 +531,130 @@ class TestPaginationHelpers:
                 service_name="service1",
                 scope_type="GLOBAL",
             )
+
+
+class TestApiKeyClient:
+    @patch("oracle.oci_limits_mcp_server.server.oci.limits.LimitsClient")
+    @patch("oracle.oci_limits_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_limits_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_limits_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_limits_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_limits_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        result = server.get_limits_client()
+
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert result is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(self, tmp_path, monkeypatch):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_limits_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_limits_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_limits_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/server.py
+++ b/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/server.py
@@ -6,6 +6,7 @@ https://oss.oracle.com/licenses/upl.
 
 from __future__ import annotations
 
+import configparser
 import os
 from logging import Logger
 from typing import Literal, Optional
@@ -108,6 +109,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_load_balancer_client():
     logger.info("entering get_load_balancer_client")
     config, signer = _get_http_config_and_signer()
@@ -118,18 +187,7 @@ def get_load_balancer_client():
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    # Use the same token-based signer approach used in other servers for consistency
-    token_file = (
-        os.path.expanduser(config["security_token_file"])
-        if "security_token_file" in config
-        else None
-    )
-    token = None
-    if token_file:
-        with open(token_file, "r") as f:
-            token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key) if token else None
+    signer = _build_signer(config)
     return oci.load_balancer.LoadBalancerClient(config, **_get_oci_client_kwargs(signer))
 
 

--- a/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/tests/test_load_balancer_tools.py
+++ b/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/tests/test_load_balancer_tools.py
@@ -103,8 +103,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_load_balancer_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_load_balancer_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_load_balancer_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_load_balancer_client_passes_circuit_breaker(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -127,6 +132,44 @@ class TestGetClient:
         assert kwargs["signer"] is mock_security_token_signer.return_value
         assert isinstance(kwargs["circuit_breaker_strategy"], oci.circuit_breaker.CircuitBreakerStrategy)
         assert callable(kwargs["circuit_breaker_callback"])
+        assert result is mock_client.return_value
+
+    @patch("oracle.oci_load_balancer_mcp_server.server.oci.load_balancer.LoadBalancerClient")
+    @patch("oracle.oci_load_balancer_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_load_balancer_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_load_balancer_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_load_balancer_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_load_balancer_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        result = server.get_load_balancer_client()
+
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
         assert result is mock_client.return_value
 
 
@@ -1542,3 +1585,92 @@ async def test_update_backend_set_preserve_existing(mock_client):
         load_balancer_id="lb", name="bs", backends=None
     )
     assert out is not None
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(
+        self, tmp_path, monkeypatch
+    ):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_load_balancer_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_load_balancer_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_load_balancer_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-logging-mcp-server/oracle/oci_logging_mcp_server/server.py
+++ b/src/oci-logging-mcp-server/oracle/oci_logging_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 import urllib.parse
 from logging import Logger
@@ -82,6 +83,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_logging_client():
     logger.info("entering get_logging_client")
     config, signer = _get_http_config_and_signer()
@@ -92,12 +161,7 @@ def get_logging_client():
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
 
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.logging.LoggingManagementClient(config, **_get_oci_client_kwargs(signer))
 
 
@@ -111,12 +175,7 @@ def get_logging_search_client():
         profile_name=os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE),
     )
 
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.loggingsearch.LogSearchClient(config, **_get_oci_client_kwargs(signer))
 
 

--- a/src/oci-logging-mcp-server/oracle/oci_logging_mcp_server/tests/test_logging_tools.py
+++ b/src/oci-logging-mcp-server/oracle/oci_logging_mcp_server/tests/test_logging_tools.py
@@ -26,8 +26,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_logging_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_logging_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_logging_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_logging_client_passes_circuit_breaker(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -62,8 +67,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_logging_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_logging_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_logging_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_logging_search_client_passes_circuit_breaker(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -657,8 +667,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_logging_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_logging_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_logging_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_logging_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -705,8 +720,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_logging_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_logging_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_logging_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_logging_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -751,8 +771,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_logging_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_logging_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_logging_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_logging_search_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -799,8 +824,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_logging_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_logging_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_logging_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_logging_search_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -834,3 +864,172 @@ class TestGetClient:
         assert cc_args[0] is config
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_logging_mcp_server.server.oci.logging.LoggingManagementClient")
+    @patch("oracle.oci_logging_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_logging_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_logging_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_logging_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_logging_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_logging_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_logging_mcp_server.server.oci.loggingsearch.LogSearchClient")
+    @patch("oracle.oci_logging_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_logging_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_logging_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_logging_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_logging_search_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_logging_search_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(self, tmp_path, monkeypatch):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_logging_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_logging_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_logging_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/server.py
+++ b/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 from logging import Logger
 from typing import Literal, Optional
@@ -70,6 +71,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_migration_client():
     logger.info("entering get_migration_client")
     config, signer = _get_http_config_and_signer()
@@ -81,12 +150,7 @@ def get_migration_client():
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.cloud_migrations.MigrationClient(config, **_get_oci_client_kwargs(signer))
 
 

--- a/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/tests/test_migration_tools.py
+++ b/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/tests/test_migration_tools.py
@@ -366,8 +366,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_migration_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_migration_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_migration_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_migration_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -418,8 +423,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_migration_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_migration_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_migration_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_migration_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -455,3 +465,131 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_migration_mcp_server.server.oci.cloud_migrations.MigrationClient")
+    @patch("oracle.oci_migration_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_migration_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_migration_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_migration_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_migration_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_migration_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(self, tmp_path, monkeypatch):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_migration_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_migration_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_migration_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/server.py
+++ b/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 from datetime import datetime, timezone
 from logging import Logger
@@ -86,6 +87,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_monitoring_client():
     logger.info("entering get_monitoring_client")
     config, signer = _get_http_config_and_signer()
@@ -98,12 +167,7 @@ def get_monitoring_client():
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
 
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.monitoring.MonitoringClient(config, **_get_oci_client_kwargs(signer))
 
 

--- a/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/tests/test_monitoring_tools.py
+++ b/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/tests/test_monitoring_tools.py
@@ -376,8 +376,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_monitoring_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_monitoring_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_monitoring_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_monitoring_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -428,8 +433,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_monitoring_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_monitoring_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_monitoring_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_monitoring_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -465,3 +475,131 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_monitoring_mcp_server.server.oci.monitoring.MonitoringClient")
+    @patch("oracle.oci_monitoring_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_monitoring_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_monitoring_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_monitoring_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_monitoring_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_monitoring_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(self, tmp_path, monkeypatch):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_monitoring_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_monitoring_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_monitoring_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/server.py
+++ b/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 from logging import Logger
 from typing import Literal, Optional
@@ -74,6 +75,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_nlb_client():
     logger.info("entering get_nlb_client")
     config, signer = _get_http_config_and_signer()
@@ -87,12 +156,7 @@ def get_nlb_client():
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.network_load_balancer.NetworkLoadBalancerClient(
         config, **_get_oci_client_kwargs(signer)
     )

--- a/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/tests/test_network_load_balancer_tools.py
+++ b/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/tests/test_network_load_balancer_tools.py
@@ -633,8 +633,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_network_load_balancer_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_network_load_balancer_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_network_load_balancer_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_nlb_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -688,8 +693,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_network_load_balancer_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_network_load_balancer_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_network_load_balancer_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_nlb_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -725,3 +735,136 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch(
+        "oracle.oci_network_load_balancer_mcp_server.server.oci"
+        ".network_load_balancer.NetworkLoadBalancerClient"
+    )
+    @patch("oracle.oci_network_load_balancer_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_network_load_balancer_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_network_load_balancer_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_network_load_balancer_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_nlb_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_nlb_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(
+        self, tmp_path, monkeypatch
+    ):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_network_load_balancer_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_network_load_balancer_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_network_load_balancer_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/server.py
+++ b/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 from logging import Logger
 from typing import Annotated
@@ -78,6 +79,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_networking_client():
     config, signer = _get_http_config_and_signer()
     if signer is not None:
@@ -88,12 +157,7 @@ def get_networking_client():
     )
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.core.VirtualNetworkClient(config, **_get_oci_client_kwargs(signer))
 
 

--- a/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/tests/test_networking_tools.py
+++ b/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/tests/test_networking_tools.py
@@ -632,8 +632,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_networking_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_networking_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_networking_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_networking_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -684,8 +689,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_networking_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_networking_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_networking_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_networking_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -721,3 +731,133 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_networking_mcp_server.server.oci.core.VirtualNetworkClient")
+    @patch("oracle.oci_networking_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_networking_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_networking_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_networking_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_networking_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_networking_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(
+        self, tmp_path, monkeypatch
+    ):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_networking_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_networking_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_networking_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/server.py
+++ b/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 import tempfile
 from logging import Logger
@@ -115,6 +116,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_object_storage_client():
     config, signer = _get_http_config_and_signer()
     if signer is not None:
@@ -126,12 +195,7 @@ def get_object_storage_client():
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
 
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.object_storage.ObjectStorageClient(config, **_get_oci_client_kwargs(signer))
 
 

--- a/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/tests/test_object_storage_tools.py
+++ b/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/tests/test_object_storage_tools.py
@@ -485,8 +485,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_object_storage_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_object_storage_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_object_storage_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -537,8 +542,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_object_storage_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_object_storage_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_object_storage_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -574,3 +584,133 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_object_storage_mcp_server.server.oci.object_storage.ObjectStorageClient")
+    @patch("oracle.oci_object_storage_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_object_storage_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_object_storage_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_object_storage_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_object_storage_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(
+        self, tmp_path, monkeypatch
+    ):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_object_storage_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_object_storage_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/server.py
+++ b/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/server.py
@@ -579,17 +579,22 @@ def _tool_logger(tool_name: str):
 # Auth/Config
 
 
-def _effective_auth_method() -> Literal["session", "apikey"]:
+def _effective_auth_method() -> Literal["session", "apikey"] | None:
     """
-    Auth selection is done strictly via environment variables (set by the MCP host).
+    Optional explicit override of the OCI authentication type via env var.
 
-    Required:
-      - ORACLE_MCP_AUTH_METHOD: "session" or "apikey"
+    ORACLE_MCP_AUTH_METHOD is OPTIONAL:
+      - "apikey"/"api_key"/"api-key" -> force the API-key path
+      - "session"                    -> force the session-token path
+      - unset or empty               -> None; the auth type is auto-detected from
+                                        the selected profile (see _build_signer)
 
-    Optional:
-      - ORACLE_MCP_AUTH_PROFILE: OCI config profile name (defaults to OCI_CONFIG_PROFILE/DEFAULT)
+    ORACLE_MCP_AUTH_PROFILE optionally selects the OCI config profile name
+    (defaults to OCI_CONFIG_PROFILE/DEFAULT).
     """
-    m = (os.getenv("ORACLE_MCP_AUTH_METHOD") or "session").strip().lower()
+    m = (os.getenv("ORACLE_MCP_AUTH_METHOD") or "").strip().lower()
+    if not m:
+        return None
     if m in ("apikey", "api_key", "api-key"):
         return "apikey"
     return "session"
@@ -643,12 +648,73 @@ def _get_http_config_and_signer(region: str | None = None):
     )
 
 
-def _build_signer_for_session(config: dict):
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = config["security_token_file"]
-    with open(token_file, "r", encoding="utf-8") as f:
-        token = f.read()
-    return oci.auth.signers.SecurityTokenSigner(token, private_key)
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _effective_profile_name()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type.
+
+    An explicit ORACLE_MCP_AUTH_METHOD override (session/apikey) wins. When it is
+    unset the auth type is auto-detected from the selected profile.
+    """
+    global _api_key_warning_emitted
+
+    method = _effective_auth_method()
+    if method == "session" or (method is None and _profile_declares_session_token()):
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _effective_profile_name()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
 
 
 def _get_oci_client_kwargs(signer=None):
@@ -668,27 +734,21 @@ def _get_oci_client_kwargs(signer=None):
 
 # Create the FastMCP app that exposes the functions decorated with @mcp.tool
 mcp = FastMCP(name=__project__)
+
+
 def get_recovery_client(
     region: str | None = None,
     *,
     request_id: Optional[str] = None,
 ) -> oci.recovery.DatabaseRecoveryClient:
-    """Create a Recovery Service client using auth selected via env vars."""
+    """Create a Recovery Service client using auth selected from the OCI profile."""
     regional_config, signer = _get_http_config_and_signer(region)
     if signer is None:
         config = _load_oci_config_for_server()
         regional_config = config if region is None else {**config, "region": region}
+        signer = _build_signer(regional_config)
 
-    method = _effective_auth_method()
-    if signer is not None:
-        client = oci.recovery.DatabaseRecoveryClient(regional_config, **_get_oci_client_kwargs(signer))
-    elif method == "apikey":
-        client = oci.recovery.DatabaseRecoveryClient(regional_config, **_get_oci_client_kwargs())
-    else:
-        signer = _build_signer_for_session(regional_config)
-        client = oci.recovery.DatabaseRecoveryClient(
-            regional_config, **_get_oci_client_kwargs(signer)
-        )
+    client = oci.recovery.DatabaseRecoveryClient(regional_config, **_get_oci_client_kwargs(signer))
 
     rid = request_id or uuid.uuid4().hex
     return _wrap_oci_client(client, request_id=rid, client_name="recovery")
@@ -698,14 +758,9 @@ def get_identity_client(*, request_id: Optional[str] = None):
     config, signer = _get_http_config_and_signer()
     if signer is None:
         config = _load_oci_config_for_server()
-    method = _effective_auth_method()
-    if signer is not None:
-        client = oci.identity.IdentityClient(config, **_get_oci_client_kwargs(signer))
-    elif method == "apikey":
-        client = oci.identity.IdentityClient(config, **_get_oci_client_kwargs())
-    else:
-        signer = _build_signer_for_session(config)
-        client = oci.identity.IdentityClient(config, **_get_oci_client_kwargs(signer))
+        signer = _build_signer(config)
+
+    client = oci.identity.IdentityClient(config, **_get_oci_client_kwargs(signer))
 
     rid = request_id or uuid.uuid4().hex
     return _wrap_oci_client(client, request_id=rid, client_name="identity")
@@ -716,14 +771,9 @@ def get_database_client(region: str = None, *, request_id: Optional[str] = None)
     if signer is None:
         config = _load_oci_config_for_server()
         regional_config = config if region is None else {**config, "region": region}
-    method = _effective_auth_method()
-    if signer is not None:
-        client = oci.database.DatabaseClient(regional_config, **_get_oci_client_kwargs(signer))
-    elif method == "apikey":
-        client = oci.database.DatabaseClient(regional_config, **_get_oci_client_kwargs())
-    else:
-        signer = _build_signer_for_session(regional_config)
-        client = oci.database.DatabaseClient(regional_config, **_get_oci_client_kwargs(signer))
+        signer = _build_signer(regional_config)
+
+    client = oci.database.DatabaseClient(regional_config, **_get_oci_client_kwargs(signer))
 
     rid = request_id or uuid.uuid4().hex
     return _wrap_oci_client(client, request_id=rid, client_name="database")
@@ -735,16 +785,9 @@ def get_monitoring_client(region: str | None = None, *, request_id: Optional[str
     if signer is None:
         config = _load_oci_config_for_server()
         regional_config = config if region is None else {**config, "region": region}
-    method = _effective_auth_method()
-    if signer is not None:
-        client = oci.monitoring.MonitoringClient(regional_config, **_get_oci_client_kwargs(signer))
-    elif method == "apikey":
-        client = oci.monitoring.MonitoringClient(regional_config, **_get_oci_client_kwargs())
-    else:
-        signer = _build_signer_for_session(regional_config)
-        client = oci.monitoring.MonitoringClient(
-            regional_config, **_get_oci_client_kwargs(signer)
-        )
+        signer = _build_signer(regional_config)
+
+    client = oci.monitoring.MonitoringClient(regional_config, **_get_oci_client_kwargs(signer))
 
     rid = request_id or uuid.uuid4().hex
     return _wrap_oci_client(client, request_id=rid, client_name="monitoring")

--- a/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/tests/test_recovery_tools.py
+++ b/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/tests/test_recovery_tools.py
@@ -39,25 +39,24 @@ class TestGetClientFactories:
         side_effect=lambda client, **_: client,
     )
     @patch("oracle.oci_recovery_mcp_server.server.oci.recovery.DatabaseRecoveryClient")
-    @patch(
-        "oracle.oci_recovery_mcp_server.server._effective_auth_method",
-        return_value="apikey",
-    )
+    @patch("oracle.oci_recovery_mcp_server.server._build_signer")
     @patch("oracle.oci_recovery_mcp_server.server._load_oci_config_for_server")
-    def test_get_recovery_client_apikey_passes_circuit_breaker(
+    def test_get_recovery_client_passes_signer_and_circuit_breaker(
         self,
         mock_load_config,
-        _mock_auth_method,
+        mock_build_signer,
         mock_client,
         _mock_wrap,
     ):
         mock_load_config.return_value = {"region": "us-ashburn-1"}
+        signer = object()
+        mock_build_signer.return_value = signer
 
         result = server.get_recovery_client(region="us-phoenix-1", request_id="rid")
 
         args, kwargs = mock_client.call_args
         assert args[0]["region"] == "us-phoenix-1"
-        assert "signer" not in kwargs
+        assert kwargs["signer"] is signer
         assert isinstance(
             kwargs["circuit_breaker_strategy"],
             oci.circuit_breaker.CircuitBreakerStrategy,
@@ -69,19 +68,14 @@ class TestGetClientFactories:
         "oracle.oci_recovery_mcp_server.server._wrap_oci_client",
         side_effect=lambda client, **_: client,
     )
-    @patch("oracle.oci_recovery_mcp_server.server._build_signer_for_session")
     @patch("oracle.oci_recovery_mcp_server.server.oci.monitoring.MonitoringClient")
-    @patch(
-        "oracle.oci_recovery_mcp_server.server._effective_auth_method",
-        return_value="session",
-    )
+    @patch("oracle.oci_recovery_mcp_server.server._build_signer")
     @patch("oracle.oci_recovery_mcp_server.server._load_oci_config_for_server")
-    def test_get_monitoring_client_session_passes_circuit_breaker(
+    def test_get_monitoring_client_passes_signer_and_circuit_breaker(
         self,
         mock_load_config,
-        _mock_auth_method,
-        mock_client,
         mock_build_signer,
+        mock_client,
         _mock_wrap,
     ):
         mock_load_config.return_value = {"region": "us-ashburn-1"}
@@ -99,6 +93,192 @@ class TestGetClientFactories:
         )
         assert callable(kwargs["circuit_breaker_callback"])
         assert result is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self, monkeypatch):
+        monkeypatch.delenv("ORACLE_MCP_AUTH_PROFILE", raising=False)
+        monkeypatch.delenv("ORACLE_MCP_AUTH_METHOD", raising=False)
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(
+        self, tmp_path, monkeypatch
+    ):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    def test_build_signer_reads_session_token(self, tmp_path, monkeypatch):
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        config = oci.config.from_file(file_location=str(cfg), profile_name="DEFAULT")
+
+        private_key = object()
+        monkeypatch.setattr(
+            server.oci.signer,
+            "load_private_key_from_file",
+            lambda key_file: private_key,
+        )
+        security_token_signer = MagicMock(return_value="session-signer")
+        monkeypatch.setattr(
+            server.oci.auth.signers, "SecurityTokenSigner", security_token_signer
+        )
+
+        assert server._build_signer(config) == "session-signer"
+        security_token_signer.assert_called_once_with("TOK", private_key)
+
+    @patch(
+        "oracle.oci_recovery_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_recovery_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_recovery_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]
+
+    def test_env_session_override_forces_session_on_api_key_profile(
+        self, tmp_path, monkeypatch
+    ):
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+        monkeypatch.setenv("ORACLE_MCP_AUTH_METHOD", "session")
+        # The APIKEY profile declares no security_token_file of its own.
+        assert server._profile_declares_session_token() is False
+
+        config = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        private_key = object()
+        monkeypatch.setattr(
+            server.oci.signer, "load_private_key_from_file", lambda key_file: private_key
+        )
+        security_token_signer = MagicMock(return_value="session-signer")
+        monkeypatch.setattr(
+            server.oci.auth.signers, "SecurityTokenSigner", security_token_signer
+        )
+        api_key_signer = MagicMock(return_value="api-key-signer")
+        monkeypatch.setattr(server.oci.signer, "Signer", api_key_signer)
+
+        # Explicit override wins: session path taken even though the profile is API-key.
+        assert server._build_signer(config) == "session-signer"
+        api_key_signer.assert_not_called()
+
+    def test_env_apikey_override_forces_api_key_on_session_profile(
+        self, tmp_path, monkeypatch
+    ):
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        monkeypatch.setenv("ORACLE_MCP_AUTH_METHOD", "apikey")
+        # The DEFAULT profile DOES declare a security_token_file.
+        assert server._profile_declares_session_token() is True
+
+        config = oci.config.from_file(file_location=str(cfg), profile_name="DEFAULT")
+        security_token_signer = MagicMock(return_value="session-signer")
+        monkeypatch.setattr(
+            server.oci.auth.signers, "SecurityTokenSigner", security_token_signer
+        )
+        api_key_signer = MagicMock(return_value="api-key-signer")
+        monkeypatch.setattr(server.oci.signer, "Signer", api_key_signer)
+
+        # Explicit override wins: API-key path taken even though a session token exists.
+        assert server._build_signer(config) == "api-key-signer"
+        security_token_signer.assert_not_called()
+        api_key_signer.assert_called_once()
+
+    def test_unset_env_auto_detects_both_directions(self, tmp_path, monkeypatch):
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.delenv("ORACLE_MCP_AUTH_METHOD", raising=False)
+        assert server._effective_auth_method() is None
+
+        security_token_signer = MagicMock(return_value="session-signer")
+        monkeypatch.setattr(
+            server.oci.auth.signers, "SecurityTokenSigner", security_token_signer
+        )
+        monkeypatch.setattr(
+            server.oci.signer, "load_private_key_from_file", lambda key_file: object()
+        )
+        api_key_signer = MagicMock(return_value="api-key-signer")
+        monkeypatch.setattr(server.oci.signer, "Signer", api_key_signer)
+
+        # Session profile auto-detects to the session-token path.
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        session_config = oci.config.from_file(file_location=str(cfg), profile_name="DEFAULT")
+        assert server._build_signer(session_config) == "session-signer"
+
+        # API-key profile auto-detects to the API-key path.
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+        api_key_config = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert server._build_signer(api_key_config) == "api-key-signer"
 
 
 def test_model_conversion_helpers_cover_fallback_paths(monkeypatch):
@@ -323,10 +503,6 @@ def test_server_helpers_cover_serialization_config_and_wrapping(monkeypatch, tmp
         "error",
     ]
 
-    monkeypatch.setenv("ORACLE_MCP_AUTH_METHOD", "api-key")
-    assert server._effective_auth_method() == "apikey"
-    monkeypatch.setenv("ORACLE_MCP_AUTH_METHOD", "session")
-    assert server._effective_auth_method() == "session"
     monkeypatch.setenv("ORACLE_MCP_AUTH_PROFILE", "PROFILE1")
     assert server._effective_profile_name() == "PROFILE1"
     monkeypatch.delenv("ORACLE_MCP_AUTH_PROFILE", raising=False)
@@ -350,29 +526,7 @@ def test_server_helpers_cover_serialization_config_and_wrapping(monkeypatch, tmp
     assert server._get_profile_value("user") == "user1"
     assert server._get_profile_value("tenancy") == "tenancy-default"
 
-    token_file = tmp_path / "security_token"
-    token_file.write_text("SECURITY_TOKEN", encoding="utf-8")
-    private_key = object()
     signer = object()
-    monkeypatch.setattr(
-        server.oci.signer,
-        "load_private_key_from_file",
-        lambda key_file: private_key if key_file == "key.pem" else None,
-    )
-    security_token_signer = MagicMock(return_value=signer)
-    monkeypatch.setattr(
-        server.oci.auth.signers,
-        "SecurityTokenSigner",
-        security_token_signer,
-    )
-    assert (
-        server._build_signer_for_session(
-            {"key_file": "key.pem", "security_token_file": str(token_file)}
-        )
-        is signer
-    )
-    security_token_signer.assert_called_once_with("SECURITY_TOKEN", private_key)
-
     kwargs_without_signer = server._get_oci_client_kwargs()
     kwargs_with_signer = server._get_oci_client_kwargs(signer=signer)
     assert "signer" not in kwargs_without_signer
@@ -462,9 +616,8 @@ def test_http_config_and_client_factories_cover_auth_paths(monkeypatch):
     monkeypatch.setattr(
         server, "_load_oci_config_for_server", lambda: {"region": "home"}
     )
-    monkeypatch.setattr(server, "_effective_auth_method", lambda: "session")
     monkeypatch.setattr(
-        server, "_build_signer_for_session", lambda config: "session-signer"
+        server, "_build_signer", lambda config: "session-signer"
     )
     assert server.get_identity_client()[2] == "identity"
     assert server.get_database_client(region="us-chicago-1")[2] == "database"
@@ -1601,7 +1754,9 @@ def test_logging_tool_wrapper_tenancy_and_apikey_client_paths(monkeypatch, tmp_p
     monkeypatch.setattr(
         server, "_load_oci_config_for_server", lambda: {"region": "home"}
     )
-    monkeypatch.setattr(server, "_effective_auth_method", lambda: "apikey")
+    monkeypatch.setattr(
+        server, "_build_signer", lambda _config: "profile-signer"
+    )
     monkeypatch.setattr(
         server,
         "_wrap_oci_client",
@@ -1617,18 +1772,14 @@ def test_logging_tool_wrapper_tenancy_and_apikey_client_paths(monkeypatch, tmp_p
     assert server.get_identity_client()[1] == "identity"
     assert server.get_database_client(region="us-phoenix-1")[1] == "database"
     assert server.get_monitoring_client(region="us-phoenix-1")[1] == "monitoring"
-    assert "signer" not in identity_client.call_args.kwargs
+    assert identity_client.call_args.kwargs["signer"] == "profile-signer"
     assert database_client.call_args.args[0]["region"] == "us-phoenix-1"
-    assert "signer" not in monitoring_client.call_args.kwargs
+    assert monitoring_client.call_args.kwargs["signer"] == "profile-signer"
 
     recovery_client = MagicMock(return_value="recovery-client")
     monkeypatch.setattr(server.oci.recovery, "DatabaseRecoveryClient", recovery_client)
-    monkeypatch.setattr(server, "_effective_auth_method", lambda: "session")
-    monkeypatch.setattr(
-        server, "_build_signer_for_session", lambda _config: "session-signer"
-    )
     assert server.get_recovery_client(region="us-ashburn-1")[1] == "recovery"
-    assert recovery_client.call_args.kwargs["signer"] == "session-signer"
+    assert recovery_client.call_args.kwargs["signer"] == "profile-signer"
 
 
 def test_summary_serialization_fallbacks_and_error_paths(monkeypatch):

--- a/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/server.py
+++ b/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 from logging import Logger
 from typing import Optional
@@ -70,6 +71,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_ocir_client():
     config, signer = _get_http_config_and_signer()
     if signer is not None:
@@ -82,12 +151,7 @@ def get_ocir_client():
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
 
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.artifacts.ArtifactsClient(config, **_get_oci_client_kwargs(signer))
 
 

--- a/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/tests/test_registry_tools.py
+++ b/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/tests/test_registry_tools.py
@@ -326,8 +326,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_registry_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_registry_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_registry_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_ocir_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -378,8 +383,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_registry_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_registry_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_registry_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_ocir_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -415,3 +425,133 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_registry_mcp_server.server.oci.artifacts.ArtifactsClient")
+    @patch("oracle.oci_registry_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_registry_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_registry_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_registry_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_ocir_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_ocir_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(
+        self, tmp_path, monkeypatch
+    ):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_registry_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_registry_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_registry_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/server.py
+++ b/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 import re
 from logging import Logger
@@ -114,6 +115,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_search_client():
     logger.info("entering get_search_client")
     config, signer = _get_http_config_and_signer()
@@ -127,12 +196,7 @@ def get_search_client():
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
 
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.resource_search.ResourceSearchClient(config, **_get_oci_client_kwargs(signer))
 
 

--- a/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/tests/test_resource_search_tools.py
+++ b/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/tests/test_resource_search_tools.py
@@ -643,8 +643,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_resource_search_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_resource_search_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_search_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -695,8 +700,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_resource_search_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_resource_search_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_search_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -732,3 +742,133 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_resource_search_mcp_server.server.oci.resource_search.ResourceSearchClient")
+    @patch("oracle.oci_resource_search_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_resource_search_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_resource_search_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_search_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_search_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(
+        self, tmp_path, monkeypatch
+    ):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_resource_search_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_resource_search_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]

--- a/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/server.py
+++ b/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/server.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import configparser
 import os
 from logging import Logger
 from typing import Annotated
@@ -64,6 +65,74 @@ def _get_oci_client_kwargs(signer=None):
     return kwargs
 
 
+_SESSION_TOKEN_DOCS = "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm"
+_API_KEY_FIELDS = ("tenancy", "user", "fingerprint", "key_file")
+
+# configparser reserves "DEFAULT" as the section whose keys are inherited by every
+# other section. Naming a section that cannot appear in an OCI config disables that.
+_NO_INHERIT = "\x00oci-mcp-no-inherited-defaults"
+
+_api_key_warning_emitted = False
+
+
+def _selected_profile():
+    return os.getenv("OCI_CONFIG_PROFILE", oci.config.DEFAULT_PROFILE)
+
+
+def _profile_declares_session_token():
+    """Whether the selected profile declares security_token_file in its own section.
+
+    oci.config.from_file() merges the [DEFAULT] section into every named profile, so
+    `"security_token_file" in config` is true for an API-key profile whenever [DEFAULT]
+    happens to be a session profile -- which would sign requests with the wrong
+    credentials. Re-read the file with that inheritance disabled.
+    """
+    parser = configparser.ConfigParser(default_section=_NO_INHERIT)
+    parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
+    profile = _selected_profile()
+    if not parser.has_section(profile):
+        return False
+    return parser.has_option(profile, "security_token_file")
+
+
+def _build_signer(config):
+    """Build a request signer matching the selected profile's authentication type."""
+    global _api_key_warning_emitted
+
+    if _profile_declares_session_token():
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])
+        with open(os.path.expanduser(config["security_token_file"]), "r") as f:
+            token = f.read()
+        return oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    profile = _selected_profile()
+    missing = [field for field in _API_KEY_FIELDS if not config.get(field)]
+    if missing:
+        raise RuntimeError(
+            f"OCI profile [{profile}] cannot authenticate: it declares no "
+            f"security_token_file, and these API key fields are missing: "
+            f"{', '.join(missing)}. Either run 'oci session authenticate' to create a "
+            f"session-token profile, or add the missing fields. See {_SESSION_TOKEN_DOCS}"
+        )
+
+    if not _api_key_warning_emitted:
+        _api_key_warning_emitted = True
+        logger.warning(
+            f"OCI profile [{profile}] authenticates with a long-lived API key. Session "
+            f"tokens expire automatically and limit the damage from a leaked credential; "
+            f"prefer 'oci session authenticate' where your tenancy supports it. "
+            f"See {_SESSION_TOKEN_DOCS}"
+        )
+
+    return oci.signer.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config["key_file"],
+        pass_phrase=config.get("pass_phrase"),
+    )
+
+
 def get_usage_client():
     logger.info("entering get_monitoring_client")
     config, signer = _get_http_config_and_signer()
@@ -76,12 +145,7 @@ def get_usage_client():
     user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
     config["additional_user_agent"] = f"{user_agent_name}/{__version__}"
 
-    private_key = oci.signer.load_private_key_from_file(config["key_file"])
-    token_file = os.path.expanduser(config["security_token_file"])
-    token = None
-    with open(token_file, "r") as f:
-        token = f.read()
-    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    signer = _build_signer(config)
     return oci.usage_api.UsageapiClient(config, **_get_oci_client_kwargs(signer))
 
 

--- a/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/tests/test_usage_tools.py
+++ b/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/tests/test_usage_tools.py
@@ -185,8 +185,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_usage_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_usage_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_usage_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_search_client_with_profile_env(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -237,8 +242,13 @@ class TestGetClient:
     )
     @patch("oracle.oci_usage_mcp_server.server.oci.config.from_file")
     @patch("oracle.oci_usage_mcp_server.server.os.getenv")
+    @patch(
+        "oracle.oci_usage_mcp_server.server._profile_declares_session_token",
+        return_value=True,
+    )
     def test_get_search_client_uses_default_profile_when_env_missing(
         self,
+        _mock_declares_session_token,
         mock_getenv,
         mock_from_file,
         mock_open_file,
@@ -274,3 +284,133 @@ class TestGetClient:
         assert isinstance(config["additional_user_agent"], str) and "/" in config["additional_user_agent"]
         # Returned object is client instance
         assert srv_client is mock_client.return_value
+
+    @patch("oracle.oci_usage_mcp_server.server.oci.usage_api.UsageapiClient")
+    @patch("oracle.oci_usage_mcp_server.server.oci.signer.Signer")
+    @patch("oracle.oci_usage_mcp_server.server.oci.auth.signers.SecurityTokenSigner")
+    @patch("oracle.oci_usage_mcp_server.server.oci.config.from_file")
+    @patch(
+        "oracle.oci_usage_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_get_usage_client_uses_api_key_signer_without_security_token_file(
+        self,
+        _mock_declares_session_token,
+        mock_from_file,
+        mock_security_token_signer,
+        mock_api_key_signer,
+        mock_client,
+    ):
+        # Arrange: an API key profile has no security_token_file
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        mock_from_file.return_value = config
+
+        # Act
+        srv_client = server.get_usage_client()
+
+        # Assert: no session token signer, API key signer built from the profile
+        mock_security_token_signer.assert_not_called()
+        mock_api_key_signer.assert_called_once_with(
+            tenancy="ocid1.tenancy.oc1..t",
+            user="ocid1.user.oc1..u",
+            fingerprint="aa:bb:cc",
+            private_key_file_location="/k.pem",
+            pass_phrase=None,
+        )
+        _, client_kwargs = mock_client.call_args
+        assert client_kwargs["signer"] is mock_api_key_signer.return_value
+        assert srv_client is mock_client.return_value
+
+
+SESSION_DEFAULT_CONFIG = """\
+[DEFAULT]
+user=ocid1.user.oc1..sess
+fingerprint=aa:bb
+tenancy=ocid1.tenancy.oc1..sess
+region=us-ashburn-1
+key_file={key}
+security_token_file={token}
+
+[APIKEY]
+user=ocid1.user.oc1..apikey
+fingerprint=cc:dd
+tenancy=ocid1.tenancy.oc1..apikey
+region=us-ashburn-1
+key_file={key}
+"""
+
+
+class TestProfileAuthSelection:
+    @pytest.fixture(autouse=True)
+    def _reset_warning_flag(self):
+        server._api_key_warning_emitted = False
+        yield
+        server._api_key_warning_emitted = False
+
+    def _write_config(self, tmp_path):
+        key = tmp_path / "k.pem"
+        key.write_text("")
+        token = tmp_path / "token"
+        token.write_text("TOK")
+        cfg = tmp_path / "config"
+        cfg.write_text(SESSION_DEFAULT_CONFIG.format(key=key, token=token))
+        return cfg
+
+    def test_session_profile_is_detected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "DEFAULT")
+        assert server._profile_declares_session_token() is True
+
+    def test_api_key_profile_does_not_inherit_default_security_token_file(
+        self, tmp_path, monkeypatch
+    ):
+        # oci.config.from_file() merges [DEFAULT] into every profile, so the raw config
+        # dict claims APIKEY has a security_token_file. The profile itself does not, and
+        # signing with the [DEFAULT] session token would use the wrong credentials.
+        cfg = self._write_config(tmp_path)
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(cfg))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "APIKEY")
+
+        merged = oci.config.from_file(file_location=str(cfg), profile_name="APIKEY")
+        assert "security_token_file" in merged  # inherited from [DEFAULT]
+
+        assert server._profile_declares_session_token() is False
+
+    def test_unknown_profile_reports_no_session_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OCI_CONFIG_FILE", str(self._write_config(tmp_path)))
+        monkeypatch.setenv("OCI_CONFIG_PROFILE", "NOSUCH")
+        assert server._profile_declares_session_token() is False
+
+    @patch(
+        "oracle.oci_usage_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_incomplete_api_key_profile_raises_actionable_error(self, _mock_declares):
+        with pytest.raises(RuntimeError) as excinfo:
+            server._build_signer({"key_file": "/k.pem"})
+        message = str(excinfo.value)
+        assert "tenancy" in message and "user" in message and "fingerprint" in message
+        assert "oci session authenticate" in message
+
+    @patch("oracle.oci_usage_mcp_server.server.oci.signer.Signer")
+    @patch(
+        "oracle.oci_usage_mcp_server.server._profile_declares_session_token",
+        return_value=False,
+    )
+    def test_api_key_warning_is_emitted_once(self, _mock_declares, _mock_signer):
+        config = {
+            "key_file": "/k.pem",
+            "tenancy": "ocid1.tenancy.oc1..t",
+            "user": "ocid1.user.oc1..u",
+            "fingerprint": "aa:bb:cc",
+        }
+        with patch.object(server.logger, "warning") as mock_warning:
+            server._build_signer(config)
+            server._build_signer(config)
+        mock_warning.assert_called_once()
+        assert "session authenticate" in mock_warning.call_args[0][0]


### PR DESCRIPTION
## Summary

`AGENTS.md` (line 52) and `BEST_PRACTICES.md` (line 91) both list **API-key** first among the supported client-construction authentication paths, and `AGENTS.md` requires a unit test asserting the derived `additional_user_agent` for each supported path. `README.md` (line 162) already tells users that *"Some MCP servers may not work with token-based authentication alone"* and links the API-key docs.

In practice, **17 servers could not use an API-key profile at all**, two more silently selected the wrong credentials, and `oci-api` hung. None had a test for the API-key path.

This PR makes the code match the documented support matrix. It does **not** change the default or the recommendation: session tokens remain what the docs advise, and API-key auth now logs a one-time warning pointing at `oci session authenticate`. What changes is what happens to a user who has *already* configured an API-key profile.

## The three defects

### 1. `KeyError` on API-key profiles (17 servers)

Every SDK-backed server built its signer through an unconditional `config["security_token_file"]`. That key is absent from an API-key profile, so the server raised `KeyError: 'security_token_file'` before issuing any request — surfacing to the user as an opaque MCP tool failure naming an internal config key.

Affected: `cloud-guard`, `compute`, `compute-instance-agent`, `database`, `faaas`, `identity`, `limits`, `logging`, `migration`, `monitoring`, `network-load-balancer`, `networking`, `object-storage`, `recovery`, `registry`, `resource-search`, `usage`.

Note this is a bug under *any* auth policy. Even a deliberate decision to mandate session tokens should produce an actionable error, not a `KeyError` escaping into a tool call.

### 2. `[DEFAULT]` inheritance selected the wrong credentials (`oci-cloud`, `oci-load-balancer`)

These two already guarded the lookup, so they did not crash — but the guard is unsound.

`oci.config.from_file()` returns `dict(parser.items(profile))`, and Python's `configparser` treats `DEFAULT` as a magic section whose keys are inherited by **every** other section. So for a config like:

```ini
[DEFAULT]          # a session profile
security_token_file = ~/.oci/sessions/DEFAULT/token
...
[APIKEY]           # an API-key profile, no security_token_file of its own
user = ocid1.user.oc1..apikey
...
```

`from_file(profile_name="APIKEY")` returns a dict that **does** contain `security_token_file`. Both `"security_token_file" in config` (`oci-load-balancer`) and `config.get("security_token_file")` (`oci-cloud`) therefore report a session profile, and requests get signed with `[DEFAULT]`'s session token instead of `APIKEY`'s API key — a different principal than the profile names.

`oci-cloud`'s additional `os.path.exists(token_file)` check does not rescue this: the inherited token file usually *does* exist.

The discriminator now re-reads the config with that inheritance disabled and asks whether the selected profile's **own** section declares `security_token_file`:

```python
parser = configparser.ConfigParser(default_section=_NO_INHERIT)
parser.read(os.path.expanduser(os.getenv("OCI_CONFIG_FILE", oci.config.DEFAULT_LOCATION)))
return parser.has_section(profile) and parser.has_option(profile, "security_token_file")
```

Each server gets a regression test that asserts the merged `from_file()` dict contains the inherited key while the discriminator correctly returns `False`.

### 3. `oci-api` hung rather than failing

`run_oci_command` injected `--auth security_token` into every CLI invocation:

```python
["oci", "--profile", profile, "--auth", "security_token"] + shlex.split(command)
```

Against an API-key profile the CLI attempts an interactive re-authentication. There is no TTY under MCP stdio, so it blocks forever — no message, no timeout, no diagnosis. It also overrode the profile the user selected via `OCI_CONFIG_PROFILE` and defeated `OCI_CLI_AUTH`.

The flag is now derived from the profile using the same sound discriminator, and omitted entirely when the config file or profile section cannot be read, so the CLI applies its own default.

## Also included

- An incomplete profile now raises an actionable `RuntimeError` naming the missing fields and pointing at `oci session authenticate`, rather than a bare `KeyError` from a later line.
- API-key auth emits a **one-time** `logger.warning` recommending session tokens and linking the docs. Session tokens stay the documented default; this communicates the benefit rather than enforcing it.

## Behavior changes worth reviewing

- **`oci-cloud`** no longer silently falls back to an API-key signer when a session profile's token file cannot be read. Signing as a principal other than the one the profile names is not a safe fallback, so the error now propagates. Two tests that asserted the old fallback were rewritten.
- **`oci-recovery`**'s `ORACLE_MCP_AUTH_METHOD` still forces `session` or `apikey` when set — no breaking change. Previously *unset* meant `"session"`, which is precisely why API-key profiles hit the `KeyError` by default. Unset now auto-detects from the profile.

## Testing

- All **25** OCI server suites pass; `uv tool run ruff check` is clean repo-wide.
- Every touched server gains tests for: the API-key signer path, the `[DEFAULT]`-inheritance regression, the actionable error on an incomplete profile, and the once-only warning — satisfying `AGENTS.md`'s per-auth-path test requirement, which the API-key path previously did not meet anywhere.
- Verified end-to-end against a live tenancy (`us-ashburn-1`) with an API-key `[DEFAULT]` profile, driving each server over stdio JSON-RPC exactly as a Claude Desktop config launches it: `oci-api`, `oci-database`, `oci-logging`, `oci-monitoring`, `oci-networking`, `oci-resource-search`, `oci-cloud`, and `oci-load-balancer` all authenticate and return real data. `oci-api` returns in ~3s where it previously hung indefinitely.
- No formatting-only changes: the diff is limited to the auth fix and its tests.
