### PR TITLE
fix(oci-api-mcp-server): validate OCI help commands

### DIFF
--- a/src/oci-api-mcp-server/CHANGELOG.md
+++ b/src/oci-api-mcp-server/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Restricted `get_oci_command_help` to option-free OCI command paths and applied the destructive-command denylist before invoking the OCI CLI.
 - OCI command parsing now preserves quoted arguments when retrieving command help or running OCI CLI commands. ([#100](https://github.com/oracle/mcp/issues/100))
 
 ## 2.0.0

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/server.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/server.py
@@ -6,6 +6,7 @@ https://oss.oracle.com/licenses/upl.
 
 import json
 import os
+import re
 import subprocess
 from logging import Logger
 import shlex
@@ -28,6 +29,30 @@ initAuditLogger(logger)
 
 # Read and setup deny list
 denylist_manager = Denylist(logger)
+
+_OCI_COMMAND_TOKEN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_OCI_HELP_COMMAND_ERROR = "OCI help accepts command paths only without options or values"
+
+
+def _parse_oci_help_command(command: str) -> list[str]:
+    try:
+        command_tokens = shlex.split(command)
+    except ValueError as exc:
+        raise ValueError(_OCI_HELP_COMMAND_ERROR) from exc
+
+    if not command_tokens:
+        raise ValueError(_OCI_HELP_COMMAND_ERROR)
+    if command_tokens[0] == "oci":
+        raise ValueError("Do not include the 'oci' executable in the command path")
+    if any(_OCI_COMMAND_TOKEN.fullmatch(token) is None for token in command_tokens):
+        raise ValueError(_OCI_HELP_COMMAND_ERROR)
+
+    command_path = " ".join(command_tokens)
+    if denylist_manager.isCommandInDenyList(command_path):
+        raise ValueError("Command path is denied by denylist")
+
+    return command_tokens
+
 
 # Initialize the MCP server
 mcp = FastMCP(
@@ -71,6 +96,7 @@ def get_oci_command_help(command: str) -> str:
     IMPORTANT:
       - Only provide the command _after_ 'oci' — do not include the string
         'oci' in `command`.
+      - Provide command-path tokens only. Options and option values are not accepted.
       - Never use the information returned by this tool to instruct an end
         user directly. Use it only to determine which command to run
         yourself using run_oci_command.
@@ -106,12 +132,13 @@ def get_oci_command_help(command: str) -> str:
 
     """
     logger.info(f"get_oci_command_help called with command: {command}")
+    command_tokens = _parse_oci_help_command(command)
     env_copy = os.environ.copy()
     env_copy["OCI_SDK_APPEND_USER_AGENT"] = USER_AGENT
 
     try:
         result = subprocess.run(
-            ["oci"] + shlex.split(command) + ["--help"],
+            ["oci", *command_tokens, "--help"],
             env=env_copy,
             capture_output=True,
             text=True,

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
@@ -11,6 +11,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from fastmcp import Client
+from fastmcp.exceptions import ToolError
 import oracle.oci_api_mcp_server.server as server
 from oracle.oci_api_mcp_server import __project__
 from oracle.oci_api_mcp_server.denylist import Denylist
@@ -48,7 +49,7 @@ class TestOCITools:
 
     @pytest.mark.asyncio
     @patch("oracle.oci_api_mcp_server.server.subprocess.run")
-    async def test_get_oci_command_help_preserves_quoted_arguments(self, mock_run):
+    async def test_get_oci_command_help_accepts_hyphenated_command_path(self, mock_run):
         mock_result = MagicMock()
         mock_result.stdout = "Help output"
         mock_result.stderr = ""
@@ -58,7 +59,12 @@ class TestOCITools:
             result = (
                 await client.call_tool(
                     "get_oci_command_help",
-                    {"command": 'compute instance list --display-name "Shared Services"'},
+                    {
+                        "command": (
+                            "recovery protected-database-collection "
+                            "list-protected-databases"
+                        )
+                    },
                 )
             ).structured_content["result"]
 
@@ -66,11 +72,9 @@ class TestOCITools:
             mock_run.assert_called_once_with(
                 [
                     "oci",
-                    "compute",
-                    "instance",
-                    "list",
-                    "--display-name",
-                    "Shared Services",
+                    "recovery",
+                    "protected-database-collection",
+                    "list-protected-databases",
                     "--help",
                 ],
                 env=ANY,
@@ -79,6 +83,59 @@ class TestOCITools:
                 check=True,
                 shell=False,
             )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "compute instance terminate --opc-client-request-id",
+            'compute instance list --display-name "Shared Services"',
+        ],
+    )
+    @patch("oracle.oci_api_mcp_server.server.subprocess.run")
+    async def test_get_oci_command_help_rejects_options(self, mock_run, command):
+        mock_run.return_value.stdout = "Help output"
+
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError, match="command paths only"):
+                await client.call_tool("get_oci_command_help", {"command": command})
+
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("command", "error"),
+        [
+            ("", "command paths only"),
+            ("oci compute instance list", "Do not include the 'oci' executable"),
+            ("compute 'unterminated", "command paths only"),
+            ("compute instance/list", "command paths only"),
+        ],
+    )
+    @patch("oracle.oci_api_mcp_server.server.subprocess.run")
+    async def test_get_oci_command_help_rejects_invalid_command_paths(
+        self, mock_run, command, error
+    ):
+        mock_run.return_value.stdout = "Help output"
+
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError, match=error):
+                await client.call_tool("get_oci_command_help", {"command": command})
+
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("oracle.oci_api_mcp_server.server.subprocess.run")
+    async def test_get_oci_command_help_rejects_denylisted_command(self, mock_run):
+        mock_run.return_value.stdout = "Help output"
+
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError, match="denied by denylist"):
+                await client.call_tool(
+                    "get_oci_command_help", {"command": "compute instance terminate"}
+                )
+
+        mock_run.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("oracle.oci_api_mcp_server.server.subprocess.run")


### PR DESCRIPTION
# Description

Fixes `get_oci_command_help` command handling by accepting only valid OCI command paths and applying the existing denylist before invoking the OCI CLI.

Fixes #<issue-number>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `make test project=oci-api-mcp-server`
- [x] `make lint`
  - Ruff completed with no findings.

**Test Configuration**:

- OS: macOS/Darwin
- Python: 3.13.7
- pytest: 9.0.3
- FastMCP: 3.4.2
- OCI CLI: 3.87.0

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules