### PR TITLE
fix: invoke_oci_api fails for LogSearchClient.search_logs bug

### DIFF
--- a/src/oci-cloud-mcp-server/CHANGELOG.md
+++ b/src/oci-cloud-mcp-server/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Updated dependency locks for FastMCP 3.4.2, OCI SDK 2.179.0, and refreshed authentication-related transitive packages.
 
+### Fixed
+
+- Fixed `invoke_oci_api` pagination for OCI responses that expose records through `results`, including Logging Search `search_logs`.
+
 ## 2.1.0
 
 ### Security

--- a/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/server.py
+++ b/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/server.py
@@ -894,6 +894,9 @@ def _extract_paginated_items(response_data: Any) -> Tuple[Any, Optional[str], An
         return response_data.objects, "object_storage", None
     if isinstance(response_data, list):
         return response_data, None, None
+    results = getattr(response_data, "results", None)
+    if results is not None:
+        return results, None, None
     items = getattr(response_data, "items", response_data)
     return (response_data if callable(items) else items), None, None
 
@@ -1020,78 +1023,75 @@ def _call_with_pagination_if_applicable(
         uses_pagination = _supports_pagination(method, operation_name)
     if uses_pagination:
         logger.info(f"Using paginator for operation {operation_name}")
-        if max_results is not None:
-            call_params = dict(params)
-            requested_limit = call_params.get("limit")
-            remaining_items = max_results
-            aggregated_results: List[Any] = []
-            is_dns_record_collection = False
-            dns_record_collection_class = None
-            is_list_objects_response = False
-            list_objects_prefixes = set()
-            call_result = None
-            more_results_available = False
+        call_params = dict(params)
+        requested_limit = call_params.get("limit")
+        remaining_items = max_results
+        aggregated_results: List[Any] = []
+        is_dns_record_collection = False
+        dns_record_collection_class = None
+        is_list_objects_response = False
+        list_objects_prefixes = set()
+        call_result = None
+        more_results_available = False
 
-            while remaining_items > 0:
+        while remaining_items is None or remaining_items > 0:
+            if remaining_items is not None:
                 if isinstance(requested_limit, int) and requested_limit > 0:
                     call_params["limit"] = min(requested_limit, remaining_items)
                 else:
                     call_params.pop("limit", None)
 
-                call_result = oci.retry.DEFAULT_RETRY_STRATEGY.make_retrying_call(method, **call_params)
-                response_data = call_result.data if hasattr(call_result, "data") else call_result
-                available_slots = remaining_items
+            call_result = oci.retry.DEFAULT_RETRY_STRATEGY.make_retrying_call(method, **call_params)
+            response_data = call_result.data if hasattr(call_result, "data") else call_result
+            available_slots = remaining_items
 
-                current_items, collection_kind, collection_class = _extract_paginated_items(response_data)
-                if collection_kind == "dns":
-                    is_dns_record_collection = True
-                    dns_record_collection_class = collection_class
-                elif collection_kind == "object_storage":
-                    is_list_objects_response = True
-                    if response_data.prefixes:
-                        list_objects_prefixes.update(response_data.prefixes)
+            current_items, collection_kind, collection_class = _extract_paginated_items(response_data)
+            if collection_kind == "dns":
+                is_dns_record_collection = True
+                dns_record_collection_class = collection_class
+            elif collection_kind == "object_storage":
+                is_list_objects_response = True
+                if response_data.prefixes:
+                    list_objects_prefixes.update(response_data.prefixes)
 
-                if not hasattr(current_items, "__len__") or not hasattr(current_items, "__getitem__"):
-                    current_items = list(current_items)
-                current_count = len(current_items)
-                aggregated_results.extend(islice(current_items, available_slots))
-                if current_count > available_slots:
-                    more_results_available = True
+            if not hasattr(current_items, "__len__") or not hasattr(current_items, "__getitem__"):
+                current_items = list(current_items)
+            current_count = len(current_items)
+            aggregated_results.extend(islice(current_items, available_slots))
+            if available_slots is not None and current_count > available_slots:
+                more_results_available = True
+            if remaining_items is not None:
                 remaining_items -= current_count
 
-                if remaining_items <= 0:
-                    if is_list_objects_response and getattr(response_data, "next_start_with", None) is not None:
-                        more_results_available = True
-                    elif getattr(call_result, "has_next_page", False):
-                        more_results_available = True
+            if remaining_items is not None and remaining_items <= 0:
+                if is_list_objects_response and getattr(response_data, "next_start_with", None) is not None:
+                    more_results_available = True
+                elif getattr(call_result, "has_next_page", False):
+                    more_results_available = True
+                break
+
+            if is_list_objects_response:
+                next_start_with = getattr(response_data, "next_start_with", None)
+                if next_start_with is None:
                     break
+                call_params["start"] = next_start_with
+                continue
 
-                if is_list_objects_response:
-                    next_start_with = getattr(response_data, "next_start_with", None)
-                    if next_start_with is None:
-                        break
-                    call_params["start"] = next_start_with
-                    continue
+            if not getattr(call_result, "has_next_page", False):
+                break
+            call_params["page"] = call_result.next_page
 
-                if not getattr(call_result, "has_next_page", False):
-                    break
-                call_params["page"] = call_result.next_page
-
-            response = call_result
-            if is_dns_record_collection:
-                data = dns_record_collection_class(items=aggregated_results)
-            elif is_list_objects_response:
-                data = oci.object_storage.models.ListObjects(
-                    objects=aggregated_results,
-                    prefixes=list(list_objects_prefixes),
-                )
-            else:
-                data = aggregated_results
-            has_more = more_results_available
+        response = call_result
+        if is_dns_record_collection:
+            data = dns_record_collection_class(items=aggregated_results)
+        elif is_list_objects_response:
+            data = oci.object_storage.models.ListObjects(
+                objects=aggregated_results,
+                prefixes=list(list_objects_prefixes),
+            )
         else:
-            response = oci.pagination.list_call_get_all_results(method, **params)
-            data = response.data
-            has_more = getattr(response, "has_next_page", False)
+            data = aggregated_results
+        has_more = more_results_available
         try:
             opc_request_id = response.headers.get("opc-request-id")
         except Exception:

--- a/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_edge_cases.py
+++ b/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_edge_cases.py
@@ -625,23 +625,15 @@ class TestInvokeGenericException:
 
 
 class TestListPaginatorHeadersMissing:
-    def test_list_headers_object_without_get(self, monkeypatch):
+    def test_list_headers_object_without_get(self):
         # ensure list_* branch handles headers object without 'get'
         class Resp:
             def __init__(self, data):
                 self.data = data
                 self.headers = object()  # lacks .get
 
-        def fake_pager(method, **kwargs):  # noqa: ARG001
-            return Resp([1, 2])
-
-        monkeypatch.setattr(
-            "oracle.oci_cloud_mcp_server.server.oci.pagination.list_call_get_all_results",
-            fake_pager,
-        )
-
         def list_things():
-            return Resp([9])
+            return Resp([1, 2])
 
         data, opc, has_more = _call_with_pagination_if_applicable(list_things, {}, "list_things")
         assert data == [1, 2]

--- a/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_pagination_and_invocation.py
+++ b/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_pagination_and_invocation.py
@@ -127,27 +127,158 @@ class TestImportClientHappyPath:
 
 
 class TestPaginatorHeadersWithGet:
-    def test_paginator_headers_with_get_yields_request_id(self, monkeypatch):
+    def test_paginator_headers_with_get_yields_request_id(self):
         class Resp:
             def __init__(self, data):
                 self.data = data
                 self.headers = {"opc-request-id": "req-123"}
 
-        def fake_pager(method, **kwargs):  # noqa: ARG001
-            return Resp([1, 2, 3])
-
-        monkeypatch.setattr(
-            "oracle.oci_cloud_mcp_server.server.oci.pagination.list_call_get_all_results",
-            fake_pager,
-        )
-
         def list_things():
-            return Resp([9])
+            return Resp([1, 2, 3])
 
         data, opc, has_more = _call_with_pagination_if_applicable(list_things, {}, "list_things")
         assert data == [1, 2, 3]
         assert opc == "req-123"
         assert has_more is False
+
+
+class TestUnboundedPaginationLimits:
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_unbounded_pagination_preserves_non_positive_limit(self, limit):
+        captured = []
+
+        class Response:
+            data = []
+            headers = {}
+
+        def list_things(limit=None):
+            captured.append(limit)
+            return Response()
+
+        data, _, has_more = _call_with_pagination_if_applicable(
+            list_things,
+            {"limit": limit},
+            "list_things",
+        )
+
+        assert captured == [limit]
+        assert data == []
+        assert has_more is False
+
+
+class TestLoggingSearchPagination:
+    @staticmethod
+    def _patch_log_search_client(monkeypatch, captured, *, has_second_page=True):
+        class SearchResponse:
+            def __init__(self, results):
+                self.results = results
+
+        class Response:
+            def __init__(self, results, request_id, next_page=None):
+                self.data = SearchResponse(results)
+                self.headers = {"opc-request-id": request_id}
+                self.next_page = next_page
+
+            @property
+            def has_next_page(self):
+                return self.next_page is not None
+
+        class LogSearchClient:
+            def __init__(self, config, signer):  # noqa: ARG002
+                pass
+
+            def search_logs(self, search_logs_details, limit=None, page=None):  # noqa: ARG002
+                captured.append({"limit": limit, "page": page})
+                if page is None:
+                    next_page = "page-2" if has_second_page else None
+                    return Response([{"id": "result-1"}, {"id": "result-2"}], "req-1", next_page)
+                return Response([{"id": "result-3"}, {"id": "result-4"}], "req-2")
+
+        monkeypatch.setattr(
+            "oracle.oci_cloud_mcp_server.server.import_module",
+            lambda name: SimpleNamespace(LogSearchClient=LogSearchClient),
+        )
+        monkeypatch.setattr(
+            "oracle.oci_cloud_mcp_server.server._get_config_and_signer",
+            lambda: ({}, object()),
+        )
+
+    @pytest.mark.asyncio
+    async def test_search_logs_returns_one_page_of_results(self, monkeypatch):
+        captured = []
+        self._patch_log_search_client(monkeypatch, captured, has_second_page=False)
+
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "invoke_oci_api",
+                    {
+                        "client_fqn": "oci.loggingsearch.LogSearchClient",
+                        "operation": "search_logs",
+                        "params": {"search_logs_details": {"search_query": "search \"example\""}},
+                        "result_mode": "full",
+                    },
+                )
+            ).data
+
+        assert captured == [{"limit": None, "page": None}]
+        assert result["opc_request_id"] == "req-1"
+        assert result["data"] == [{"id": "result-1"}, {"id": "result-2"}]
+        assert result["result_meta"]["total_items"] == 2
+
+    @pytest.mark.asyncio
+    async def test_search_logs_aggregates_results_across_pages(self, monkeypatch):
+        captured = []
+        self._patch_log_search_client(monkeypatch, captured)
+
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "invoke_oci_api",
+                    {
+                        "client_fqn": "oci.loggingsearch.LogSearchClient",
+                        "operation": "search_logs",
+                        "params": {"search_logs_details": {"search_query": "search \"example\""}},
+                        "result_mode": "full",
+                    },
+                )
+            ).data
+
+        assert captured == [{"limit": None, "page": None}, {"limit": None, "page": "page-2"}]
+        assert result["opc_request_id"] == "req-2"
+        assert result["data"] == [
+            {"id": "result-1"},
+            {"id": "result-2"},
+            {"id": "result-3"},
+            {"id": "result-4"},
+        ]
+        assert result["result_meta"]["pagination_used"] is True
+        assert result["result_meta"]["total_items"] == 4
+
+    @pytest.mark.asyncio
+    async def test_search_logs_respects_max_results(self, monkeypatch):
+        captured = []
+        self._patch_log_search_client(monkeypatch, captured)
+
+        async with Client(mcp) as client:
+            result = (
+                await client.call_tool(
+                    "invoke_oci_api",
+                    {
+                        "client_fqn": "oci.loggingsearch.LogSearchClient",
+                        "operation": "search_logs",
+                        "params": {"search_logs_details": {"search_query": "search \"example\""}},
+                        "max_results": 3,
+                        "result_mode": "full",
+                    },
+                )
+            ).data
+
+        assert captured == [{"limit": None, "page": None}, {"limit": None, "page": "page-2"}]
+        assert result["opc_request_id"] == "req-2"
+        assert result["data"] == [{"id": "result-1"}, {"id": "result-2"}, {"id": "result-3"}]
+        assert result["result_meta"]["returned_items"] == 3
+        assert result["result_meta"]["truncated"] is True
 
 
 class TestCallWithPaginationTypeErrorFallback:

--- a/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_server_extras.py
+++ b/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_server_extras.py
@@ -978,27 +978,19 @@ class TestFromDictSuccess:
         assert inst._data == {"a": 2}
 
 class TestPaginationListPath:
-    def test_list_operation_uses_paginator_direct(self, monkeypatch):
-        # exercise list_* branch in _call_with_pagination_if_applicable directly
+    def test_list_operation_aggregates_directly(self):
+        # Exercise the unbounded list_* pagination branch directly.
         class Resp:
             def __init__(self, data):
                 self.data = data
                 self.headers = {}
-
-        def fake_pager(method, **kwargs):  # noqa: ARG001
-            return Resp([{"n": 1}, {"n": 2}])
-
-        monkeypatch.setattr(
-            "oracle.oci_cloud_mcp_server.server.oci.pagination.list_call_get_all_results",
-            fake_pager,
-        )
 
         from oracle.oci_cloud_mcp_server.server import (
             _call_with_pagination_if_applicable,
         )
 
         def list_things(compartment_id=None):  # noqa: ARG001
-            return Resp([{"n": 9}])
+            return Resp([{"n": 1}, {"n": 2}])
 
         data, opc, has_more = _call_with_pagination_if_applicable(
             list_things, {"compartment_id": "ocid1"}, "list_things"
@@ -1021,9 +1013,9 @@ class TestListOpcRequestIdPropagation:
                 pass
 
             def list_things(self, compartment_id):  # noqa: ARG002
-                return FakeResponse([{"x": 1}])
+                return FakeResponse([{"a": 1}, {"a": 2}])
 
-        # return our fake client and a paginator result with headers
+        # Return a fake client whose response carries the request ID.
         monkeypatch.setattr(
             "oracle.oci_cloud_mcp_server.server.import_module",
             lambda name: SimpleNamespace(FakeClient=FakeClient),
@@ -1032,11 +1024,6 @@ class TestListOpcRequestIdPropagation:
             "oracle.oci_cloud_mcp_server.server._get_config_and_signer",
             lambda: ({}, object()),
         )
-        monkeypatch.setattr(
-            "oracle.oci_cloud_mcp_server.server.oci.pagination.list_call_get_all_results",
-            lambda method, **kwargs: FakeResponse([{"a": 1}, {"a": 2}]),
-        )
-
         async with Client(mcp) as client:
             res = (
                 await client.call_tool(

--- a/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_tools.py
+++ b/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/tests/test_tools.py
@@ -96,7 +96,7 @@ class TestCloudSdkTools:
                 assert result["data"] == {"id": "abc", "value": "ok"}
 
     @pytest.mark.asyncio
-    async def test_invoke_oci_api_list_uses_paginator(self):
+    async def test_invoke_oci_api_list_uses_direct_pagination(self):
         class FakeResponse:
             def __init__(self, data):
                 self.data = data
@@ -107,22 +107,18 @@ class TestCloudSdkTools:
                 self.config = config
                 self.signer = signer
 
-            # existence of a list_* method is enough; paginator will be patched
+            # The list_* operation is automatically paginated.
             def list_things(self, compartment_id):
-                return FakeResponse([{"name": "x"}])
+                return FakeResponse([{"name": "a"}, {"name": "b"}, {"name": "c"}])
 
         fake_module = SimpleNamespace(FakeClient=FakeClient)
 
         with (
             patch("oracle.oci_cloud_mcp_server.server.import_module") as mock_import,
             patch("oracle.oci_cloud_mcp_server.server._get_config_and_signer") as mock_cfg,
-            patch(
-                "oracle.oci_cloud_mcp_server.server.oci.pagination.list_call_get_all_results"
-            ) as mock_pager,
         ):
             mock_import.return_value = fake_module
             mock_cfg.return_value = ({}, object())
-            mock_pager.return_value = FakeResponse([{"name": "a"}, {"name": "b"}, {"name": "c"}])
 
             async with Client(mcp) as client:
                 result = (
@@ -143,7 +139,7 @@ class TestCloudSdkTools:
                 assert result["data"]["item_count"] == 3
 
     @pytest.mark.asyncio
-    async def test_invoke_oci_api_dns_get_zone_records_uses_paginator(self):
+    async def test_invoke_oci_api_dns_get_zone_records_uses_direct_pagination(self):
         class FakeResponse:
             def __init__(self, data):
                 self.data = data
@@ -156,22 +152,16 @@ class TestCloudSdkTools:
 
             # non-list operation name but supports pagination via page/limit params (DNS style)
             def get_zone_records(self, zone_name, page=None, limit=None):
-                return FakeResponse([{"name": "first"}])
+                return FakeResponse([{"name": "a"}, {"name": "b"}, {"name": "c"}, {"name": "d"}])
 
         fake_module = SimpleNamespace(FakeClient=FakeClient)
 
         with (
             patch("oracle.oci_cloud_mcp_server.server.import_module") as mock_import,
             patch("oracle.oci_cloud_mcp_server.server._get_config_and_signer") as mock_cfg,
-            patch(
-                "oracle.oci_cloud_mcp_server.server.oci.pagination.list_call_get_all_results"
-            ) as mock_pager,
         ):
             mock_import.return_value = fake_module
             mock_cfg.return_value = ({}, object())
-            mock_pager.return_value = FakeResponse(
-                [{"name": "a"}, {"name": "b"}, {"name": "c"}, {"name": "d"}]
-            )
 
             async with Client(mcp) as client:
                 result = (
@@ -192,7 +182,7 @@ class TestCloudSdkTools:
                 assert len(result["data"]) == 4
 
     @pytest.mark.asyncio
-    async def test_invoke_oci_api_summarize_prefix_uses_paginator(self):
+    async def test_invoke_oci_api_summarize_prefix_uses_direct_pagination(self):
         class FakeResponse:
             def __init__(self, data):
                 self.data = data
@@ -205,20 +195,16 @@ class TestCloudSdkTools:
 
             # summarize_* should trigger pagination even without page/limit
             def summarize_metrics(self, compartment_id):
-                return FakeResponse([{"sum": 1}])
+                return FakeResponse([{"sum": 10}, {"sum": 20}])
 
         fake_module = SimpleNamespace(FakeClient=FakeClient)
 
         with (
             patch("oracle.oci_cloud_mcp_server.server.import_module") as mock_import,
             patch("oracle.oci_cloud_mcp_server.server._get_config_and_signer") as mock_cfg,
-            patch(
-                "oracle.oci_cloud_mcp_server.server.oci.pagination.list_call_get_all_results"
-            ) as mock_pager,
         ):
             mock_import.return_value = fake_module
             mock_cfg.return_value = ({}, object())
-            mock_pager.return_value = FakeResponse([{"sum": 10}, {"sum": 20}])
 
             async with Client(mcp) as client:
                 result = (
@@ -239,7 +225,7 @@ class TestCloudSdkTools:
                 assert len(result["data"]) == 2
 
     @pytest.mark.asyncio
-    async def test_invoke_oci_api_dns_get_rr_set_allowlist_uses_paginator(self):
+    async def test_invoke_oci_api_dns_get_rr_set_allowlist_uses_direct_pagination(self):
         class FakeResponse:
             def __init__(self, data):
                 self.data = data
@@ -252,20 +238,16 @@ class TestCloudSdkTools:
 
             # DNS-style op name; include page/limit in signature so pagination is detected
             def get_rr_set(self, zone_name_or_id, domain, rtype, page=None, limit=None):
-                return FakeResponse([{"rr": "first"}])
+                return FakeResponse([{"rr": 1}, {"rr": 2}, {"rr": 3}])
 
         fake_module = SimpleNamespace(FakeClient=FakeClient)
 
         with (
             patch("oracle.oci_cloud_mcp_server.server.import_module") as mock_import,
             patch("oracle.oci_cloud_mcp_server.server._get_config_and_signer") as mock_cfg,
-            patch(
-                "oracle.oci_cloud_mcp_server.server.oci.pagination.list_call_get_all_results"
-            ) as mock_pager,
         ):
             mock_import.return_value = fake_module
             mock_cfg.return_value = ({}, object())
-            mock_pager.return_value = FakeResponse([{"rr": 1}, {"rr": 2}, {"rr": 3}])
 
             async with Client(mcp) as client:
                 result = (


### PR DESCRIPTION
# Description

Fix `invoke_oci_api` pagination for OCI responses that expose records through `results`, including `oci.loggingsearch.LogSearchClient.search_logs`.

The generic OCI SDK paginator assumes non-list response models expose `items`, which caused `SearchResponse.results` calls to fail. This change uses the server’s response-shape-aware pagination loop for bounded and unbounded requests, preserves DNS/Object Storage handling, and retains unbounded SDK `limit` pass-through semantics.

Dependencies: none.

Fixes #356 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `make lint`
- [x] `make test project=oci-cloud-mcp-server` — 199 passed; 91.75% coverage
- [x] Live read-only `LogSearchClient.search_logs` calls against the supplied Phoenix log group, covering empty `SearchResponse.results` for bounded and unbounded paths

**Test Configuration**:
* Firmware version: N/A
* Hardware: macOS development machine
* Toolchain: Python 3.13.13, UV
* SDK: OCI Python SDK 2.179.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
