### PR TITLE
Add OCI Document Understanding MCP Server

### DIFF
--- a/src/oci-document-understanding-mcp-server/CHANGELOG.md
+++ b/src/oci-document-understanding-mcp-server/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Added public Oracle MCP package layout under `oracle/oci_document_understanding_mcp_server`.
+- Added the FastMCP-based `oracle.oci-document-understanding-mcp-server` stdio entry point.
+- Added OCI SDK additional user-agent telemetry for Document Understanding clients.
+- Removed the custom stdio JSON-RPC transport and prototype shell helper scripts from the public package layout.
+
+## 0.1.0
+
+### Added
+
+- Initial OCI Document Understanding MCP server with document extraction and classification tools.

--- a/src/oci-document-understanding-mcp-server/CHANGELOG.md
+++ b/src/oci-document-understanding-mcp-server/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 0.1.0
+
 ### Added
 
 - Added public Oracle MCP package layout under `oracle/oci_document_understanding_mcp_server`.
@@ -18,9 +20,3 @@
 - Honor `include_confidence=false` by omitting confidence values from extraction results.
 - Serialize and map OCI SDK response models into extraction and classification results.
 - Apply `confidence_threshold` to classification results.
-
-## 0.1.0
-
-### Added
-
-- Initial OCI Document Understanding MCP server with document extraction and classification tools.

--- a/src/oci-document-understanding-mcp-server/CHANGELOG.md
+++ b/src/oci-document-understanding-mcp-server/CHANGELOG.md
@@ -16,6 +16,8 @@
 ### Fixed
 
 - Honor `include_confidence=false` by omitting confidence values from extraction results.
+- Serialize and map OCI SDK response models into extraction and classification results.
+- Apply `confidence_threshold` to classification results.
 
 ## 0.1.0
 

--- a/src/oci-document-understanding-mcp-server/CHANGELOG.md
+++ b/src/oci-document-understanding-mcp-server/CHANGELOG.md
@@ -9,6 +9,14 @@
 - Added OCI SDK additional user-agent telemetry for Document Understanding clients.
 - Removed the custom stdio JSON-RPC transport and prototype shell helper scripts from the public package layout.
 
+### Changed
+
+- Use `oracle-mcp-common` for OCI SDK authentication and standard region resolution.
+
+### Fixed
+
+- Honor `include_confidence=false` by omitting confidence values from extraction results.
+
 ## 0.1.0
 
 ### Added

--- a/src/oci-document-understanding-mcp-server/LICENSE.txt
+++ b/src/oci-document-understanding-mcp-server/LICENSE.txt
@@ -1,0 +1,35 @@
+Copyright (c) 2026 Oracle and/or its affiliates.
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any
+person obtaining a copy of this software, associated documentation and/or data
+(collectively the "Software"), free of charge and under any and all copyright
+rights in the Software, and any and all patent rights owned or freely
+licensable by each licensor hereunder covering either (i) the unmodified
+Software as contributed to or provided by such licensor, or (ii) the Larger
+Works (as defined below), to deal in both
+
+(a) the Software, and
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+one is included with the Software (each a "Larger Work" to which the Software
+is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create
+derivative works of, display, perform, and distribute the Software and make,
+use, sell, offer for sale, import, export, have made, and have sold the
+Software and the Larger Work(s), and to sublicense the foregoing rights on
+either these or other terms.
+
+This license is subject to the following condition:
+The above copyright notice and either this complete permission notice or at
+a minimum a reference to the UPL must be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/oci-document-understanding-mcp-server/README.md
+++ b/src/oci-document-understanding-mcp-server/README.md
@@ -1,0 +1,200 @@
+# OCI Document Understanding MCP Server
+
+## Overview
+
+This FastMCP-based server provides MCP tools for OCI Document Understanding
+extraction and classification workflows.
+
+It supports stdio transport only. It does not expose HTTP, streamable HTTP,
+OAuth, IDCS bearer-token validation, `/mcp`, or `/.well-known/*` endpoints.
+
+## Running the Server
+
+### STDIO Transport Mode
+
+```sh
+uvx oracle.oci-document-understanding-mcp-server
+```
+
+For local source testing:
+
+```sh
+uv run oracle.oci-document-understanding-mcp-server
+```
+
+For local wheel testing:
+
+```sh
+uvx \
+  --python 3.13 \
+  --no-python-downloads \
+  --from ./dist/oracle_oci_document_understanding_mcp_server-0.1.0-py3-none-any.whl \
+  oracle.oci-document-understanding-mcp-server
+```
+
+## Authentication
+
+The server supports OCI SDK authentication modes through `OCI_AUTH_MODE`.
+
+Supported values:
+
+- `session-token`
+- `api-key`
+- `instance-principal`
+- `none`
+
+`none` is only for `DOCUMENT_MCP_MODE=stub`, which uses a deterministic fake
+provider and does not call OCI.
+
+`DOCUMENT_MCP_MODE` controls the default auth mode:
+
+| `DOCUMENT_MCP_MODE` | Default `OCI_AUTH_MODE` | Description |
+| --- | --- | --- |
+| `stub` | `none` | Local MCP flow testing without OCI calls. |
+| `local` | `session-token` | Local OCI config profile with session-token auth. |
+| `prod` | `instance-principal` | OCI Compute instance principal auth. |
+
+For local session-token authentication, run:
+
+```sh
+oci session authenticate --profile-name DEFAULT --region us-phoenix-1
+```
+
+The selected OCI config profile must contain `security_token_file` and the
+matching session `key_file`.
+
+## Configuration
+
+| Environment Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `DOCUMENT_MCP_MODE` | No | `local` | Runtime mode: `stub`, `local`, or `prod`. |
+| `OCI_AUTH_MODE` | No | Derived from `DOCUMENT_MCP_MODE` | OCI auth mode: `session-token`, `api-key`, `instance-principal`, or `none`. |
+| `OCI_REGION` | No | `us-ashburn-1` | OCI region used for Document Understanding requests. |
+| `OCI_COMPARTMENT_ID` | Yes for non-stub OCI calls | None | Default compartment OCID for Document Understanding requests. |
+| `OCI_CONFIG_PROFILE` | No | `DEFAULT` | OCI config profile name. |
+| `OCI_CONFIG_FILE` | No | OCI SDK default | OCI config file path. |
+| `OCI_DOCUMENT_ENDPOINT` | No | None | Optional Document Understanding endpoint override. |
+
+## Tools
+
+| Tool Name | Description |
+| --- | --- |
+| `document_extract` | Extract text, key-value pairs, tables, and document elements from an inline base64 or Object Storage document. |
+| `document_classify` | Classify an inline base64 or Object Storage document and return candidate document classes. |
+
+## Input Sources
+
+Inline base64 input:
+
+```json
+{
+  "document": "<base64-document>",
+  "mime_type": "application/pdf",
+  "features": ["TEXT", "KEY_VALUE"],
+  "options": {
+    "language": "en",
+    "include_confidence": true
+  }
+}
+```
+
+Object Storage input:
+
+```json
+{
+  "document_source": {
+    "source_type": "OBJECT_STORAGE",
+    "namespace_name": "my_namespace",
+    "bucket_name": "my_bucket",
+    "object_name": "documents/invoice.pdf"
+  },
+  "features": ["TEXT", "KEY_VALUE", "TABLE"],
+  "options": {
+    "language": "en",
+    "include_confidence": true
+  }
+}
+```
+
+Classification input:
+
+```json
+{
+  "document": "<base64-document>",
+  "mime_type": "application/pdf",
+  "document_type_hint": "invoice",
+  "options": {
+    "language": "en",
+    "confidence_threshold": 0.2
+  }
+}
+```
+
+## Local Stub Mode
+
+Stub mode validates MCP flow without OCI credentials:
+
+```sh
+DOCUMENT_MCP_MODE=stub \
+OCI_AUTH_MODE=none \
+uv run oracle.oci-document-understanding-mcp-server
+```
+
+Use the development test command below for local validation. MCP clients can run
+the server with the package entry point shown in the running examples above.
+
+## Project Layout
+
+```text
+oci-document-understanding-mcp-server/
+├── LICENSE.txt
+├── CHANGELOG.md
+├── README.md
+├── pyproject.toml
+├── uv.lock
+└── oracle/
+    ├── __init__.py
+    └── oci_document_understanding_mcp_server/
+        ├── __init__.py
+        ├── server.py
+        ├── handlers/
+        ├── oci/
+        ├── parsers/
+        ├── response.py
+        └── tests/
+```
+
+## Development
+
+```sh
+uv sync --locked --all-extras --dev
+uv run pytest --cov=. --cov-branch --cov-report=term-missing
+uv build
+```
+
+The package entry point is:
+
+```toml
+[project.scripts]
+"oracle.oci-document-understanding-mcp-server" = "oracle.oci_document_understanding_mcp_server.server:main"
+```
+
+## Third-Party APIs
+
+Developers choosing to distribute a binary implementation of this project are
+responsible for obtaining and providing all required licenses and copyright
+notices for third-party code used in order to ensure compliance with their
+respective open source licenses.
+
+## Disclaimer
+
+Users are responsible for their local environment, OCI permissions, and
+credential safety. Different language model selections may yield different
+results and performance.
+
+## License
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+
+Released under the Universal Permissive License v1.0 as shown at
+<https://oss.oracle.com/licenses/upl/>.

--- a/src/oci-document-understanding-mcp-server/README.md
+++ b/src/oci-document-understanding-mcp-server/README.md
@@ -34,25 +34,29 @@ uvx \
 
 ## Authentication
 
-The server supports OCI SDK authentication modes through `OCI_AUTH_MODE`.
+For real OCI calls, the server uses `oracle-mcp-common` to resolve OCI SDK
+authentication. Set `OCI_MCP_AUTH_TYPE` when you need a specific mode:
 
-Supported values:
+- `security_token`
+- `api_key`
+- `instance_principal`
+- `resource_principal`
+- `instance_principal_delegation`
+- `resource_principal_delegation`
+- `oke_workload_identity`
+- `identity_domain_upst`
 
-- `session-token`
-- `api-key`
-- `instance-principal`
-- `none`
+When `OCI_MCP_AUTH_TYPE` is unset, the common library's `auto` mode uses a
+security token only when the selected OCI profile directly declares
+`security_token_file`; otherwise it uses API-key authentication. Principal
+authentication modes must be selected explicitly.
 
-`none` is only for `DOCUMENT_MCP_MODE=stub`, which uses a deterministic fake
-provider and does not call OCI.
+`DOCUMENT_MCP_MODE` selects the provider, not the authentication mode:
 
-`DOCUMENT_MCP_MODE` controls the default auth mode:
-
-| `DOCUMENT_MCP_MODE` | Default `OCI_AUTH_MODE` | Description |
-| --- | --- | --- |
-| `stub` | `none` | Local MCP flow testing without OCI calls. |
-| `local` | `session-token` | Local OCI config profile with session-token auth. |
-| `prod` | `instance-principal` | OCI Compute instance principal auth. |
+| `DOCUMENT_MCP_MODE` | Description |
+| --- | --- |
+| `oci` (default) | Real OCI Document Understanding SDK provider. |
+| `stub` | Deterministic fake provider for local MCP flow testing. |
 
 For local session-token authentication, run:
 
@@ -67,18 +71,33 @@ matching session `key_file`.
 
 | Environment Variable | Required | Default | Description |
 | --- | --- | --- | --- |
-| `DOCUMENT_MCP_MODE` | No | `local` | Runtime mode: `stub`, `local`, or `prod`. |
-| `OCI_AUTH_MODE` | No | Derived from `DOCUMENT_MCP_MODE` | OCI auth mode: `session-token`, `api-key`, `instance-principal`, or `none`. |
-| `OCI_REGION` | No | `us-ashburn-1` | OCI region used for Document Understanding requests. |
+| `DOCUMENT_MCP_MODE` | No | `oci` | Provider mode: `oci` or `stub`. |
+| `OCI_MCP_AUTH_TYPE` | No | `auto` | OCI authentication type, resolved by `oracle-mcp-common`. |
+| `OCI_REGION` | Depends on auth type | Profile or signer region | OCI region, resolved by `oracle-mcp-common`. |
 | `OCI_COMPARTMENT_ID` | Yes for non-stub OCI calls | None | Default compartment OCID for Document Understanding requests. |
-| `OCI_CONFIG_PROFILE` | No | `DEFAULT` | OCI config profile name. |
-| `OCI_CONFIG_FILE` | No | OCI SDK default | OCI config file path. |
-| `OCI_DOCUMENT_ENDPOINT` | No | None | Optional Document Understanding endpoint override. |
+| `OCI_CONFIG_PROFILE` | No | `DEFAULT` | OCI config profile, resolved by `oracle-mcp-common`. |
+| `OCI_CONFIG_FILE` | No | OCI SDK default | OCI config file, resolved by `oracle-mcp-common`. |
 
 `OCI_REGION`, when set, takes precedence over the region in an OCI config
 profile. Otherwise, profile authentication uses the profile region and
-principal authentication uses the signer region, with `us-ashburn-1` as the
-server fallback.
+principal authentication uses the signer region. The OCI SDK derives the
+official Document Understanding endpoint from that resolved region.
+
+Session-token authentication with the default OCI profile:
+
+```sh
+OCI_MCP_AUTH_TYPE=security_token \
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..example \
+uv run oracle.oci-document-understanding-mcp-server
+```
+
+Instance-principal authentication:
+
+```sh
+OCI_MCP_AUTH_TYPE=instance_principal \
+OCI_COMPARTMENT_ID=ocid1.compartment.oc1..example \
+uv run oracle.oci-document-understanding-mcp-server
+```
 
 ## Tools
 
@@ -143,9 +162,7 @@ Classification input:
 Stub mode validates MCP flow without OCI credentials:
 
 ```sh
-DOCUMENT_MCP_MODE=stub \
-OCI_AUTH_MODE=none \
-uv run oracle.oci-document-understanding-mcp-server
+DOCUMENT_MCP_MODE=stub uv run oracle.oci-document-understanding-mcp-server
 ```
 
 Use the development test command below for local validation. MCP clients can run

--- a/src/oci-document-understanding-mcp-server/README.md
+++ b/src/oci-document-understanding-mcp-server/README.md
@@ -75,6 +75,11 @@ matching session `key_file`.
 | `OCI_CONFIG_FILE` | No | OCI SDK default | OCI config file path. |
 | `OCI_DOCUMENT_ENDPOINT` | No | None | Optional Document Understanding endpoint override. |
 
+`OCI_REGION`, when set, takes precedence over the region in an OCI config
+profile. Otherwise, profile authentication uses the profile region and
+principal authentication uses the signer region, with `us-ashburn-1` as the
+server fallback.
+
 ## Tools
 
 | Tool Name | Description |
@@ -97,6 +102,9 @@ Inline base64 input:
   }
 }
 ```
+
+Set `include_confidence` to `false` to omit confidence fields from extraction
+results.
 
 Object Storage input:
 

--- a/src/oci-document-understanding-mcp-server/oracle/__init__.py
+++ b/src/oci-document-understanding-mcp-server/oracle/__init__.py
@@ -1,0 +1,5 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/__init__.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/__init__.py
@@ -1,0 +1,10 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+__project__ = "oracle.oci-document-understanding-mcp-server"
+__version__ = "0.1.0"
+
+__all__ = ["__project__", "__version__"]

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/__main__.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/__main__.py
@@ -1,0 +1,10 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from oracle.oci_document_understanding_mcp_server.server import main
+
+if __name__ == "__main__":
+    main()

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/handlers/classification.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/handlers/classification.py
@@ -1,0 +1,71 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from typing import Any
+
+from oracle.oci_document_understanding_mcp_server.handlers.ids import document_id_from_source
+from oracle.oci_document_understanding_mcp_server.handlers.sources import parse_document_source
+from oracle.oci_document_understanding_mcp_server.handlers.validation import (
+    optional_number_between,
+    optional_object,
+    optional_string,
+)
+from oracle.oci_document_understanding_mcp_server.models import ClassificationOptions, ClassificationRequest
+from oracle.oci_document_understanding_mcp_server.oci.provider import OciDocumentUnderstandingProvider
+from oracle.oci_document_understanding_mcp_server.parsers.classification import ClassificationOutputParser
+from oracle.oci_document_understanding_mcp_server.response import successful_envelope
+
+ALLOWED_DOCUMENT_TYPE_HINTS = {
+    "INVOICE",
+    "RECEIPT",
+    "RESUME",
+    "TAX_FORM",
+    "DRIVER_LICENSE",
+    "PASSPORT",
+    "BANK_STATEMENT",
+    "CHECK",
+    "PAYSLIP",
+    "OTHERS",
+    "HEALTH_INSURANCE_ID",
+}
+
+
+class DocumentClassificationHandler:
+    """Validates document_classify input, calls OCI, parses output, and wraps the response."""
+
+    def __init__(self, provider: OciDocumentUnderstandingProvider, parser: ClassificationOutputParser) -> None:
+        self.provider = provider
+        self.parser = parser
+
+    def handle(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Runs the complete classification flow for a single MCP tools/call request."""
+        request = self._to_request(arguments)
+        raw_result = self.provider.classify(request)
+        result = self.parser.parse(raw_result)
+        return successful_envelope(raw_result.request_id, document_id_from_source(request.document_source), result)
+
+    def _to_request(self, arguments: dict[str, Any]) -> ClassificationRequest:
+        """Converts untyped MCP arguments into an internal classification request."""
+        options = optional_object(arguments, "options")
+        return ClassificationRequest(
+            document_source=parse_document_source(arguments),
+            options=ClassificationOptions(
+                language=optional_string(options, "language"),
+                confidence_threshold=optional_number_between(options, "confidence_threshold", 0, 1),
+            ),
+            document_type_hint=_normalize_document_type_hint(optional_string(arguments, "document_type_hint")),
+        )
+
+
+def _normalize_document_type_hint(value: str | None) -> str | None:
+    """Normalizes user-provided document type hints into OCI enum values."""
+    if value is None or not value.strip():
+        return None
+    normalized = value.strip().replace("-", "_").replace(" ", "_").upper()
+    if normalized not in ALLOWED_DOCUMENT_TYPE_HINTS:
+        allowed = ", ".join(sorted(ALLOWED_DOCUMENT_TYPE_HINTS))
+        raise ValueError(f"document_type_hint must be one of: {allowed}")
+    return normalized

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/handlers/extraction.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/handlers/extraction.py
@@ -1,0 +1,54 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from typing import Any
+
+from oracle.oci_document_understanding_mcp_server.handlers.ids import document_id_from_source
+from oracle.oci_document_understanding_mcp_server.handlers.sources import parse_document_source
+from oracle.oci_document_understanding_mcp_server.handlers.validation import (
+    optional_boolean,
+    optional_object,
+    optional_string,
+    required_string_list,
+)
+from oracle.oci_document_understanding_mcp_server.models import ExtractionOptions, ExtractionRequest
+from oracle.oci_document_understanding_mcp_server.oci.provider import OciDocumentUnderstandingProvider
+from oracle.oci_document_understanding_mcp_server.parsers.extraction import ExtractionOutputParser
+from oracle.oci_document_understanding_mcp_server.response import successful_envelope
+
+ALLOWED_FEATURES = {"TEXT", "KEY_VALUE", "TABLE", "ELEMENT"}
+
+
+class DocumentExtractionHandler:
+    """Validates document_extract input, calls OCI, parses output, and wraps the response."""
+
+    def __init__(self, provider: OciDocumentUnderstandingProvider, parser: ExtractionOutputParser) -> None:
+        self.provider = provider
+        self.parser = parser
+
+    def handle(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Runs the complete extraction flow for a single MCP tools/call request."""
+        request = self._to_request(arguments)
+        raw_result = self.provider.extract(request)
+        result = self.parser.parse(raw_result)
+        return successful_envelope(raw_result.request_id, document_id_from_source(request.document_source), result)
+
+    def _to_request(self, arguments: dict[str, Any]) -> ExtractionRequest:
+        """Converts untyped MCP arguments into an internal extraction request."""
+        features = [feature.upper() for feature in required_string_list(arguments, "features")]
+        unsupported = [feature for feature in features if feature not in ALLOWED_FEATURES]
+        if unsupported:
+            raise ValueError(f"Unsupported extraction feature(s): {', '.join(unsupported)}")
+
+        options = optional_object(arguments, "options")
+        return ExtractionRequest(
+            document_source=parse_document_source(arguments),
+            features=features,
+            options=ExtractionOptions(
+                language=optional_string(options, "language"),
+                include_confidence=optional_boolean(options, "include_confidence", True),
+            ),
+        )

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/handlers/ids.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/handlers/ids.py
@@ -1,0 +1,37 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+import base64
+import hashlib
+
+from oracle.oci_document_understanding_mcp_server.models import DocumentSource
+
+
+def document_id_from_base64(document: str, mime_type: str) -> str:
+    """Creates a stable document id from the MIME type and decoded content."""
+    digest = hashlib.sha256()
+    digest.update(mime_type.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(base64.b64decode(document, validate=True))
+    return "doc_" + digest.hexdigest()[:32]
+
+
+def document_id_from_source(source: DocumentSource) -> str:
+    """Creates a stable document id for either inline or Object Storage document sources."""
+    if source.source_type == "INLINE_BASE64":
+        if source.document is None or source.mime_type is None:
+            raise ValueError("INLINE_BASE64 document source requires document and mime_type")
+        return document_id_from_base64(source.document, source.mime_type)
+
+    digest = hashlib.sha256()
+    digest.update(b"OBJECT_STORAGE")
+    digest.update(b"\0")
+    digest.update((source.namespace_name or "").encode("utf-8"))
+    digest.update(b"\0")
+    digest.update((source.bucket_name or "").encode("utf-8"))
+    digest.update(b"\0")
+    digest.update((source.object_name or "").encode("utf-8"))
+    return "doc_" + digest.hexdigest()[:32]

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/handlers/sources.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/handlers/sources.py
@@ -1,0 +1,53 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from typing import Any
+
+from oracle.oci_document_understanding_mcp_server.handlers.validation import optional_object, required_base64_string, required_string
+from oracle.oci_document_understanding_mcp_server.models import DocumentSource
+
+
+def parse_document_source(arguments: dict[str, Any]) -> DocumentSource:
+    """Parses either the new document_source object or the legacy top-level inline fields."""
+    if "document_source" not in arguments:
+        return DocumentSource(
+            source_type="INLINE_BASE64",
+            document=required_base64_string(arguments, "document"),
+            mime_type=required_string(arguments, "mime_type"),
+        )
+
+    source = optional_object(arguments, "document_source")
+    source_type = required_string(source, "source_type").upper()
+    page_range = _optional_string_list(source, "page_range")
+
+    if source_type == "INLINE_BASE64":
+        return DocumentSource(
+            source_type=source_type,
+            document=required_base64_string(source, "document"),
+            mime_type=required_string(source, "mime_type"),
+            page_range=page_range,
+        )
+
+    if source_type == "OBJECT_STORAGE":
+        return DocumentSource(
+            source_type=source_type,
+            namespace_name=required_string(source, "namespace_name"),
+            bucket_name=required_string(source, "bucket_name"),
+            object_name=required_string(source, "object_name"),
+            page_range=page_range,
+        )
+
+    raise ValueError("document_source.source_type must be INLINE_BASE64 or OBJECT_STORAGE")
+
+
+def _optional_string_list(arguments: dict[str, Any], name: str) -> list[str] | None:
+    """Reads an optional list of strings."""
+    value = arguments.get(name)
+    if value is None:
+        return None
+    if not isinstance(value, list) or not all(isinstance(item, str) and item.strip() for item in value):
+        raise ValueError(f"{name} must be an array of non-empty strings")
+    return value

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/handlers/validation.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/handlers/validation.py
@@ -1,0 +1,80 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+import base64
+from typing import Any
+
+
+def required_string(arguments: dict[str, Any], name: str) -> str:
+    """Reads a required string argument."""
+    value = arguments.get(name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def optional_string(arguments: dict[str, Any], name: str) -> str | None:
+    """Reads an optional string argument."""
+    value = arguments.get(name)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    return value
+
+
+def required_base64_string(arguments: dict[str, Any], name: str) -> str:
+    """Reads and validates a required base64 string without changing its value."""
+    value = required_string(arguments, name)
+    try:
+        base64.b64decode(value, validate=True)
+    except Exception as exc:
+        raise ValueError(f"{name} must be valid base64-encoded content") from exc
+    return value
+
+
+def required_string_list(arguments: dict[str, Any], name: str) -> list[str]:
+    """Reads a required non-empty list of strings."""
+    value = arguments.get(name)
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{name} must be a non-empty array")
+    if not all(isinstance(item, str) and item.strip() for item in value):
+        raise ValueError(f"{name} must contain only non-empty strings")
+    return value
+
+
+def optional_object(arguments: dict[str, Any], name: str) -> dict[str, Any]:
+    """Reads an optional object argument."""
+    value = arguments.get(name)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be an object")
+    return value
+
+
+def optional_boolean(arguments: dict[str, Any], name: str, default: bool) -> bool:
+    """Reads an optional boolean argument."""
+    value = arguments.get(name)
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
+def optional_number_between(arguments: dict[str, Any], name: str, minimum: float, maximum: float) -> float | None:
+    """Reads an optional numeric argument constrained to an inclusive range."""
+    value = arguments.get(name)
+    if value is None:
+        return None
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError(f"{name} must be a number")
+    number = float(value)
+    if number < minimum or number > maximum:
+        raise ValueError(f"{name} must be between {minimum:g} and {maximum:g}")
+    return number
+

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/handlers/validation.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/handlers/validation.py
@@ -77,4 +77,3 @@ def optional_number_between(arguments: dict[str, Any], name: str, minimum: float
     if number < minimum or number > maximum:
         raise ValueError(f"{name} must be between {minimum:g} and {maximum:g}")
     return number
-

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/models.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/models.py
@@ -1,0 +1,69 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class FrozenModel(BaseModel):
+    """Base model for immutable MCP request and response models."""
+
+    model_config = ConfigDict(frozen=True)
+
+
+class DocumentSource(FrozenModel):
+    """Normalized document input source for inline base64 and Object Storage inputs."""
+
+    source_type: Literal["INLINE_BASE64", "OBJECT_STORAGE", "inline_base64", "object_storage"] = Field(
+        ..., description="Document source type: INLINE_BASE64 or OBJECT_STORAGE."
+    )
+    document: str | None = Field(None, description="Base64-encoded inline document content.")
+    mime_type: str | None = Field(None, description="MIME type for inline document content.")
+    namespace_name: str | None = Field(None, description="OCI Object Storage namespace.")
+    bucket_name: str | None = Field(None, description="OCI Object Storage bucket name.")
+    object_name: str | None = Field(None, description="OCI Object Storage object name.")
+    page_range: list[str] | None = Field(None, description="Optional page ranges accepted by OCI Document Understanding.")
+
+
+class ExtractionOptions(FrozenModel):
+    """Options accepted by the document_extract tool."""
+
+    language: str | None = Field(None, description="Optional document language code.")
+    include_confidence: bool = Field(True, description="Whether confidence scores should be included in extraction metadata.")
+
+
+class ExtractionRequest(FrozenModel):
+    """Normalized internal request for document extraction."""
+
+    document_source: DocumentSource = Field(..., description="Document input source.")
+    features: list[str] = Field(..., description="Document extraction feature names.")
+    options: ExtractionOptions = Field(..., description="Extraction options.")
+
+
+class ClassificationOptions(FrozenModel):
+    """Options accepted by the document_classify tool."""
+
+    language: str | None = Field(None, description="Optional document language code.")
+    confidence_threshold: float | None = Field(None, description="Minimum classification confidence threshold.")
+
+
+class ClassificationRequest(FrozenModel):
+    """Normalized internal request for document classification."""
+
+    document_source: DocumentSource = Field(..., description="Document input source.")
+    options: ClassificationOptions = Field(..., description="Classification options.")
+    document_type_hint: str | None = Field(None, description="Optional OCI document type hint.")
+
+
+class RawOciDocumentResult(FrozenModel):
+    """Raw provider result before post-processing."""
+
+    request_id: str = Field(..., description="OCI request identifier or generated stub request id.")
+    operation: str = Field(..., description="Provider operation name.")
+    received_at: datetime = Field(..., description="Timestamp when the provider result was received.")
+    payload: dict[str, Any] = Field(..., description="Raw provider payload.")

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/models.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/models.py
@@ -34,7 +34,7 @@ class ExtractionOptions(FrozenModel):
     """Options accepted by the document_extract tool."""
 
     language: str | None = Field(None, description="Optional document language code.")
-    include_confidence: bool = Field(True, description="Whether confidence scores should be included in extraction metadata.")
+    include_confidence: bool = Field(True, description="Whether confidence scores should be included in extraction results.")
 
 
 class ExtractionRequest(FrozenModel):

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/config.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/config.py
@@ -1,0 +1,79 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+import os
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class OciDocumentUnderstandingConfig(BaseModel):
+    """Runtime configuration for OCI provider setup."""
+
+    model_config = ConfigDict(frozen=True)
+
+    runtime_mode: str = Field(..., description="Runtime mode: stub, local, or prod.")
+    region: str = Field(..., description="OCI region used for Document Understanding requests.")
+    endpoint: str | None = Field(None, description="Optional OCI Document Understanding endpoint override.")
+    auth_mode: str = Field(..., description="OCI auth mode.")
+    default_compartment_id: str | None = Field(None, description="Default compartment OCID for OCI Document Understanding calls.")
+    config_file_path: str | None = Field(None, description="Optional OCI config file path.")
+    profile: str = Field(..., description="OCI config profile name.")
+
+    @staticmethod
+    def from_environment() -> "OciDocumentUnderstandingConfig":
+        """Builds provider configuration from environment variables."""
+        runtime_mode = _normalize_mode(_env("DOCUMENT_MCP_MODE", "local"))
+        auth_mode = _normalize_auth(_env("OCI_AUTH_MODE", _default_auth_mode(runtime_mode)))
+        return OciDocumentUnderstandingConfig(
+            runtime_mode=runtime_mode,
+            region=_env("OCI_REGION", "us-ashburn-1"),
+            endpoint=_env("OCI_DOCUMENT_ENDPOINT", None),
+            auth_mode=auth_mode,
+            default_compartment_id=_env("OCI_COMPARTMENT_ID", None),
+            config_file_path=_env("OCI_CONFIG_FILE", None),
+            profile=_env("OCI_CONFIG_PROFILE", "DEFAULT"),
+        )
+
+
+def _env(name: str, default: str | None) -> str | None:
+    """Reads an environment variable and falls back when absent or blank."""
+    value = os.environ.get(name)
+    return value.strip() if value and value.strip() else default
+
+
+def _normalize_mode(value: str | None) -> str:
+    """Parses environment runtime mode aliases."""
+    normalized = (value or "local").strip().replace("_", "-").lower()
+    if normalized in {"stub", "test", "mock"}:
+        return "stub"
+    if normalized in {"local", "dev", "development"}:
+        return "local"
+    if normalized in {"prod", "production", "compute"}:
+        return "prod"
+    raise ValueError(f"Unsupported DOCUMENT_MCP_MODE: {value}")
+
+
+def _normalize_auth(value: str | None) -> str:
+    """Parses environment auth mode aliases."""
+    normalized = (value or "").strip().replace("_", "-").lower()
+    if normalized in {"session-token", "sessiontoken", "local"}:
+        return "session-token"
+    if normalized in {"instance-principal", "instanceprincipal", "prod", "production"}:
+        return "instance-principal"
+    if normalized in {"api-key", "apikey", "config-file", "config"}:
+        return "api-key"
+    if normalized in {"none", "stub"}:
+        return "none"
+    raise ValueError(f"Unsupported OCI_AUTH_MODE: {value}")
+
+
+def _default_auth_mode(runtime_mode: str) -> str:
+    """Returns the default auth mode for a runtime mode."""
+    if runtime_mode == "stub":
+        return "none"
+    if runtime_mode == "prod":
+        return "instance-principal"
+    return "session-token"

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/config.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/config.py
@@ -5,6 +5,7 @@ https://oss.oracle.com/licenses/upl.
 """
 
 import os
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -14,27 +15,16 @@ class OciDocumentUnderstandingConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    runtime_mode: str = Field(..., description="Runtime mode: stub, local, or prod.")
-    region: str = Field(..., description="OCI region used for Document Understanding requests.")
-    endpoint: str | None = Field(None, description="Optional OCI Document Understanding endpoint override.")
-    auth_mode: str = Field(..., description="OCI auth mode.")
+    runtime_mode: Literal["oci", "stub"] = Field(..., description="Provider mode: OCI SDK or deterministic stub.")
     default_compartment_id: str | None = Field(None, description="Default compartment OCID for OCI Document Understanding calls.")
-    config_file_path: str | None = Field(None, description="Optional OCI config file path.")
-    profile: str = Field(..., description="OCI config profile name.")
 
     @staticmethod
     def from_environment() -> "OciDocumentUnderstandingConfig":
         """Builds provider configuration from environment variables."""
-        runtime_mode = _normalize_mode(_env("DOCUMENT_MCP_MODE", "local"))
-        auth_mode = _normalize_auth(_env("OCI_AUTH_MODE", _default_auth_mode(runtime_mode)))
+        runtime_mode = _normalize_mode(_env("DOCUMENT_MCP_MODE", "oci"))
         return OciDocumentUnderstandingConfig(
             runtime_mode=runtime_mode,
-            region=_env("OCI_REGION", "us-ashburn-1"),
-            endpoint=_env("OCI_DOCUMENT_ENDPOINT", None),
-            auth_mode=auth_mode,
             default_compartment_id=_env("OCI_COMPARTMENT_ID", None),
-            config_file_path=_env("OCI_CONFIG_FILE", None),
-            profile=_env("OCI_CONFIG_PROFILE", "DEFAULT"),
         )
 
 
@@ -45,35 +35,10 @@ def _env(name: str, default: str | None) -> str | None:
 
 
 def _normalize_mode(value: str | None) -> str:
-    """Parses environment runtime mode aliases."""
-    normalized = (value or "local").strip().replace("_", "-").lower()
-    if normalized in {"stub", "test", "mock"}:
+    """Parses the supported provider modes."""
+    normalized = (value or "oci").strip().lower()
+    if normalized == "stub":
         return "stub"
-    if normalized in {"local", "dev", "development"}:
-        return "local"
-    if normalized in {"prod", "production", "compute"}:
-        return "prod"
+    if normalized == "oci":
+        return "oci"
     raise ValueError(f"Unsupported DOCUMENT_MCP_MODE: {value}")
-
-
-def _normalize_auth(value: str | None) -> str:
-    """Parses environment auth mode aliases."""
-    normalized = (value or "").strip().replace("_", "-").lower()
-    if normalized in {"session-token", "sessiontoken", "local"}:
-        return "session-token"
-    if normalized in {"instance-principal", "instanceprincipal", "prod", "production"}:
-        return "instance-principal"
-    if normalized in {"api-key", "apikey", "config-file", "config"}:
-        return "api-key"
-    if normalized in {"none", "stub"}:
-        return "none"
-    raise ValueError(f"Unsupported OCI_AUTH_MODE: {value}")
-
-
-def _default_auth_mode(runtime_mode: str) -> str:
-    """Returns the default auth mode for a runtime mode."""
-    if runtime_mode == "stub":
-        return "none"
-    if runtime_mode == "prod":
-        return "instance-principal"
-    return "session-token"

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/provider.py
@@ -1,0 +1,33 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from typing import Protocol
+
+from oracle.oci_document_understanding_mcp_server.models import ClassificationRequest, ExtractionRequest, RawOciDocumentResult
+from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
+
+
+class OciDocumentUnderstandingProvider(Protocol):
+    """Provider contract implemented by stub and OCI SDK-backed providers."""
+
+    def extract(self, request: ExtractionRequest) -> RawOciDocumentResult:
+        """Submits an extraction request and returns raw provider output."""
+
+    def classify(self, request: ClassificationRequest) -> RawOciDocumentResult:
+        """Submits a classification request and returns raw provider output."""
+
+
+def create_provider(config: OciDocumentUnderstandingConfig) -> OciDocumentUnderstandingProvider:
+    """Chooses the provider implementation for the configured runtime mode."""
+    if config.runtime_mode == "stub":
+        from oracle.oci_document_understanding_mcp_server.oci.stub_provider import StubOciDocumentUnderstandingProvider
+
+        return StubOciDocumentUnderstandingProvider(config)
+
+    from oracle.oci_document_understanding_mcp_server.oci.sdk_provider import OciSdkDocumentUnderstandingProvider
+
+    return OciSdkDocumentUnderstandingProvider(config)
+

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/provider.py
@@ -30,4 +30,3 @@ def create_provider(config: OciDocumentUnderstandingConfig) -> OciDocumentUnders
     from oracle.oci_document_understanding_mcp_server.oci.sdk_provider import OciSdkDocumentUnderstandingProvider
 
     return OciSdkDocumentUnderstandingProvider(config)
-

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/request_mapper.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/request_mapper.py
@@ -1,0 +1,66 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from typing import Any
+
+from oracle.oci_document_understanding_mcp_server.models import ClassificationRequest, DocumentSource, ExtractionRequest
+from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
+
+
+def extraction_configs(request: ExtractionRequest, config: OciDocumentUnderstandingConfig) -> list[dict[str, Any]]:
+    """Builds sanitized OCI request metadata for extraction features."""
+    return [
+        {
+            "operationName": "AnalyzeDocument",
+            "parameters": {
+                "compartmentId": config.default_compartment_id,
+                "document": {
+                    **_source_metadata(request.document_source),
+                },
+                "featureType": feature,
+                "includeConfidence": request.options.include_confidence,
+                "languageCode": request.options.language,
+            },
+        }
+        for feature in request.features
+    ]
+
+
+def classification_config(request: ClassificationRequest, config: OciDocumentUnderstandingConfig) -> dict[str, Any]:
+    """Builds sanitized OCI request metadata for classification."""
+    return {
+        "operationName": "AnalyzeDocument",
+        "parameters": {
+            "compartmentId": config.default_compartment_id,
+            "document": {
+                **_source_metadata(request.document_source),
+            },
+            "featureType": "DOCUMENT_CLASSIFICATION",
+            "languageCode": request.options.language,
+            "documentTypeHint": request.document_type_hint,
+            "confidenceThreshold": request.options.confidence_threshold,
+        },
+    }
+
+
+def _source_metadata(source: DocumentSource) -> dict[str, Any]:
+    """Builds sanitized metadata for inline and Object Storage document sources."""
+    if source.source_type == "INLINE_BASE64":
+        return {
+            "sourceType": "INLINE_BASE64",
+            "content": "<redacted>",
+            "contentLength": len(source.document or ""),
+            "mimeType": source.mime_type,
+            "pageRange": source.page_range,
+        }
+
+    return {
+        "sourceType": "OBJECT_STORAGE",
+        "namespaceName": source.namespace_name,
+        "bucketName": source.bucket_name,
+        "objectName": source.object_name,
+        "pageRange": source.page_range,
+    }

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/response_filter.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/response_filter.py
@@ -1,0 +1,16 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from typing import Any
+
+
+def without_confidence(payload: Any) -> Any:
+    """Returns a copy of a provider payload with all confidence fields removed."""
+    if isinstance(payload, dict):
+        return {key: without_confidence(value) for key, value in payload.items() if key != "confidence"}
+    if isinstance(payload, list):
+        return [without_confidence(value) for value in payload]
+    return payload

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/sdk_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/sdk_provider.py
@@ -1,0 +1,158 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+
+from oracle.oci_document_understanding_mcp_server import __project__, __version__
+from oracle.oci_document_understanding_mcp_server.models import ClassificationRequest, DocumentSource, ExtractionRequest, RawOciDocumentResult
+from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
+from oracle.oci_document_understanding_mcp_server.oci.request_mapper import classification_config, extraction_configs
+
+_user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
+_ADDITIONAL_UA = f"{_user_agent_name}/{__version__}"
+
+
+class OciSdkDocumentUnderstandingProvider:
+    """OCI SDK-backed provider for local and production calls."""
+
+    def __init__(self, config: OciDocumentUnderstandingConfig) -> None:
+        self.config = config
+        self.oci, self.client = self._create_client()
+
+    def extract(self, request: ExtractionRequest) -> RawOciDocumentResult:
+        """Submits an extraction request to OCI Document Understanding."""
+        response = self._analyze_document(request, operation="extract", feature_types=request.features)
+        payload = self._response_to_payload(response)
+        payload.setdefault("provider", "oci-sdk")
+        payload.setdefault("requestConfigs", extraction_configs(request, self.config))
+        return RawOciDocumentResult(
+            request_id=self._request_id(response),
+            operation="extract",
+            received_at=datetime.now(timezone.utc),
+            payload=payload,
+        )
+
+    def classify(self, request: ClassificationRequest) -> RawOciDocumentResult:
+        """Submits a classification request to OCI Document Understanding."""
+        response = self._analyze_document(request, operation="classify", feature_types=["DOCUMENT_CLASSIFICATION"])
+        payload = self._response_to_payload(response)
+        payload.setdefault("provider", "oci-sdk")
+        payload.setdefault("requestConfig", classification_config(request, self.config))
+        return RawOciDocumentResult(
+            request_id=self._request_id(response),
+            operation="classify",
+            received_at=datetime.now(timezone.utc),
+            payload=payload,
+        )
+
+    def _create_client(self) -> tuple[Any, Any]:
+        """Initializes the OCI Python SDK client for the configured auth mode."""
+        try:
+            import oci
+        except ImportError as exc:
+            raise RuntimeError("oci Python SDK is required for local/prod modes. Install with: pip install -e .") from exc
+
+        if self.config.auth_mode == "instance-principal":
+            signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+            client_config = {
+                "region": self.config.region,
+                "additional_user_agent": _ADDITIONAL_UA,
+            }
+            client = oci.ai_document.AIServiceDocumentClient(client_config, signer=signer)
+        elif self.config.auth_mode == "session-token":
+            client_config = oci.config.from_file(self.config.config_file_path or oci.config.DEFAULT_LOCATION, self.config.profile)
+            client_config["additional_user_agent"] = _ADDITIONAL_UA
+            token_file = client_config.get("security_token_file")
+            if not token_file:
+                raise RuntimeError("session-token auth requires security_token_file in the OCI config profile")
+            with open(token_file, encoding="utf-8") as token:
+                security_token = token.read()
+            private_key = oci.signer.load_private_key_from_file(client_config["key_file"])
+            signer = oci.auth.signers.SecurityTokenSigner(security_token, private_key)
+            client = oci.ai_document.AIServiceDocumentClient(client_config, signer=signer)
+        elif self.config.auth_mode == "api-key":
+            client_config = oci.config.from_file(self.config.config_file_path or oci.config.DEFAULT_LOCATION, self.config.profile)
+            client_config["additional_user_agent"] = _ADDITIONAL_UA
+            client = oci.ai_document.AIServiceDocumentClient(client_config)
+        else:
+            raise RuntimeError(f"Unsupported OCI auth mode for SDK provider: {self.config.auth_mode}")
+
+        if self.config.endpoint:
+            client.base_client.set_endpoint(self.config.endpoint)
+        return oci, client
+
+    def _analyze_document(self, request: ExtractionRequest | ClassificationRequest, operation: str, feature_types: list[str]) -> Any:
+        """Builds an OCI AnalyzeDocument request and sends it with the SDK client."""
+        details = self._build_analyze_document_details(request, operation, feature_types)
+        return self.client.analyze_document(analyze_document_details=details)
+
+    def _build_analyze_document_details(self, request: ExtractionRequest | ClassificationRequest, operation: str, feature_types: list[str]) -> Any:
+        """Creates SDK model objects for AnalyzeDocument."""
+        if not self.config.default_compartment_id:
+            raise RuntimeError("OCI_COMPARTMENT_ID is required for OCI Document Understanding requests")
+        models = self.oci.ai_document.models
+        document = self._document_model(request.document_source)
+        features = [self._feature_model(feature_type) for feature_type in feature_types]
+
+        kwargs: dict[str, Any] = {
+            "compartment_id": self.config.default_compartment_id,
+            "document": document,
+            "features": features,
+        }
+        language = request.options.language
+        if language:
+            kwargs["language"] = language
+
+        if operation == "classify" and isinstance(request, ClassificationRequest) and request.document_type_hint:
+            kwargs["document_type"] = request.document_type_hint
+
+        return models.AnalyzeDocumentDetails(**kwargs)
+
+    def _document_model(self, source: DocumentSource) -> Any:
+        """Maps the normalized document source to the OCI SDK document model."""
+        models = self.oci.ai_document.models
+        page_range = source.page_range
+
+        if source.source_type == "INLINE_BASE64":
+            kwargs: dict[str, Any] = {"data": source.document}
+            if page_range:
+                kwargs["page_range"] = page_range
+            return models.InlineDocumentDetails(**kwargs)
+
+        kwargs = {
+            "namespace_name": source.namespace_name,
+            "bucket_name": source.bucket_name,
+            "object_name": source.object_name,
+        }
+        if page_range:
+            kwargs["page_range"] = page_range
+        return models.ObjectStorageDocumentDetails(**kwargs)
+
+    def _feature_model(self, feature_type: str) -> Any:
+        """Maps public feature names to OCI SDK feature model objects."""
+        models = self.oci.ai_document.models
+        return {
+            "TEXT": models.DocumentTextExtractionFeature,
+            "KEY_VALUE": models.DocumentKeyValueExtractionFeature,
+            "TABLE": models.DocumentTableExtractionFeature,
+            "ELEMENT": models.DocumentElementsExtractionFeature,
+            "DOCUMENT_CLASSIFICATION": models.DocumentClassificationFeature,
+        }[feature_type]()
+
+    def _response_to_payload(self, response: Any) -> dict[str, Any]:
+        """Converts the SDK response object into a JSON-ready payload."""
+        data = getattr(response, "data", response)
+        if hasattr(data, "to_dict"):
+            return data.to_dict()
+        if isinstance(data, dict):
+            return data
+        return {"raw": str(data)}
+
+    def _request_id(self, response: Any) -> str:
+        """Extracts the OCI request id used as job_id in the MCP response."""
+        headers = getattr(response, "headers", {}) or {}
+        return headers.get("opc-request-id") or headers.get("Opc-Request-Id") or "unknown"

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/sdk_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/sdk_provider.py
@@ -7,10 +7,13 @@ https://oss.oracle.com/licenses/upl.
 from datetime import datetime, timezone
 from typing import Any
 
+from oracle_mcp_common import AuthOptions, build_auth_context
+
 from oracle.oci_document_understanding_mcp_server import __project__, __version__
 from oracle.oci_document_understanding_mcp_server.models import ClassificationRequest, DocumentSource, ExtractionRequest, RawOciDocumentResult
 from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
 from oracle.oci_document_understanding_mcp_server.oci.request_mapper import classification_config, extraction_configs
+from oracle.oci_document_understanding_mcp_server.oci.response_filter import without_confidence
 
 _user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
 _ADDITIONAL_UA = f"{_user_agent_name}/{__version__}"
@@ -27,6 +30,8 @@ class OciSdkDocumentUnderstandingProvider:
         """Submits an extraction request to OCI Document Understanding."""
         response = self._analyze_document(request, operation="extract", feature_types=request.features)
         payload = self._response_to_payload(response)
+        if not request.options.include_confidence:
+            payload = without_confidence(payload)
         payload.setdefault("provider", "oci-sdk")
         payload.setdefault("requestConfigs", extraction_configs(request, self.config))
         return RawOciDocumentResult(
@@ -56,30 +61,18 @@ class OciSdkDocumentUnderstandingProvider:
         except ImportError as exc:
             raise RuntimeError("oci Python SDK is required for local/prod modes. Install with: pip install -e .") from exc
 
-        if self.config.auth_mode == "instance-principal":
-            signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
-            client_config = {
-                "region": self.config.region,
-                "additional_user_agent": _ADDITIONAL_UA,
-            }
-            client = oci.ai_document.AIServiceDocumentClient(client_config, signer=signer)
-        elif self.config.auth_mode == "session-token":
-            client_config = oci.config.from_file(self.config.config_file_path or oci.config.DEFAULT_LOCATION, self.config.profile)
-            client_config["additional_user_agent"] = _ADDITIONAL_UA
-            token_file = client_config.get("security_token_file")
-            if not token_file:
-                raise RuntimeError("session-token auth requires security_token_file in the OCI config profile")
-            with open(token_file, encoding="utf-8") as token:
-                security_token = token.read()
-            private_key = oci.signer.load_private_key_from_file(client_config["key_file"])
-            signer = oci.auth.signers.SecurityTokenSigner(security_token, private_key)
-            client = oci.ai_document.AIServiceDocumentClient(client_config, signer=signer)
-        elif self.config.auth_mode == "api-key":
-            client_config = oci.config.from_file(self.config.config_file_path or oci.config.DEFAULT_LOCATION, self.config.profile)
-            client_config["additional_user_agent"] = _ADDITIONAL_UA
-            client = oci.ai_document.AIServiceDocumentClient(client_config)
-        else:
-            raise RuntimeError(f"Unsupported OCI auth mode for SDK provider: {self.config.auth_mode}")
+        auth_context = build_auth_context(
+            AuthOptions(
+                auth_type=self.config.auth_mode,
+                config_file=self.config.config_file_path,
+                profile_name=self.config.profile,
+            )
+        )
+        client_config = {**auth_context.config, "additional_user_agent": _ADDITIONAL_UA}
+        # oracle-mcp-common resolves OCI_REGION, then the profile or signer
+        # region. Preserve this server's documented IAD value only as a final fallback.
+        client_config.setdefault("region", self.config.region)
+        client = oci.ai_document.AIServiceDocumentClient(client_config, signer=auth_context.signer)
 
         if self.config.endpoint:
             client.base_client.set_endpoint(self.config.endpoint)

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/sdk_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/sdk_provider.py
@@ -5,6 +5,7 @@ https://oss.oracle.com/licenses/upl.
 """
 
 from datetime import datetime, timezone
+import logging
 from typing import Any
 
 from oracle_mcp_common import AuthOptions, build_auth_context
@@ -17,6 +18,7 @@ from oracle.oci_document_understanding_mcp_server.oci.response_filter import wit
 
 _user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
 _ADDITIONAL_UA = f"{_user_agent_name}/{__version__}"
+logger = logging.getLogger(__name__)
 
 
 class OciSdkDocumentUnderstandingProvider:
@@ -47,6 +49,7 @@ class OciSdkDocumentUnderstandingProvider:
         payload = self._response_to_payload(response)
         payload.setdefault("provider", "oci-sdk")
         payload.setdefault("requestConfig", classification_config(request, self.config))
+        payload.setdefault("confidenceThreshold", request.options.confidence_threshold)
         return RawOciDocumentResult(
             request_id=self._request_id(response),
             operation="classify",
@@ -72,10 +75,16 @@ class OciSdkDocumentUnderstandingProvider:
         # oracle-mcp-common resolves OCI_REGION, then the profile or signer
         # region. Preserve this server's documented IAD value only as a final fallback.
         client_config.setdefault("region", self.config.region)
-        client = oci.ai_document.AIServiceDocumentClient(client_config, signer=auth_context.signer)
-
+        client = oci.ai_document.AIServiceDocumentClient(
+            client_config,
+            signer=auth_context.signer,
+            retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY,
+            circuit_breaker_strategy=oci.circuit_breaker.CircuitBreakerStrategy(),
+            circuit_breaker_callback=lambda error: logger.warning("OCI Document Understanding circuit breaker triggered: %s", error),
+        )
         if self.config.endpoint:
             client.base_client.set_endpoint(self.config.endpoint)
+
         return oci, client
 
     def _analyze_document(self, request: ExtractionRequest | ClassificationRequest, operation: str, feature_types: list[str]) -> Any:
@@ -139,10 +148,11 @@ class OciSdkDocumentUnderstandingProvider:
     def _response_to_payload(self, response: Any) -> dict[str, Any]:
         """Converts the SDK response object into a JSON-ready payload."""
         data = getattr(response, "data", response)
-        if hasattr(data, "to_dict"):
-            return data.to_dict()
         if isinstance(data, dict):
             return data
+        serialized = self.oci.util.to_dict(data)
+        if isinstance(serialized, dict):
+            return serialized
         return {"raw": str(data)}
 
     def _request_id(self, response: Any) -> str:

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/sdk_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/sdk_provider.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 import logging
 from typing import Any
 
-from oracle_mcp_common import AuthOptions, build_auth_context
+from oracle_mcp_common import build_auth_context
 
 from oracle.oci_document_understanding_mcp_server import __project__, __version__
 from oracle.oci_document_understanding_mcp_server.models import ClassificationRequest, DocumentSource, ExtractionRequest, RawOciDocumentResult
@@ -62,19 +62,12 @@ class OciSdkDocumentUnderstandingProvider:
         try:
             import oci
         except ImportError as exc:
-            raise RuntimeError("oci Python SDK is required for local/prod modes. Install with: pip install -e .") from exc
+            raise RuntimeError("oci Python SDK is required for OCI mode. Install with: pip install -e .") from exc
 
-        auth_context = build_auth_context(
-            AuthOptions(
-                auth_type=self.config.auth_mode,
-                config_file=self.config.config_file_path,
-                profile_name=self.config.profile,
-            )
-        )
+        auth_context = build_auth_context()
+        if not auth_context.region:
+            raise RuntimeError("OCI region is required. Set OCI_REGION or configure a region in the selected OCI profile.")
         client_config = {**auth_context.config, "additional_user_agent": _ADDITIONAL_UA}
-        # oracle-mcp-common resolves OCI_REGION, then the profile or signer
-        # region. Preserve this server's documented IAD value only as a final fallback.
-        client_config.setdefault("region", self.config.region)
         client = oci.ai_document.AIServiceDocumentClient(
             client_config,
             signer=auth_context.signer,
@@ -82,9 +75,6 @@ class OciSdkDocumentUnderstandingProvider:
             circuit_breaker_strategy=oci.circuit_breaker.CircuitBreakerStrategy(),
             circuit_breaker_callback=lambda error: logger.warning("OCI Document Understanding circuit breaker triggered: %s", error),
         )
-        if self.config.endpoint:
-            client.base_client.set_endpoint(self.config.endpoint)
-
         return oci, client
 
     def _analyze_document(self, request: ExtractionRequest | ClassificationRequest, operation: str, feature_types: list[str]) -> Any:

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/stub_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/stub_provider.py
@@ -1,0 +1,79 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from oracle.oci_document_understanding_mcp_server.models import ClassificationRequest, ExtractionRequest, RawOciDocumentResult
+from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
+from oracle.oci_document_understanding_mcp_server.oci.request_mapper import classification_config, extraction_configs
+
+
+class StubOciDocumentUnderstandingProvider:
+    """Deterministic provider for smoke tests and local MCP flow debugging."""
+
+    def __init__(self, config: OciDocumentUnderstandingConfig) -> None:
+        self.config = config
+
+    def extract(self, request: ExtractionRequest) -> RawOciDocumentResult:
+        """Returns fake extraction output shaped like the real provider payload."""
+        payload: dict[str, Any] = {
+            "provider": "stub",
+            "region": self.config.region,
+            "requestConfigs": extraction_configs(request, self.config),
+            "includeConfidence": request.options.include_confidence,
+        }
+        if "TEXT" in request.features:
+            payload["text"] = "Sample extracted text from OCI Document Understanding."
+        if "KEY_VALUE" in request.features:
+            payload["keyValues"] = [
+                {"key": "InvoiceNumber", "value": "INV-001", "confidence": 0.98},
+                {"key": "TotalAmount", "value": "1250.00", "confidence": 0.95},
+            ]
+        if "TABLE" in request.features:
+            payload["tables"] = [
+                {
+                    "headers": ["Item", "Quantity", "Amount"],
+                    "rows": [["Consulting", "10", "1000.00"], ["Support", "5", "250.00"]],
+                    "confidence": 0.93,
+                }
+            ]
+        if "ELEMENT" in request.features:
+            payload["elements"] = [
+                {"type": "TITLE", "text": "Invoice", "page": 1, "confidence": 0.99},
+                {"type": "PARAGRAPH", "text": "Sample extracted text from OCI Document Understanding.", "page": 1, "confidence": 0.94},
+            ]
+        return RawOciDocumentResult(
+            request_id=str(uuid4()),
+            operation="extract",
+            received_at=datetime.now(timezone.utc),
+            payload=payload,
+        )
+
+    def classify(self, request: ClassificationRequest) -> RawOciDocumentResult:
+        """Returns fake classification output shaped like the real provider payload."""
+        payload: dict[str, Any] = {
+            "provider": "stub",
+            "region": self.config.region,
+            "requestConfig": classification_config(request, self.config),
+            "documentTypeHint": request.document_type_hint,
+            "documentType": "INVOICE",
+            "confidence": 0.97,
+            "classifications": [
+                {"label": "INVOICE", "confidence": 0.97},
+                {"label": "RECEIPT", "confidence": 0.02},
+                {"label": "CONTRACT", "confidence": 0.01},
+            ],
+        }
+        if request.options.confidence_threshold is not None:
+            payload["confidenceThreshold"] = request.options.confidence_threshold
+        return RawOciDocumentResult(
+            request_id=str(uuid4()),
+            operation="classify",
+            received_at=datetime.now(timezone.utc),
+            payload=payload,
+        )

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/stub_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/stub_provider.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 from oracle.oci_document_understanding_mcp_server.models import ClassificationRequest, ExtractionRequest, RawOciDocumentResult
 from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
 from oracle.oci_document_understanding_mcp_server.oci.request_mapper import classification_config, extraction_configs
+from oracle.oci_document_understanding_mcp_server.oci.response_filter import without_confidence
 
 
 class StubOciDocumentUnderstandingProvider:
@@ -47,6 +48,8 @@ class StubOciDocumentUnderstandingProvider:
                 {"type": "TITLE", "text": "Invoice", "page": 1, "confidence": 0.99},
                 {"type": "PARAGRAPH", "text": "Sample extracted text from OCI Document Understanding.", "page": 1, "confidence": 0.94},
             ]
+        if not request.options.include_confidence:
+            payload = without_confidence(payload)
         return RawOciDocumentResult(
             request_id=str(uuid4()),
             operation="extract",

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/stub_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/oci/stub_provider.py
@@ -24,7 +24,6 @@ class StubOciDocumentUnderstandingProvider:
         """Returns fake extraction output shaped like the real provider payload."""
         payload: dict[str, Any] = {
             "provider": "stub",
-            "region": self.config.region,
             "requestConfigs": extraction_configs(request, self.config),
             "includeConfidence": request.options.include_confidence,
         }
@@ -61,7 +60,6 @@ class StubOciDocumentUnderstandingProvider:
         """Returns fake classification output shaped like the real provider payload."""
         payload: dict[str, Any] = {
             "provider": "stub",
-            "region": self.config.region,
             "requestConfig": classification_config(request, self.config),
             "documentTypeHint": request.document_type_hint,
             "documentType": "INVOICE",

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/parsers/classification.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/parsers/classification.py
@@ -1,0 +1,47 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from typing import Any
+
+from oracle.oci_document_understanding_mcp_server.models import RawOciDocumentResult
+
+
+class ClassificationOutputParser:
+    """Converts raw OCI classification output into structured MCP data."""
+
+    def parse(self, raw_result: RawOciDocumentResult) -> dict[str, Any]:
+        """Parses classification payload fields into the unified data shape."""
+        payload = raw_result.payload
+        classifications = payload.get("classifications") or payload.get("documentClassification") or []
+        return {
+            "documentType": payload.get("documentType") or self._top_label(classifications),
+            "confidence": payload.get("confidence") or self._top_confidence(classifications),
+            "classifications": classifications,
+            "metadata": {
+                "requestId": raw_result.request_id,
+                "operation": raw_result.operation,
+                "receivedAt": raw_result.received_at.isoformat().replace("+00:00", "Z"),
+                "provider": payload.get("provider", "oci-sdk"),
+                "requestConfig": payload.get("requestConfig", {}),
+            },
+        }
+
+    def _top_label(self, classifications: Any) -> str | None:
+        """Returns the highest-ranked classification label if present."""
+        if isinstance(classifications, list) and classifications:
+            first = classifications[0]
+            if isinstance(first, dict):
+                return first.get("label") or first.get("documentType")
+        return None
+
+    def _top_confidence(self, classifications: Any) -> float | None:
+        """Returns the highest-ranked classification confidence if present."""
+        if isinstance(classifications, list) and classifications:
+            first = classifications[0]
+            if isinstance(first, dict):
+                return first.get("confidence")
+        return None
+

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/parsers/classification.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/parsers/classification.py
@@ -15,10 +15,18 @@ class ClassificationOutputParser:
     def parse(self, raw_result: RawOciDocumentResult) -> dict[str, Any]:
         """Parses classification payload fields into the unified data shape."""
         payload = raw_result.payload
-        classifications = payload.get("classifications") or payload.get("documentClassification") or []
+        classifications = self._classifications(payload)
+        threshold = payload.get("confidenceThreshold")
+        if isinstance(threshold, (int, float)):
+            classifications = [
+                classification
+                for classification in classifications
+                if isinstance(classification.get("confidence"), (int, float))
+                and classification["confidence"] >= threshold
+            ]
         return {
-            "documentType": payload.get("documentType") or self._top_label(classifications),
-            "confidence": payload.get("confidence") or self._top_confidence(classifications),
+            "documentType": self._top_label(classifications),
+            "confidence": self._top_confidence(classifications),
             "classifications": classifications,
             "metadata": {
                 "requestId": raw_result.request_id,
@@ -28,6 +36,31 @@ class ClassificationOutputParser:
                 "requestConfig": payload.get("requestConfig", {}),
             },
         }
+
+    def _classifications(self, payload: dict[str, Any]) -> list[dict[str, Any]]:
+        """Normalizes stub and OCI SDK classification result shapes."""
+        values = payload.get("classifications") or payload.get("documentClassification")
+        if values is None:
+            values = payload.get("detected_document_types") or self._page_document_types(payload)
+        if not isinstance(values, list):
+            return []
+        return [
+            {
+                **value,
+                "label": value.get("label") or value.get("documentType") or value.get("document_type"),
+                "confidence": value.get("confidence"),
+            }
+            for value in values
+            if isinstance(value, dict)
+        ]
+
+    def _page_document_types(self, payload: dict[str, Any]) -> list[dict[str, Any]]:
+        """Collects document types returned per page when no document-level list exists."""
+        values: list[dict[str, Any]] = []
+        for page in payload.get("pages") or []:
+            if isinstance(page, dict):
+                values.extend(value for value in page.get("detected_document_types") or [] if isinstance(value, dict))
+        return values
 
     def _top_label(self, classifications: Any) -> str | None:
         """Returns the highest-ranked classification label if present."""
@@ -44,4 +77,3 @@ class ClassificationOutputParser:
             if isinstance(first, dict):
                 return first.get("confidence")
         return None
-

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/parsers/extraction.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/parsers/extraction.py
@@ -1,0 +1,44 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from typing import Any
+
+from oracle.oci_document_understanding_mcp_server.models import RawOciDocumentResult
+
+
+class ExtractionOutputParser:
+    """Converts raw OCI extraction output into structured MCP data."""
+
+    def parse(self, raw_result: RawOciDocumentResult) -> dict[str, Any]:
+        """Parses extraction payload fields into the unified data shape."""
+        payload = raw_result.payload
+        return {
+            "text": payload.get("text") or payload.get("extractedText") or self._text_from_pages(payload),
+            "keyValues": payload.get("keyValues") or payload.get("key_value_fields") or [],
+            "tables": payload.get("tables") or [],
+            "elements": payload.get("elements") or [],
+            "metadata": {
+                "requestId": raw_result.request_id,
+                "operation": raw_result.operation,
+                "receivedAt": raw_result.received_at.isoformat().replace("+00:00", "Z"),
+                "provider": payload.get("provider", "oci-sdk"),
+                "requestConfigs": payload.get("requestConfigs", []),
+            },
+        }
+
+    def _text_from_pages(self, payload: dict[str, Any]) -> str:
+        """Best-effort text extraction from page-oriented SDK dictionaries."""
+        pages = payload.get("pages")
+        if not isinstance(pages, list):
+            return ""
+        lines: list[str] = []
+        for page in pages:
+            if isinstance(page, dict):
+                for line in page.get("lines", []) or []:
+                    if isinstance(line, dict) and isinstance(line.get("text"), str):
+                        lines.append(line["text"])
+        return "\n".join(lines)
+

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/parsers/extraction.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/parsers/extraction.py
@@ -17,9 +17,9 @@ class ExtractionOutputParser:
         payload = raw_result.payload
         return {
             "text": payload.get("text") or payload.get("extractedText") or self._text_from_pages(payload),
-            "keyValues": payload.get("keyValues") or payload.get("key_value_fields") or [],
-            "tables": payload.get("tables") or [],
-            "elements": payload.get("elements") or [],
+            "keyValues": payload.get("keyValues") or payload.get("key_value_fields") or self._page_values(payload, "document_fields"),
+            "tables": payload.get("tables") or self._page_values(payload, "tables"),
+            "elements": payload.get("elements") or self._elements_from_pages(payload),
             "metadata": {
                 "requestId": raw_result.request_id,
                 "operation": raw_result.operation,
@@ -42,3 +42,29 @@ class ExtractionOutputParser:
                         lines.append(line["text"])
         return "\n".join(lines)
 
+    def _page_values(self, payload: dict[str, Any], name: str) -> list[dict[str, Any]]:
+        """Flattens an OCI SDK page-level collection into the public result."""
+        values: list[dict[str, Any]] = []
+        for page in payload.get("pages") or []:
+            if not isinstance(page, dict):
+                continue
+            for value in page.get(name) or []:
+                if isinstance(value, dict):
+                    values.append(value)
+        return values
+
+    def _elements_from_pages(self, payload: dict[str, Any]) -> list[dict[str, Any]]:
+        """Maps OCI page-level document elements into a single public collection."""
+        elements: list[dict[str, Any]] = []
+        for page in payload.get("pages") or []:
+            if not isinstance(page, dict):
+                continue
+            for source_name, element_type in (
+                ("bar_codes", "BAR_CODE"),
+                ("signatures", "SIGNATURE"),
+                ("selection_marks", "SELECTION_MARK"),
+            ):
+                for value in page.get(source_name) or []:
+                    if isinstance(value, dict):
+                        elements.append({"type": element_type, "page": page.get("page_number"), **value})
+        return elements

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/response.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/response.py
@@ -1,0 +1,35 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+import json
+from typing import Any
+
+
+def successful_envelope(job_id: str, document_id: str, data: dict[str, Any]) -> dict[str, Any]:
+    """Returns the structured response envelope used by Document MCP tools."""
+    return {
+        "status": "Successful",
+        "job_id": job_id,
+        "document_id": document_id,
+        "data": data,
+        "metadata": data.get("metadata", {}),
+    }
+
+
+def failed_envelope(message: str) -> dict[str, Any]:
+    """Returns the structured response envelope used for handled failures."""
+    return {
+        "status": "Failed",
+        "job_id": "",
+        "document_id": "",
+        "data": {"message": message},
+        "metadata": {},
+    }
+
+
+def to_text(data: dict[str, Any]) -> str:
+    """Serializes a response envelope to compact JSON for text-only clients."""
+    return json.dumps(data, separators=(",", ":"))

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/server.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/server.py
@@ -1,0 +1,119 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from typing import Any
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+from pydantic.fields import FieldInfo
+
+from oracle.oci_document_understanding_mcp_server import __project__, __version__
+from oracle.oci_document_understanding_mcp_server.handlers.classification import DocumentClassificationHandler
+from oracle.oci_document_understanding_mcp_server.handlers.extraction import DocumentExtractionHandler
+from oracle.oci_document_understanding_mcp_server.models import ClassificationOptions, DocumentSource, ExtractionOptions
+from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
+from oracle.oci_document_understanding_mcp_server.oci.provider import OciDocumentUnderstandingProvider, create_provider
+from oracle.oci_document_understanding_mcp_server.parsers.classification import ClassificationOutputParser
+from oracle.oci_document_understanding_mcp_server.parsers.extraction import ExtractionOutputParser
+
+mcp = FastMCP(name=__project__, version=__version__)
+
+_provider: OciDocumentUnderstandingProvider | None = None
+_extraction_handler: DocumentExtractionHandler | None = None
+_classification_handler: DocumentClassificationHandler | None = None
+
+
+def _get_provider() -> OciDocumentUnderstandingProvider:
+    """Creates the configured OCI provider once for this server process."""
+    global _provider
+    if _provider is None:
+        _provider = create_provider(OciDocumentUnderstandingConfig.from_environment())
+    return _provider
+
+
+def _get_extraction_handler() -> DocumentExtractionHandler:
+    """Creates the document extraction handler once for this server process."""
+    global _extraction_handler
+    if _extraction_handler is None:
+        _extraction_handler = DocumentExtractionHandler(_get_provider(), ExtractionOutputParser())
+    return _extraction_handler
+
+
+def _get_classification_handler() -> DocumentClassificationHandler:
+    """Creates the document classification handler once for this server process."""
+    global _classification_handler
+    if _classification_handler is None:
+        _classification_handler = DocumentClassificationHandler(_get_provider(), ClassificationOutputParser())
+    return _classification_handler
+
+
+def _model_dump(value: BaseModel | dict[str, Any] | FieldInfo | None) -> dict[str, Any] | None:
+    """Normalizes FastMCP/Pydantic inputs into the existing handler dictionary contract."""
+    if value is None or isinstance(value, FieldInfo):
+        return None
+    if isinstance(value, BaseModel):
+        return value.model_dump(exclude_none=True)
+    return value
+
+
+def _arguments(**kwargs: Any) -> dict[str, Any]:
+    """Drops omitted optional tool arguments before delegating to existing handlers."""
+    return {key: value for key, value in kwargs.items() if value is not None and not isinstance(value, FieldInfo)}
+
+
+@mcp.tool(name="document_extract")
+def document_extract(
+    features: list[str] = Field(..., description="Document extraction features to run: TEXT, KEY_VALUE, TABLE, or ELEMENT."),
+    document_source: DocumentSource | None = Field(
+        None,
+        description="Structured document source. Use INLINE_BASE64 for inline content or OBJECT_STORAGE for an OCI Object Storage object.",
+    ),
+    document: str | None = Field(None, description="Base64-encoded document content for backward-compatible inline input."),
+    mime_type: str | None = Field(None, description="MIME type for backward-compatible inline input, for example application/pdf."),
+    options: ExtractionOptions | None = Field(None, description="Optional extraction settings such as language and confidence output."),
+) -> dict[str, Any]:
+    """Extract text, key-value pairs, tables, and document elements from a document."""
+    return _get_extraction_handler().handle(
+        _arguments(
+            document_source=_model_dump(document_source),
+            document=document,
+            mime_type=mime_type,
+            features=features,
+            options=_model_dump(options),
+        )
+    )
+
+
+@mcp.tool(name="document_classify")
+def document_classify(
+    document_source: DocumentSource | None = Field(
+        None,
+        description="Structured document source. Use INLINE_BASE64 for inline content or OBJECT_STORAGE for an OCI Object Storage object.",
+    ),
+    document: str | None = Field(None, description="Base64-encoded document content for backward-compatible inline input."),
+    mime_type: str | None = Field(None, description="MIME type for backward-compatible inline input, for example application/pdf."),
+    options: ClassificationOptions | None = Field(None, description="Optional classification settings such as language and confidence threshold."),
+    document_type_hint: str | None = Field(None, description="Optional hint to guide classification, for example INVOICE or RECEIPT."),
+) -> dict[str, Any]:
+    """Classify a document and return candidate document classes with confidence."""
+    return _get_classification_handler().handle(
+        _arguments(
+            document_source=_model_dump(document_source),
+            document=document,
+            mime_type=mime_type,
+            options=_model_dump(options),
+            document_type_hint=document_type_hint,
+        )
+    )
+
+
+def main() -> None:
+    """Run the MCP server over stdio."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_config.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_config.py
@@ -1,0 +1,82 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+import pytest
+
+from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
+
+
+def test_config_defaults_to_local_session_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DOCUMENT_MCP_MODE", raising=False)
+    monkeypatch.delenv("OCI_AUTH_MODE", raising=False)
+    monkeypatch.delenv("OCI_COMPARTMENT_ID", raising=False)
+    monkeypatch.delenv("OCI_CONFIG_PROFILE", raising=False)
+
+    config = OciDocumentUnderstandingConfig.from_environment()
+
+    assert config.runtime_mode == "local"
+    assert config.auth_mode == "session-token"
+    assert config.region == "us-ashburn-1"
+    assert config.default_compartment_id is None
+    assert config.profile == "DEFAULT"
+
+
+def test_config_supports_stub_mode_and_config_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DOCUMENT_MCP_MODE", "test")
+    monkeypatch.delenv("OCI_AUTH_MODE", raising=False)
+    monkeypatch.setenv("OCI_REGION", "us-phoenix-1")
+    monkeypatch.setenv("OCI_COMPARTMENT_ID", "ocid1.compartment.oc1..example")
+    monkeypatch.setenv("OCI_CONFIG_PROFILE", "MYPROFILE")
+
+    config = OciDocumentUnderstandingConfig.from_environment()
+
+    assert config.runtime_mode == "stub"
+    assert config.auth_mode == "none"
+    assert config.region == "us-phoenix-1"
+    assert config.default_compartment_id == "ocid1.compartment.oc1..example"
+    assert config.profile == "MYPROFILE"
+
+
+@pytest.mark.parametrize("name", ["DOCUMENT_MCP_MODE", "OCI_AUTH_MODE"])
+def test_config_rejects_invalid_modes(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    monkeypatch.setenv(name, "bad-value")
+
+    with pytest.raises(ValueError, match="Unsupported"):
+        OciDocumentUnderstandingConfig.from_environment()
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_auth"),
+    [
+        ("production", "instance-principal"),
+        ("compute", "instance-principal"),
+        ("development", "session-token"),
+    ],
+)
+def test_config_runtime_mode_aliases_set_default_auth(monkeypatch: pytest.MonkeyPatch, mode: str, expected_auth: str) -> None:
+    monkeypatch.setenv("DOCUMENT_MCP_MODE", mode)
+    monkeypatch.delenv("OCI_AUTH_MODE", raising=False)
+
+    config = OciDocumentUnderstandingConfig.from_environment()
+
+    assert config.auth_mode == expected_auth
+
+
+@pytest.mark.parametrize(
+    ("auth", "expected"),
+    [
+        ("config-file", "api-key"),
+        ("prod", "instance-principal"),
+        ("stub", "none"),
+    ],
+)
+def test_config_auth_aliases(monkeypatch: pytest.MonkeyPatch, auth: str, expected: str) -> None:
+    monkeypatch.setenv("DOCUMENT_MCP_MODE", "local")
+    monkeypatch.setenv("OCI_AUTH_MODE", auth)
+
+    config = OciDocumentUnderstandingConfig.from_environment()
+
+    assert config.auth_mode == expected

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_config.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_config.py
@@ -9,77 +9,36 @@ import pytest
 from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
 
 
-def test_config_defaults_to_local_session_token(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_config_defaults_to_oci_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DOCUMENT_MCP_MODE", raising=False)
-    monkeypatch.delenv("OCI_AUTH_MODE", raising=False)
     monkeypatch.delenv("OCI_COMPARTMENT_ID", raising=False)
-    monkeypatch.delenv("OCI_CONFIG_PROFILE", raising=False)
 
     config = OciDocumentUnderstandingConfig.from_environment()
 
-    assert config.runtime_mode == "local"
-    assert config.auth_mode == "session-token"
-    assert config.region == "us-ashburn-1"
-    assert config.endpoint is None
+    assert config.runtime_mode == "oci"
     assert config.default_compartment_id is None
-    assert config.profile == "DEFAULT"
 
 
-def test_config_supports_stub_mode_and_config_profile(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("DOCUMENT_MCP_MODE", "test")
-    monkeypatch.delenv("OCI_AUTH_MODE", raising=False)
-    monkeypatch.setenv("OCI_REGION", "us-phoenix-1")
+def test_config_supports_stub_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DOCUMENT_MCP_MODE", "stub")
     monkeypatch.setenv("OCI_COMPARTMENT_ID", "ocid1.compartment.oc1..example")
-    monkeypatch.setenv("OCI_CONFIG_PROFILE", "MYPROFILE")
-    monkeypatch.setenv("OCI_DOCUMENT_ENDPOINT", "https://document.example.test")
 
     config = OciDocumentUnderstandingConfig.from_environment()
 
     assert config.runtime_mode == "stub"
-    assert config.auth_mode == "none"
-    assert config.region == "us-phoenix-1"
-    assert config.endpoint == "https://document.example.test"
     assert config.default_compartment_id == "ocid1.compartment.oc1..example"
-    assert config.profile == "MYPROFILE"
 
 
-@pytest.mark.parametrize("name", ["DOCUMENT_MCP_MODE", "OCI_AUTH_MODE"])
-def test_config_rejects_invalid_modes(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
-    monkeypatch.setenv(name, "bad-value")
+def test_config_rejects_invalid_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DOCUMENT_MCP_MODE", "bad-value")
 
     with pytest.raises(ValueError, match="Unsupported"):
         OciDocumentUnderstandingConfig.from_environment()
 
 
-@pytest.mark.parametrize(
-    ("mode", "expected_auth"),
-    [
-        ("production", "instance-principal"),
-        ("compute", "instance-principal"),
-        ("development", "session-token"),
-    ],
-)
-def test_config_runtime_mode_aliases_set_default_auth(monkeypatch: pytest.MonkeyPatch, mode: str, expected_auth: str) -> None:
+@pytest.mark.parametrize("mode", ["local", "dev", "prod", "production", "compute", "test", "mock"])
+def test_config_rejects_legacy_modes(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
     monkeypatch.setenv("DOCUMENT_MCP_MODE", mode)
-    monkeypatch.delenv("OCI_AUTH_MODE", raising=False)
 
-    config = OciDocumentUnderstandingConfig.from_environment()
-
-    assert config.auth_mode == expected_auth
-
-
-@pytest.mark.parametrize(
-    ("auth", "expected"),
-    [
-        ("config-file", "api-key"),
-        ("prod", "instance-principal"),
-        ("stub", "none"),
-    ],
-)
-def test_config_auth_aliases(monkeypatch: pytest.MonkeyPatch, auth: str, expected: str) -> None:
-    monkeypatch.setenv("DOCUMENT_MCP_MODE", "local")
-    monkeypatch.setenv("OCI_AUTH_MODE", auth)
-
-    config = OciDocumentUnderstandingConfig.from_environment()
-
-    assert config.auth_mode == expected
+    with pytest.raises(ValueError, match="Unsupported"):
+        OciDocumentUnderstandingConfig.from_environment()

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_config.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_config.py
@@ -20,6 +20,7 @@ def test_config_defaults_to_local_session_token(monkeypatch: pytest.MonkeyPatch)
     assert config.runtime_mode == "local"
     assert config.auth_mode == "session-token"
     assert config.region == "us-ashburn-1"
+    assert config.endpoint is None
     assert config.default_compartment_id is None
     assert config.profile == "DEFAULT"
 
@@ -30,12 +31,14 @@ def test_config_supports_stub_mode_and_config_profile(monkeypatch: pytest.Monkey
     monkeypatch.setenv("OCI_REGION", "us-phoenix-1")
     monkeypatch.setenv("OCI_COMPARTMENT_ID", "ocid1.compartment.oc1..example")
     monkeypatch.setenv("OCI_CONFIG_PROFILE", "MYPROFILE")
+    monkeypatch.setenv("OCI_DOCUMENT_ENDPOINT", "https://document.example.test")
 
     config = OciDocumentUnderstandingConfig.from_environment()
 
     assert config.runtime_mode == "stub"
     assert config.auth_mode == "none"
     assert config.region == "us-phoenix-1"
+    assert config.endpoint == "https://document.example.test"
     assert config.default_compartment_id == "ocid1.compartment.oc1..example"
     assert config.profile == "MYPROFILE"
 

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_fastmcp_server.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_fastmcp_server.py
@@ -1,0 +1,115 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+import asyncio
+
+from oracle.oci_document_understanding_mcp_server import __project__, __version__, server
+from oracle.oci_document_understanding_mcp_server.models import ClassificationOptions, DocumentSource, ExtractionOptions
+from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
+from oracle.oci_document_understanding_mcp_server.oci.stub_provider import StubOciDocumentUnderstandingProvider
+from oracle.oci_document_understanding_mcp_server.response import failed_envelope, successful_envelope, to_text
+
+
+def _stub_config() -> OciDocumentUnderstandingConfig:
+    return OciDocumentUnderstandingConfig(
+        runtime_mode="stub",
+        region="us-phoenix-1",
+        endpoint=None,
+        auth_mode="none",
+        default_compartment_id=None,
+        config_file_path=None,
+        profile="DEFAULT",
+    )
+
+
+def _reset_server() -> None:
+    server._provider = None
+    server._extraction_handler = None
+    server._classification_handler = None
+
+
+def test_fastmcp_server_registers_document_tools() -> None:
+    tools = asyncio.run(server.mcp.list_tools())
+
+    assert server.mcp.name == __project__
+    assert server.mcp.version == __version__
+    assert [tool.name for tool in tools] == ["document_extract", "document_classify"]
+    assert tools[0].parameters["required"] == ["features"]
+    assert "document_source" in tools[0].parameters["properties"]
+
+
+def test_fastmcp_call_tool_preserves_success_response_shape(monkeypatch) -> None:
+    _reset_server()
+    monkeypatch.setattr(server, "create_provider", lambda config: StubOciDocumentUnderstandingProvider(config))
+    monkeypatch.setattr(server.OciDocumentUnderstandingConfig, "from_environment", staticmethod(_stub_config))
+
+    result = asyncio.run(
+        server.mcp.call_tool(
+            "document_extract",
+            {
+                "document": "SGVsbG8=",
+                "mime_type": "application/pdf",
+                "features": ["TEXT", "KEY_VALUE"],
+                "options": {"language": "en", "include_confidence": True},
+            },
+        )
+    )
+
+    assert result.is_error is False
+    assert result.structured_content["status"] == "Successful"
+    assert result.structured_content["data"]["text"] == "Sample extracted text from OCI Document Understanding."
+    assert result.structured_content["data"]["metadata"]["requestConfigs"][0]["parameters"]["languageCode"] == "en"
+
+
+def test_direct_tool_functions_preserve_legacy_and_structured_inputs(monkeypatch) -> None:
+    _reset_server()
+    monkeypatch.setattr(server, "create_provider", lambda config: StubOciDocumentUnderstandingProvider(config))
+    monkeypatch.setattr(server.OciDocumentUnderstandingConfig, "from_environment", staticmethod(_stub_config))
+
+    extraction = server.document_extract(
+        document="SGVsbG8=",
+        mime_type="application/pdf",
+        features=["text"],
+        options=ExtractionOptions(language="en", include_confidence=True),
+    )
+    classification = server.document_classify(
+        document_source=DocumentSource(
+            source_type="OBJECT_STORAGE",
+            namespace_name="ns",
+            bucket_name="bucket",
+            object_name="invoice.pdf",
+        ),
+        options=ClassificationOptions(language="en", confidence_threshold=0.2),
+        document_type_hint="invoice",
+    )
+
+    assert extraction["status"] == "Successful"
+    assert extraction["data"]["metadata"]["requestConfigs"][0]["parameters"]["featureType"] == "TEXT"
+    assert classification["status"] == "Successful"
+    assert classification["data"]["documentType"] == "INVOICE"
+    assert classification["data"]["metadata"]["requestConfig"]["parameters"]["documentTypeHint"] == "INVOICE"
+
+
+def test_main_runs_fastmcp_stdio(monkeypatch) -> None:
+    called = {}
+
+    def fake_run() -> None:
+        called["run"] = True
+
+    monkeypatch.setattr(server.mcp, "run", fake_run)
+
+    server.main()
+
+    assert called == {"run": True}
+
+
+def test_response_helpers() -> None:
+    success = successful_envelope("job", "doc", {"value": 1, "metadata": {"a": "b"}})
+    failure = failed_envelope("bad")
+
+    assert success["metadata"] == {"a": "b"}
+    assert failure["status"] == "Failed"
+    assert '"status":"Successful"' in to_text(success)

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_fastmcp_server.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_fastmcp_server.py
@@ -84,6 +84,26 @@ def test_fastmcp_extract_omits_confidence_when_requested(monkeypatch) -> None:
     assert "confidence" not in str(result.structured_content["data"])
 
 
+def test_fastmcp_classify_applies_confidence_threshold(monkeypatch) -> None:
+    _reset_server()
+    monkeypatch.setattr(server, "create_provider", lambda config: StubOciDocumentUnderstandingProvider(config))
+    monkeypatch.setattr(server.OciDocumentUnderstandingConfig, "from_environment", staticmethod(_stub_config))
+
+    result = asyncio.run(
+        server.mcp.call_tool(
+            "document_classify",
+            {
+                "document": "SGVsbG8=",
+                "mime_type": "application/pdf",
+                "options": {"confidence_threshold": 0.5},
+            },
+        )
+    )
+
+    assert result.structured_content["data"]["classifications"] == [{"label": "INVOICE", "confidence": 0.97}]
+    assert result.structured_content["data"]["documentType"] == "INVOICE"
+
+
 def test_direct_tool_functions_preserve_legacy_and_structured_inputs(monkeypatch) -> None:
     _reset_server()
     monkeypatch.setattr(server, "create_provider", lambda config: StubOciDocumentUnderstandingProvider(config))

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_fastmcp_server.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_fastmcp_server.py
@@ -16,12 +16,7 @@ from oracle.oci_document_understanding_mcp_server.response import failed_envelop
 def _stub_config() -> OciDocumentUnderstandingConfig:
     return OciDocumentUnderstandingConfig(
         runtime_mode="stub",
-        region="us-phoenix-1",
-        endpoint=None,
-        auth_mode="none",
         default_compartment_id=None,
-        config_file_path=None,
-        profile="DEFAULT",
     )
 
 

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_fastmcp_server.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_fastmcp_server.py
@@ -64,6 +64,26 @@ def test_fastmcp_call_tool_preserves_success_response_shape(monkeypatch) -> None
     assert result.structured_content["data"]["metadata"]["requestConfigs"][0]["parameters"]["languageCode"] == "en"
 
 
+def test_fastmcp_extract_omits_confidence_when_requested(monkeypatch) -> None:
+    _reset_server()
+    monkeypatch.setattr(server, "create_provider", lambda config: StubOciDocumentUnderstandingProvider(config))
+    monkeypatch.setattr(server.OciDocumentUnderstandingConfig, "from_environment", staticmethod(_stub_config))
+
+    result = asyncio.run(
+        server.mcp.call_tool(
+            "document_extract",
+            {
+                "document": "SGVsbG8=",
+                "mime_type": "application/pdf",
+                "features": ["KEY_VALUE", "TABLE", "ELEMENT"],
+                "options": {"include_confidence": False},
+            },
+        )
+    )
+
+    assert "confidence" not in str(result.structured_content["data"])
+
+
 def test_direct_tool_functions_preserve_legacy_and_structured_inputs(monkeypatch) -> None:
     _reset_server()
     monkeypatch.setattr(server, "create_provider", lambda config: StubOciDocumentUnderstandingProvider(config))

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_handlers.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_handlers.py
@@ -1,0 +1,95 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from oracle.oci_document_understanding_mcp_server.handlers.classification import DocumentClassificationHandler
+from oracle.oci_document_understanding_mcp_server.handlers.extraction import DocumentExtractionHandler
+from oracle.oci_document_understanding_mcp_server.models import ClassificationRequest, ExtractionRequest, RawOciDocumentResult
+from oracle.oci_document_understanding_mcp_server.parsers.classification import ClassificationOutputParser
+from oracle.oci_document_understanding_mcp_server.parsers.extraction import ExtractionOutputParser
+
+
+class FakeProvider:
+    def __init__(self) -> None:
+        self.extraction_request: ExtractionRequest | None = None
+        self.classification_request: ClassificationRequest | None = None
+
+    def extract(self, request: ExtractionRequest) -> RawOciDocumentResult:
+        self.extraction_request = request
+        return RawOciDocumentResult(
+            request_id="req-extract",
+            operation="extract",
+            received_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            payload={"text": "hello", "keyValues": [{"key": "A", "value": "B"}]},
+        )
+
+    def classify(self, request: ClassificationRequest) -> RawOciDocumentResult:
+        self.classification_request = request
+        return RawOciDocumentResult(
+            request_id="req-classify",
+            operation="classify",
+            received_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            payload={"classifications": [{"label": "INVOICE", "confidence": 0.9}]},
+        )
+
+
+def test_extraction_handler_preserves_request_and_response_shape() -> None:
+    provider = FakeProvider()
+    handler = DocumentExtractionHandler(provider, ExtractionOutputParser())
+
+    result = handler.handle(
+        {
+            "document": "SGVsbG8=",
+            "mime_type": "application/pdf",
+            "features": ["text", "KEY_VALUE"],
+            "options": {"language": "en", "include_confidence": False},
+        }
+    )
+
+    assert provider.extraction_request is not None
+    assert provider.extraction_request.features == ["TEXT", "KEY_VALUE"]
+    assert provider.extraction_request.options.language == "en"
+    assert provider.extraction_request.options.include_confidence is False
+    assert result["status"] == "Successful"
+    assert result["job_id"] == "req-extract"
+    assert result["data"]["text"] == "hello"
+
+
+def test_extraction_handler_rejects_invalid_feature() -> None:
+    handler = DocumentExtractionHandler(FakeProvider(), ExtractionOutputParser())
+
+    with pytest.raises(ValueError, match="Unsupported extraction feature"):
+        handler.handle({"document": "SGVsbG8=", "mime_type": "application/pdf", "features": ["BAD"]})
+
+
+def test_classification_handler_normalizes_hint_and_options() -> None:
+    provider = FakeProvider()
+    handler = DocumentClassificationHandler(provider, ClassificationOutputParser())
+
+    result = handler.handle(
+        {
+            "document": "SGVsbG8=",
+            "mime_type": "application/pdf",
+            "document_type_hint": "bank statement",
+            "options": {"language": "en", "confidence_threshold": 0.2},
+        }
+    )
+
+    assert provider.classification_request is not None
+    assert provider.classification_request.document_type_hint == "BANK_STATEMENT"
+    assert provider.classification_request.options.confidence_threshold == 0.2
+    assert result["data"]["documentType"] == "INVOICE"
+    assert result["data"]["confidence"] == 0.9
+
+
+def test_classification_handler_rejects_bad_hint() -> None:
+    handler = DocumentClassificationHandler(FakeProvider(), ClassificationOutputParser())
+
+    with pytest.raises(ValueError, match="document_type_hint must be one of"):
+        handler.handle({"document": "SGVsbG8=", "mime_type": "application/pdf", "document_type_hint": "contract"})

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_parsers_and_mapping.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_parsers_and_mapping.py
@@ -1,0 +1,80 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from datetime import datetime, timezone
+
+from oracle.oci_document_understanding_mcp_server.models import (
+    ClassificationOptions,
+    ClassificationRequest,
+    DocumentSource,
+    ExtractionOptions,
+    ExtractionRequest,
+    RawOciDocumentResult,
+)
+from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
+from oracle.oci_document_understanding_mcp_server.oci.request_mapper import classification_config, extraction_configs
+from oracle.oci_document_understanding_mcp_server.parsers.classification import ClassificationOutputParser
+from oracle.oci_document_understanding_mcp_server.parsers.extraction import ExtractionOutputParser
+
+
+def _raw(payload: dict) -> RawOciDocumentResult:
+    return RawOciDocumentResult(
+        request_id="req",
+        operation="op",
+        received_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        payload=payload,
+    )
+
+
+def test_extraction_parser_reads_text_from_pages() -> None:
+    result = ExtractionOutputParser().parse(_raw({"pages": [{"lines": [{"text": "line 1"}, {"text": "line 2"}]}]}))
+
+    assert result["text"] == "line 1\nline 2"
+    assert result["keyValues"] == []
+    assert result["metadata"]["requestId"] == "req"
+
+
+def test_classification_parser_falls_back_to_top_classification() -> None:
+    result = ClassificationOutputParser().parse(_raw({"documentClassification": [{"documentType": "RECEIPT", "confidence": 0.8}]}))
+
+    assert result["documentType"] == "RECEIPT"
+    assert result["confidence"] == 0.8
+
+
+def test_classification_parser_handles_missing_or_unstructured_classifications() -> None:
+    parser = ClassificationOutputParser()
+
+    assert parser.parse(_raw({"classifications": []}))["documentType"] is None
+    assert parser.parse(_raw({"classifications": ["INVOICE"]}))["confidence"] is None
+
+
+def test_request_mapper_redacts_inline_content_and_preserves_object_storage() -> None:
+    config = OciDocumentUnderstandingConfig(
+        runtime_mode="stub",
+        region="us-phoenix-1",
+        endpoint=None,
+        auth_mode="none",
+        default_compartment_id="ocid1.compartment.oc1..example",
+        config_file_path=None,
+        profile="DEFAULT",
+    )
+    inline_source = DocumentSource(source_type="INLINE_BASE64", document="SGVsbG8=", mime_type="application/pdf")
+    object_source = DocumentSource(source_type="OBJECT_STORAGE", namespace_name="ns", bucket_name="bucket", object_name="doc.pdf")
+    extraction = ExtractionRequest(document_source=inline_source, features=["TEXT"], options=ExtractionOptions(language="en", include_confidence=True))
+    classification = ClassificationRequest(document_source=object_source, options=ClassificationOptions(language="en", confidence_threshold=0.2), document_type_hint="INVOICE")
+
+    extraction_config = extraction_configs(extraction, config)[0]
+    classification_request_config = classification_config(classification, config)
+
+    assert extraction_config["parameters"]["document"]["content"] == "<redacted>"
+    assert extraction_config["parameters"]["document"]["contentLength"] == 8
+    assert classification_request_config["parameters"]["document"]["objectName"] == "doc.pdf"
+
+
+def test_extraction_parser_ignores_unstructured_pages_and_lines() -> None:
+    result = ExtractionOutputParser().parse(_raw({"pages": ["bad", {"lines": ["bad", {"text": "line"}]}]}))
+
+    assert result["text"] == "line"

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_parsers_and_mapping.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_parsers_and_mapping.py
@@ -6,6 +6,8 @@ https://oss.oracle.com/licenses/upl.
 
 from datetime import datetime, timezone
 
+import oci
+
 from oracle.oci_document_understanding_mcp_server.models import (
     ClassificationOptions,
     ClassificationRequest,
@@ -78,3 +80,69 @@ def test_extraction_parser_ignores_unstructured_pages_and_lines() -> None:
     result = ExtractionOutputParser().parse(_raw({"pages": ["bad", {"lines": ["bad", {"text": "line"}]}]}))
 
     assert result["text"] == "line"
+
+
+def test_parsers_map_real_oci_sdk_result_models_for_advertised_outputs() -> None:
+    models = oci.ai_document.models
+    result = models.AnalyzeDocumentResult(
+        pages=[
+            models.Page(
+                page_number=1,
+                lines=[models.Line(text="Invoice 123", confidence=0.99)],
+                document_fields=[
+                    models.DocumentField(
+                        field_type="KEY_VALUE",
+                        field_label=models.FieldLabel(name="Invoice Number", confidence=0.98),
+                        field_value=models.FieldValue(value_type="STRING", text="123", confidence=0.97),
+                    )
+                ],
+                tables=[models.Table(row_count=1, column_count=2, confidence=0.96)],
+                bar_codes=[models.BarCode(value="code-123", confidence=0.95)],
+                signatures=[models.Signature(confidence=0.94)],
+                selection_marks=[models.SelectionMark(state="SELECTED", confidence=0.93)],
+            )
+        ],
+        detected_document_types=[models.DetectedDocumentType(document_type="INVOICE", confidence=0.98)],
+    )
+    payload = oci.util.to_dict(result)
+
+    extraction = ExtractionOutputParser().parse(_raw(payload))
+    classification = ClassificationOutputParser().parse(_raw(payload))
+
+    assert extraction["text"] == "Invoice 123"
+    assert extraction["keyValues"][0]["field_value"]["text"] == "123"
+    assert extraction["tables"][0]["confidence"] == 0.96
+    assert {element["type"] for element in extraction["elements"]} == {"BAR_CODE", "SIGNATURE", "SELECTION_MARK"}
+    assert classification["documentType"] == "INVOICE"
+    assert classification["confidence"] == 0.98
+
+
+def test_classification_parser_applies_threshold_and_recalculates_top_result() -> None:
+    parser = ClassificationOutputParser()
+
+    filtered = parser.parse(
+        _raw(
+            {
+                "classifications": [
+                    {"label": "INVOICE", "confidence": 0.97},
+                    {"label": "RECEIPT", "confidence": 0.02},
+                ],
+                "confidenceThreshold": 0.5,
+            }
+        )
+    )
+    empty = parser.parse(
+        _raw(
+            {
+                "classifications": [{"label": "RECEIPT", "confidence": 0.02}],
+                "confidenceThreshold": 0.5,
+            }
+        )
+    )
+
+    assert filtered["classifications"] == [{"label": "INVOICE", "confidence": 0.97}]
+    assert filtered["documentType"] == "INVOICE"
+    assert filtered["confidence"] == 0.97
+    assert empty["classifications"] == []
+    assert empty["documentType"] is None
+    assert empty["confidence"] is None

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_parsers_and_mapping.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_parsers_and_mapping.py
@@ -56,12 +56,7 @@ def test_classification_parser_handles_missing_or_unstructured_classifications()
 def test_request_mapper_redacts_inline_content_and_preserves_object_storage() -> None:
     config = OciDocumentUnderstandingConfig(
         runtime_mode="stub",
-        region="us-phoenix-1",
-        endpoint=None,
-        auth_mode="none",
         default_compartment_id="ocid1.compartment.oc1..example",
-        config_file_path=None,
-        profile="DEFAULT",
     )
     inline_source = DocumentSource(source_type="INLINE_BASE64", document="SGVsbG8=", mime_type="application/pdf")
     object_source = DocumentSource(source_type="OBJECT_STORAGE", namespace_name="ns", bucket_name="bucket", object_name="doc.pdf")

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_provider.py
@@ -1,0 +1,60 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+from oracle.oci_document_understanding_mcp_server.models import (
+    ClassificationOptions,
+    ClassificationRequest,
+    DocumentSource,
+    ExtractionOptions,
+    ExtractionRequest,
+)
+from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
+from oracle.oci_document_understanding_mcp_server.oci.provider import create_provider
+from oracle.oci_document_understanding_mcp_server.oci.stub_provider import StubOciDocumentUnderstandingProvider
+
+
+def _config() -> OciDocumentUnderstandingConfig:
+    return OciDocumentUnderstandingConfig(
+        runtime_mode="stub",
+        region="us-phoenix-1",
+        endpoint=None,
+        auth_mode="none",
+        default_compartment_id=None,
+        config_file_path=None,
+        profile="DEFAULT",
+    )
+
+
+def test_create_provider_uses_stub_for_stub_mode() -> None:
+    assert isinstance(create_provider(_config()), StubOciDocumentUnderstandingProvider)
+
+
+def test_stub_provider_returns_extraction_and_classification_payloads() -> None:
+    provider = StubOciDocumentUnderstandingProvider(_config())
+    source = DocumentSource(source_type="INLINE_BASE64", document="SGVsbG8=", mime_type="application/pdf")
+
+    extraction = provider.extract(
+        ExtractionRequest(
+            document_source=source,
+            features=["TEXT", "KEY_VALUE", "TABLE", "ELEMENT"],
+            options=ExtractionOptions(language="en", include_confidence=True),
+        )
+    )
+    classification = provider.classify(
+        ClassificationRequest(
+            document_source=source,
+            options=ClassificationOptions(language="en", confidence_threshold=0.2),
+            document_type_hint="INVOICE",
+        )
+    )
+
+    assert extraction.payload["provider"] == "stub"
+    assert extraction.payload["text"]
+    assert extraction.payload["keyValues"]
+    assert extraction.payload["tables"]
+    assert extraction.payload["elements"]
+    assert classification.payload["documentType"] == "INVOICE"
+    assert classification.payload["confidenceThreshold"] == 0.2

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_provider.py
@@ -19,12 +19,7 @@ from oracle.oci_document_understanding_mcp_server.oci.stub_provider import StubO
 def _config() -> OciDocumentUnderstandingConfig:
     return OciDocumentUnderstandingConfig(
         runtime_mode="stub",
-        region="us-phoenix-1",
-        endpoint=None,
-        auth_mode="none",
         default_compartment_id=None,
-        config_file_path=None,
-        profile="DEFAULT",
     )
 
 

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_sdk_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_sdk_provider.py
@@ -1,0 +1,181 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from oracle.oci_document_understanding_mcp_server.models import (
+    ClassificationOptions,
+    ClassificationRequest,
+    DocumentSource,
+    ExtractionOptions,
+    ExtractionRequest,
+)
+from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
+from oracle.oci_document_understanding_mcp_server.oci.sdk_provider import OciSdkDocumentUnderstandingProvider
+
+
+class FakeClient:
+    created: list[tuple[dict, object | None]] = []
+    responses: list[object] = []
+
+    def __init__(self, config: dict, signer: object | None = None) -> None:
+        self.config = config
+        self.signer = signer
+        self.base_client = SimpleNamespace(endpoint=None, set_endpoint=lambda endpoint: setattr(self.base_client, "endpoint", endpoint))
+        FakeClient.created.append((config, signer))
+
+    def analyze_document(self, analyze_document_details: object) -> object:
+        self.last_details = analyze_document_details
+        return FakeClient.responses.pop(0)
+
+
+class FakeModel:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+
+
+class FakeData:
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+
+    def to_dict(self) -> dict:
+        return self.payload
+
+
+def _install_fake_oci(monkeypatch: pytest.MonkeyPatch, token_file: str) -> None:
+    FakeClient.created.clear()
+    FakeClient.responses.clear()
+
+    class FakeSecurityTokenSigner:
+        def __init__(self, token: str, private_key: object) -> None:
+            self.token = token
+            self.private_key = private_key
+
+    class FakeInstanceSigner:
+        pass
+
+    def from_file(_path: str, _profile: str) -> dict:
+        return {
+            "region": "us-phoenix-1",
+            "security_token_file": token_file,
+            "key_file": "/tmp/key.pem",
+        }
+
+    fake_oci = SimpleNamespace(
+        config=SimpleNamespace(from_file=from_file, DEFAULT_LOCATION="~/.oci/config"),
+        signer=SimpleNamespace(load_private_key_from_file=lambda _path: object()),
+        auth=SimpleNamespace(
+            signers=SimpleNamespace(
+                SecurityTokenSigner=FakeSecurityTokenSigner,
+                InstancePrincipalsSecurityTokenSigner=FakeInstanceSigner,
+            )
+        ),
+        ai_document=SimpleNamespace(
+            AIServiceDocumentClient=FakeClient,
+            models=SimpleNamespace(
+                AnalyzeDocumentDetails=FakeModel,
+                InlineDocumentDetails=FakeModel,
+                ObjectStorageDocumentDetails=FakeModel,
+                DocumentTextExtractionFeature=FakeModel,
+                DocumentKeyValueExtractionFeature=FakeModel,
+                DocumentTableExtractionFeature=FakeModel,
+                DocumentElementsExtractionFeature=FakeModel,
+                DocumentClassificationFeature=FakeModel,
+            ),
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "oci", fake_oci)
+
+
+def _config(auth_mode: str, *, endpoint: str | None = None, compartment: str | None = "ocid1.compartment.oc1..example") -> OciDocumentUnderstandingConfig:
+    return OciDocumentUnderstandingConfig(
+        runtime_mode="local",
+        region="us-phoenix-1",
+        endpoint=endpoint,
+        auth_mode=auth_mode,
+        default_compartment_id=compartment,
+        config_file_path=None,
+        profile="DEFAULT",
+    )
+
+
+@pytest.mark.parametrize("auth_mode", ["session-token", "api-key", "instance-principal"])
+def test_sdk_provider_sets_additional_user_agent_for_auth_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    auth_mode: str,
+) -> None:
+    token_file = tmp_path / "token"
+    token_file.write_text("token", encoding="utf-8")
+    _install_fake_oci(monkeypatch, str(token_file))
+
+    provider = OciSdkDocumentUnderstandingProvider(_config(auth_mode, endpoint="https://documents.example.com"))
+
+    assert provider.client.base_client.endpoint == "https://documents.example.com"
+    assert FakeClient.created[-1][0]["additional_user_agent"] == "oci-document-understanding-mcp/0.1.0"
+
+
+def test_sdk_provider_requires_compartment_before_building_request(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    token_file = tmp_path / "token"
+    token_file.write_text("token", encoding="utf-8")
+    _install_fake_oci(monkeypatch, str(token_file))
+    provider = OciSdkDocumentUnderstandingProvider(_config("api-key", compartment=None))
+    request = ExtractionRequest(
+        document_source=DocumentSource(source_type="INLINE_BASE64", document="SGVsbG8=", mime_type="application/pdf"),
+        features=["TEXT"],
+        options=ExtractionOptions(language=None, include_confidence=True),
+    )
+
+    with pytest.raises(RuntimeError, match="OCI_COMPARTMENT_ID"):
+        provider._build_analyze_document_details(request, "extract", ["TEXT"])
+
+
+def test_sdk_provider_extract_and_classify_build_oci_requests(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    token_file = tmp_path / "token"
+    token_file.write_text("token", encoding="utf-8")
+    _install_fake_oci(monkeypatch, str(token_file))
+    FakeClient.responses.extend(
+        [
+            SimpleNamespace(data=FakeData({"text": "hello"}), headers={"opc-request-id": "extract-request"}),
+            SimpleNamespace(data={"classifications": [{"label": "INVOICE", "confidence": 0.9}]}, headers={"Opc-Request-Id": "classify-request"}),
+        ]
+    )
+    provider = OciSdkDocumentUnderstandingProvider(_config("api-key"))
+    inline_request = ExtractionRequest(
+        document_source=DocumentSource(source_type="INLINE_BASE64", document="SGVsbG8=", mime_type="application/pdf", page_range=["1"]),
+        features=["TEXT", "KEY_VALUE"],
+        options=ExtractionOptions(language="en", include_confidence=True),
+    )
+
+    extraction = provider.extract(inline_request)
+    classification = provider.classify(
+        ClassificationRequest(
+            document_source=DocumentSource(source_type="OBJECT_STORAGE", namespace_name="ns", bucket_name="bucket", object_name="doc.pdf"),
+            options=ClassificationOptions(language="en", confidence_threshold=0.2),
+            document_type_hint="INVOICE",
+        )
+    )
+
+    assert extraction.request_id == "extract-request"
+    assert extraction.payload["provider"] == "oci-sdk"
+    assert extraction.payload["requestConfigs"][0]["parameters"]["featureType"] == "TEXT"
+    assert classification.request_id == "classify-request"
+    assert classification.payload["requestConfig"]["parameters"]["documentTypeHint"] == "INVOICE"
+
+
+def test_sdk_provider_helpers_cover_fallback_paths(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    token_file = tmp_path / "token"
+    token_file.write_text("token", encoding="utf-8")
+    _install_fake_oci(monkeypatch, str(token_file))
+    provider = OciSdkDocumentUnderstandingProvider(_config("api-key"))
+
+    assert provider._response_to_payload(SimpleNamespace(data=object()))["raw"].startswith("<object")
+    assert provider._request_id(SimpleNamespace(headers={})) == "unknown"
+    with pytest.raises(KeyError):
+        provider._feature_model("BAD")

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_sdk_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_sdk_provider.py
@@ -7,7 +7,8 @@ https://oss.oracle.com/licenses/upl.
 import sys
 from types import SimpleNamespace
 
-import oci as real_oci
+from oci import util as real_oci_util
+from oci.ai_document import models as real_ai_document_models
 import pytest
 
 from oracle.oci_document_understanding_mcp_server.models import (
@@ -30,7 +31,6 @@ class FakeClient:
         self.config = config
         self.signer = signer
         self.client_kwargs = kwargs
-        self.base_client = SimpleNamespace(set_endpoint=lambda endpoint: setattr(self, "endpoint", endpoint))
         FakeClient.created.append((config, signer))
 
     def analyze_document(self, analyze_document_details: object) -> object:
@@ -74,7 +74,7 @@ def _install_fake_oci(monkeypatch: pytest.MonkeyPatch, token_file: str) -> None:
         }
 
     def to_dict(value: object) -> object:
-        return value.payload if isinstance(value, FakeData) else real_oci.util.to_dict(value)
+        return value.payload if isinstance(value, FakeData) else real_oci_util.to_dict(value)
 
     fake_oci = SimpleNamespace(
         config=SimpleNamespace(from_file=from_file, DEFAULT_LOCATION="~/.oci/config"),
@@ -106,34 +106,34 @@ def _install_fake_oci(monkeypatch: pytest.MonkeyPatch, token_file: str) -> None:
     monkeypatch.setattr(
         sdk_provider,
         "build_auth_context",
-        lambda _options: SimpleNamespace(config={"region": "us-phoenix-1"}, signer=object()),
+        lambda: SimpleNamespace(config={"region": "us-phoenix-1"}, region="us-phoenix-1", signer=object()),
     )
 
 
-def _config(auth_mode: str, *, compartment: str | None = "ocid1.compartment.oc1..example") -> OciDocumentUnderstandingConfig:
+def _config(*, compartment: str | None = "ocid1.compartment.oc1..example") -> OciDocumentUnderstandingConfig:
     return OciDocumentUnderstandingConfig(
-        runtime_mode="local",
-        region="us-phoenix-1",
-        endpoint=None,
-        auth_mode=auth_mode,
+        runtime_mode="oci",
         default_compartment_id=compartment,
-        config_file_path=None,
-        profile="DEFAULT",
     )
 
 
 @pytest.mark.parametrize(
-    ("auth_mode", "auth_config", "expected_region"),
+    ("auth_type", "auth_config", "expected_region"),
     [
-        ("session-token", {"region": "eu-frankfurt-1"}, "eu-frankfurt-1"),
-        ("api-key", {"region": "eu-frankfurt-1"}, "eu-frankfurt-1"),
-        ("instance-principal", {"region": "uk-london-1"}, "uk-london-1"),
+        ("api_key", {"region": "eu-frankfurt-1"}, "eu-frankfurt-1"),
+        ("security_token", {"region": "eu-frankfurt-1"}, "eu-frankfurt-1"),
+        ("identity_domain_upst", {"region": "us-ashburn-1"}, "us-ashburn-1"),
+        ("instance_principal", {"region": "uk-london-1"}, "uk-london-1"),
+        ("resource_principal", {"region": "us-phoenix-1"}, "us-phoenix-1"),
+        ("instance_principal_delegation", {"region": "us-chicago-1"}, "us-chicago-1"),
+        ("resource_principal_delegation", {"region": "ca-toronto-1"}, "ca-toronto-1"),
+        ("oke_workload_identity", {"region": "ap-mumbai-1"}, "ap-mumbai-1"),
     ],
 )
-def test_sdk_provider_uses_shared_auth_and_sets_user_agent_for_auth_paths(
+def test_sdk_provider_uses_shared_auth_and_sets_user_agent_for_all_auth_contexts(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
-    auth_mode: str,
+    auth_type: str,
     auth_config: dict,
     expected_region: str,
 ) -> None:
@@ -141,15 +141,16 @@ def test_sdk_provider_uses_shared_auth_and_sets_user_agent_for_auth_paths(
     token_file.write_text("token", encoding="utf-8")
     _install_fake_oci(monkeypatch, str(token_file))
     signer = object()
-    options_seen = []
+    calls = 0
 
-    def fake_build_auth_context(options):
-        options_seen.append(options)
-        return SimpleNamespace(config=auth_config, signer=signer)
+    def fake_build_auth_context():
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(auth_type=auth_type, config=auth_config, region=expected_region, signer=signer)
 
     monkeypatch.setattr(sdk_provider, "build_auth_context", fake_build_auth_context)
 
-    provider = OciSdkDocumentUnderstandingProvider(_config(auth_mode))
+    provider = OciSdkDocumentUnderstandingProvider(_config())
 
     assert FakeClient.created[-1][0]["additional_user_agent"] == "oci-document-understanding-mcp/0.1.0"
     assert FakeClient.created[-1][0]["region"] == expected_region
@@ -157,34 +158,22 @@ def test_sdk_provider_uses_shared_auth_and_sets_user_agent_for_auth_paths(
     assert provider.client.client_kwargs["retry_strategy"] is not None
     assert provider.client.client_kwargs["circuit_breaker_strategy"] is not None
     assert callable(provider.client.client_kwargs["circuit_breaker_callback"])
-    assert options_seen[-1].auth_type == auth_mode
-    assert options_seen[-1].region is None
+    assert calls == 1
 
 
-def test_sdk_provider_uses_server_region_only_when_common_auth_has_none(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_sdk_provider_requires_region_from_common_auth(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     token_file = tmp_path / "token"
     token_file.write_text("token", encoding="utf-8")
     _install_fake_oci(monkeypatch, str(token_file))
     monkeypatch.setattr(
         sdk_provider,
         "build_auth_context",
-        lambda _options: SimpleNamespace(config={}, signer=object()),
+        lambda: SimpleNamespace(config={}, region=None, signer=object()),
     )
 
-    OciSdkDocumentUnderstandingProvider(_config("instance-principal"))
+    with pytest.raises(RuntimeError, match="OCI region is required"):
+        OciSdkDocumentUnderstandingProvider(_config())
 
-    assert FakeClient.created[-1][0]["region"] == "us-phoenix-1"
-
-
-def test_sdk_provider_uses_configured_endpoint(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-    token_file = tmp_path / "token"
-    token_file.write_text("token", encoding="utf-8")
-    _install_fake_oci(monkeypatch, str(token_file))
-    config = _config("api-key").model_copy(update={"endpoint": "https://document.example.test"})
-
-    provider = OciSdkDocumentUnderstandingProvider(config)
-
-    assert provider.client.endpoint == "https://document.example.test"
 
 
 def test_sdk_provider_removes_confidence_when_requested(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
@@ -194,7 +183,7 @@ def test_sdk_provider_removes_confidence_when_requested(monkeypatch: pytest.Monk
     monkeypatch.setattr(
         sdk_provider,
         "build_auth_context",
-        lambda _options: SimpleNamespace(config={"region": "us-phoenix-1"}, signer=object()),
+        lambda: SimpleNamespace(config={"region": "us-phoenix-1"}, region="us-phoenix-1", signer=object()),
     )
     FakeClient.responses.append(
         SimpleNamespace(
@@ -202,7 +191,7 @@ def test_sdk_provider_removes_confidence_when_requested(monkeypatch: pytest.Monk
             headers={"opc-request-id": "extract-request"},
         )
     )
-    provider = OciSdkDocumentUnderstandingProvider(_config("api-key"))
+    provider = OciSdkDocumentUnderstandingProvider(_config())
 
     result = provider.extract(
         ExtractionRequest(
@@ -221,13 +210,13 @@ def test_sdk_provider_serializes_real_oci_sdk_result_model(monkeypatch: pytest.M
     _install_fake_oci(monkeypatch, str(token_file))
     FakeClient.responses.append(
         SimpleNamespace(
-            data=real_oci.ai_document.models.AnalyzeDocumentResult(
-                pages=[real_oci.ai_document.models.Page(page_number=1, lines=[real_oci.ai_document.models.Line(text="hello", confidence=0.9)])]
+            data=real_ai_document_models.AnalyzeDocumentResult(
+                pages=[real_ai_document_models.Page(page_number=1, lines=[real_ai_document_models.Line(text="hello", confidence=0.9)])]
             ),
             headers={"opc-request-id": "extract-request"},
         )
     )
-    provider = OciSdkDocumentUnderstandingProvider(_config("api-key"))
+    provider = OciSdkDocumentUnderstandingProvider(_config())
 
     result = provider.extract(
         ExtractionRequest(
@@ -244,7 +233,7 @@ def test_sdk_provider_requires_compartment_before_building_request(monkeypatch: 
     token_file = tmp_path / "token"
     token_file.write_text("token", encoding="utf-8")
     _install_fake_oci(monkeypatch, str(token_file))
-    provider = OciSdkDocumentUnderstandingProvider(_config("api-key", compartment=None))
+    provider = OciSdkDocumentUnderstandingProvider(_config(compartment=None))
     request = ExtractionRequest(
         document_source=DocumentSource(source_type="INLINE_BASE64", document="SGVsbG8=", mime_type="application/pdf"),
         features=["TEXT"],
@@ -265,7 +254,7 @@ def test_sdk_provider_extract_and_classify_build_oci_requests(monkeypatch: pytes
             SimpleNamespace(data={"classifications": [{"label": "INVOICE", "confidence": 0.9}]}, headers={"Opc-Request-Id": "classify-request"}),
         ]
     )
-    provider = OciSdkDocumentUnderstandingProvider(_config("api-key"))
+    provider = OciSdkDocumentUnderstandingProvider(_config())
     inline_request = ExtractionRequest(
         document_source=DocumentSource(source_type="INLINE_BASE64", document="SGVsbG8=", mime_type="application/pdf", page_range=["1"]),
         features=["TEXT", "KEY_VALUE"],
@@ -292,7 +281,7 @@ def test_sdk_provider_helpers_cover_fallback_paths(monkeypatch: pytest.MonkeyPat
     token_file = tmp_path / "token"
     token_file.write_text("token", encoding="utf-8")
     _install_fake_oci(monkeypatch, str(token_file))
-    provider = OciSdkDocumentUnderstandingProvider(_config("api-key"))
+    provider = OciSdkDocumentUnderstandingProvider(_config())
 
     assert provider._response_to_payload(SimpleNamespace(data=object()))["raw"].startswith("<object")
     assert provider._request_id(SimpleNamespace(headers={})) == "unknown"

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_sdk_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_sdk_provider.py
@@ -17,6 +17,7 @@ from oracle.oci_document_understanding_mcp_server.models import (
     ExtractionRequest,
 )
 from oracle.oci_document_understanding_mcp_server.oci.config import OciDocumentUnderstandingConfig
+from oracle.oci_document_understanding_mcp_server.oci import sdk_provider
 from oracle.oci_document_understanding_mcp_server.oci.sdk_provider import OciSdkDocumentUnderstandingProvider
 
 
@@ -91,6 +92,11 @@ def _install_fake_oci(monkeypatch: pytest.MonkeyPatch, token_file: str) -> None:
         ),
     )
     monkeypatch.setitem(sys.modules, "oci", fake_oci)
+    monkeypatch.setattr(
+        sdk_provider,
+        "build_auth_context",
+        lambda _options: SimpleNamespace(config={"region": "us-phoenix-1"}, signer=object()),
+    )
 
 
 def _config(auth_mode: str, *, endpoint: str | None = None, compartment: str | None = "ocid1.compartment.oc1..example") -> OciDocumentUnderstandingConfig:
@@ -105,20 +111,84 @@ def _config(auth_mode: str, *, endpoint: str | None = None, compartment: str | N
     )
 
 
-@pytest.mark.parametrize("auth_mode", ["session-token", "api-key", "instance-principal"])
-def test_sdk_provider_sets_additional_user_agent_for_auth_paths(
+@pytest.mark.parametrize(
+    ("auth_mode", "auth_config", "expected_region"),
+    [
+        ("session-token", {"region": "eu-frankfurt-1"}, "eu-frankfurt-1"),
+        ("api-key", {"region": "eu-frankfurt-1"}, "eu-frankfurt-1"),
+        ("instance-principal", {"region": "uk-london-1"}, "uk-london-1"),
+    ],
+)
+def test_sdk_provider_uses_shared_auth_and_sets_user_agent_for_auth_paths(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
     auth_mode: str,
+    auth_config: dict,
+    expected_region: str,
 ) -> None:
     token_file = tmp_path / "token"
     token_file.write_text("token", encoding="utf-8")
     _install_fake_oci(monkeypatch, str(token_file))
+    signer = object()
+    options_seen = []
+
+    def fake_build_auth_context(options):
+        options_seen.append(options)
+        return SimpleNamespace(config=auth_config, signer=signer)
+
+    monkeypatch.setattr(sdk_provider, "build_auth_context", fake_build_auth_context)
 
     provider = OciSdkDocumentUnderstandingProvider(_config(auth_mode, endpoint="https://documents.example.com"))
 
     assert provider.client.base_client.endpoint == "https://documents.example.com"
     assert FakeClient.created[-1][0]["additional_user_agent"] == "oci-document-understanding-mcp/0.1.0"
+    assert FakeClient.created[-1][0]["region"] == expected_region
+    assert FakeClient.created[-1][1] is signer
+    assert options_seen[-1].auth_type == auth_mode
+    assert options_seen[-1].region is None
+
+
+def test_sdk_provider_uses_server_region_only_when_common_auth_has_none(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    token_file = tmp_path / "token"
+    token_file.write_text("token", encoding="utf-8")
+    _install_fake_oci(monkeypatch, str(token_file))
+    monkeypatch.setattr(
+        sdk_provider,
+        "build_auth_context",
+        lambda _options: SimpleNamespace(config={}, signer=object()),
+    )
+
+    OciSdkDocumentUnderstandingProvider(_config("instance-principal"))
+
+    assert FakeClient.created[-1][0]["region"] == "us-phoenix-1"
+
+
+def test_sdk_provider_removes_confidence_when_requested(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    token_file = tmp_path / "token"
+    token_file.write_text("token", encoding="utf-8")
+    _install_fake_oci(monkeypatch, str(token_file))
+    monkeypatch.setattr(
+        sdk_provider,
+        "build_auth_context",
+        lambda _options: SimpleNamespace(config={"region": "us-phoenix-1"}, signer=object()),
+    )
+    FakeClient.responses.append(
+        SimpleNamespace(
+            data=FakeData({"keyValues": [{"key": "invoice", "confidence": 0.98, "nested": {"confidence": 0.9}}]}),
+            headers={"opc-request-id": "extract-request"},
+        )
+    )
+    provider = OciSdkDocumentUnderstandingProvider(_config("api-key"))
+
+    result = provider.extract(
+        ExtractionRequest(
+            document_source=DocumentSource(source_type="INLINE_BASE64", document="SGVsbG8=", mime_type="application/pdf"),
+            features=["KEY_VALUE"],
+            options=ExtractionOptions(language=None, include_confidence=False),
+        )
+    )
+
+    assert result.payload["keyValues"] == [{"key": "invoice", "nested": {}}]
 
 
 def test_sdk_provider_requires_compartment_before_building_request(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_sdk_provider.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_sdk_provider.py
@@ -7,6 +7,7 @@ https://oss.oracle.com/licenses/upl.
 import sys
 from types import SimpleNamespace
 
+import oci as real_oci
 import pytest
 
 from oracle.oci_document_understanding_mcp_server.models import (
@@ -25,10 +26,11 @@ class FakeClient:
     created: list[tuple[dict, object | None]] = []
     responses: list[object] = []
 
-    def __init__(self, config: dict, signer: object | None = None) -> None:
+    def __init__(self, config: dict, signer: object | None = None, **kwargs: object) -> None:
         self.config = config
         self.signer = signer
-        self.base_client = SimpleNamespace(endpoint=None, set_endpoint=lambda endpoint: setattr(self.base_client, "endpoint", endpoint))
+        self.client_kwargs = kwargs
+        self.base_client = SimpleNamespace(set_endpoint=lambda endpoint: setattr(self, "endpoint", endpoint))
         FakeClient.created.append((config, signer))
 
     def analyze_document(self, analyze_document_details: object) -> object:
@@ -61,6 +63,9 @@ def _install_fake_oci(monkeypatch: pytest.MonkeyPatch, token_file: str) -> None:
     class FakeInstanceSigner:
         pass
 
+    class FakeCircuitBreakerStrategy:
+        pass
+
     def from_file(_path: str, _profile: str) -> dict:
         return {
             "region": "us-phoenix-1",
@@ -68,9 +73,15 @@ def _install_fake_oci(monkeypatch: pytest.MonkeyPatch, token_file: str) -> None:
             "key_file": "/tmp/key.pem",
         }
 
+    def to_dict(value: object) -> object:
+        return value.payload if isinstance(value, FakeData) else real_oci.util.to_dict(value)
+
     fake_oci = SimpleNamespace(
         config=SimpleNamespace(from_file=from_file, DEFAULT_LOCATION="~/.oci/config"),
         signer=SimpleNamespace(load_private_key_from_file=lambda _path: object()),
+        util=SimpleNamespace(to_dict=to_dict),
+        retry=SimpleNamespace(DEFAULT_RETRY_STRATEGY=object()),
+        circuit_breaker=SimpleNamespace(CircuitBreakerStrategy=FakeCircuitBreakerStrategy),
         auth=SimpleNamespace(
             signers=SimpleNamespace(
                 SecurityTokenSigner=FakeSecurityTokenSigner,
@@ -99,11 +110,11 @@ def _install_fake_oci(monkeypatch: pytest.MonkeyPatch, token_file: str) -> None:
     )
 
 
-def _config(auth_mode: str, *, endpoint: str | None = None, compartment: str | None = "ocid1.compartment.oc1..example") -> OciDocumentUnderstandingConfig:
+def _config(auth_mode: str, *, compartment: str | None = "ocid1.compartment.oc1..example") -> OciDocumentUnderstandingConfig:
     return OciDocumentUnderstandingConfig(
         runtime_mode="local",
         region="us-phoenix-1",
-        endpoint=endpoint,
+        endpoint=None,
         auth_mode=auth_mode,
         default_compartment_id=compartment,
         config_file_path=None,
@@ -138,12 +149,14 @@ def test_sdk_provider_uses_shared_auth_and_sets_user_agent_for_auth_paths(
 
     monkeypatch.setattr(sdk_provider, "build_auth_context", fake_build_auth_context)
 
-    provider = OciSdkDocumentUnderstandingProvider(_config(auth_mode, endpoint="https://documents.example.com"))
+    provider = OciSdkDocumentUnderstandingProvider(_config(auth_mode))
 
-    assert provider.client.base_client.endpoint == "https://documents.example.com"
     assert FakeClient.created[-1][0]["additional_user_agent"] == "oci-document-understanding-mcp/0.1.0"
     assert FakeClient.created[-1][0]["region"] == expected_region
     assert FakeClient.created[-1][1] is signer
+    assert provider.client.client_kwargs["retry_strategy"] is not None
+    assert provider.client.client_kwargs["circuit_breaker_strategy"] is not None
+    assert callable(provider.client.client_kwargs["circuit_breaker_callback"])
     assert options_seen[-1].auth_type == auth_mode
     assert options_seen[-1].region is None
 
@@ -161,6 +174,17 @@ def test_sdk_provider_uses_server_region_only_when_common_auth_has_none(monkeypa
     OciSdkDocumentUnderstandingProvider(_config("instance-principal"))
 
     assert FakeClient.created[-1][0]["region"] == "us-phoenix-1"
+
+
+def test_sdk_provider_uses_configured_endpoint(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    token_file = tmp_path / "token"
+    token_file.write_text("token", encoding="utf-8")
+    _install_fake_oci(monkeypatch, str(token_file))
+    config = _config("api-key").model_copy(update={"endpoint": "https://document.example.test"})
+
+    provider = OciSdkDocumentUnderstandingProvider(config)
+
+    assert provider.client.endpoint == "https://document.example.test"
 
 
 def test_sdk_provider_removes_confidence_when_requested(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
@@ -189,6 +213,31 @@ def test_sdk_provider_removes_confidence_when_requested(monkeypatch: pytest.Monk
     )
 
     assert result.payload["keyValues"] == [{"key": "invoice", "nested": {}}]
+
+
+def test_sdk_provider_serializes_real_oci_sdk_result_model(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    token_file = tmp_path / "token"
+    token_file.write_text("token", encoding="utf-8")
+    _install_fake_oci(monkeypatch, str(token_file))
+    FakeClient.responses.append(
+        SimpleNamespace(
+            data=real_oci.ai_document.models.AnalyzeDocumentResult(
+                pages=[real_oci.ai_document.models.Page(page_number=1, lines=[real_oci.ai_document.models.Line(text="hello", confidence=0.9)])]
+            ),
+            headers={"opc-request-id": "extract-request"},
+        )
+    )
+    provider = OciSdkDocumentUnderstandingProvider(_config("api-key"))
+
+    result = provider.extract(
+        ExtractionRequest(
+            document_source=DocumentSource(source_type="INLINE_BASE64", document="SGVsbG8=", mime_type="application/pdf"),
+            features=["TEXT"],
+            options=ExtractionOptions(language=None, include_confidence=True),
+        )
+    )
+
+    assert result.payload["pages"][0]["lines"][0]["text"] == "hello"
 
 
 def test_sdk_provider_requires_compartment_before_building_request(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:

--- a/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_sources_and_validation.py
+++ b/src/oci-document-understanding-mcp-server/oracle/oci_document_understanding_mcp_server/tests/test_sources_and_validation.py
@@ -1,0 +1,71 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v1.0 as shown at
+https://oss.oracle.com/licenses/upl.
+"""
+
+import pytest
+
+from oracle.oci_document_understanding_mcp_server.handlers.sources import parse_document_source
+from oracle.oci_document_understanding_mcp_server.handlers.validation import (
+    optional_boolean,
+    optional_number_between,
+    required_base64_string,
+    required_string_list,
+)
+from oracle.oci_document_understanding_mcp_server.handlers.ids import document_id_from_source
+
+
+def test_parse_legacy_inline_source_and_document_id() -> None:
+    source = parse_document_source({"document": "SGVsbG8=", "mime_type": "application/pdf"})
+
+    assert source.source_type == "INLINE_BASE64"
+    assert source.document == "SGVsbG8="
+    assert document_id_from_source(source).startswith("doc_")
+
+
+def test_parse_object_storage_source() -> None:
+    source = parse_document_source(
+        {
+            "document_source": {
+                "source_type": "OBJECT_STORAGE",
+                "namespace_name": "namespace",
+                "bucket_name": "bucket",
+                "object_name": "doc.pdf",
+                "page_range": ["1-3"],
+            }
+        }
+    )
+
+    assert source.source_type == "OBJECT_STORAGE"
+    assert source.namespace_name == "namespace"
+    assert source.page_range == ["1-3"]
+    assert document_id_from_source(source).startswith("doc_")
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        ({"document": "not base64", "mime_type": "application/pdf"}, "valid base64"),
+        ({"document_source": {"source_type": "BAD"}}, "source_type"),
+        ({"document_source": {"source_type": "OBJECT_STORAGE", "namespace_name": "n"}}, "bucket_name"),
+        ({"document_source": []}, "document_source must be an object"),
+    ],
+)
+def test_parse_document_source_rejects_invalid_inputs(arguments: dict, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        parse_document_source(arguments)
+
+
+def test_validation_helpers_cover_error_paths() -> None:
+    assert required_base64_string({"document": "SGVsbG8="}, "document") == "SGVsbG8="
+    assert required_string_list({"features": ["TEXT"]}, "features") == ["TEXT"]
+    assert optional_boolean({}, "include_confidence", True) is True
+    assert optional_number_between({"threshold": 1}, "threshold", 0, 1) == 1.0
+
+    with pytest.raises(ValueError, match="non-empty array"):
+        required_string_list({"features": []}, "features")
+    with pytest.raises(ValueError, match="boolean"):
+        optional_boolean({"include_confidence": "true"}, "include_confidence", True)
+    with pytest.raises(ValueError, match="between"):
+        optional_number_between({"threshold": 2}, "threshold", 0, 1)

--- a/src/oci-document-understanding-mcp-server/pyproject.toml
+++ b/src/oci-document-understanding-mcp-server/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "oracle.oci-document-understanding-mcp-server"
+version = "0.1.0"
+description = "Stdio MCP server for OCI Document Understanding workflows."
+readme = "README.md"
+requires-python = ">=3.13"
+license = "UPL-1.0"
+license-files = ["LICENSE.txt"]
+authors = [
+    {name = "Oracle MCP", email = "237432095+oracle-mcp@users.noreply.github.com"},
+]
+dependencies = [
+    "fastmcp==3.4.2",
+    "oci==2.179.0",
+    "pydantic==2.12.3",
+]
+
+classifiers = [
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.13",
+]
+
+[project.scripts]
+"oracle.oci-document-understanding-mcp-server" = "oracle.oci_document_understanding_mcp_server.server:main"
+
+[project.urls]
+Changelog = "https://github.com/oracle/mcp/blob/main/src/oci-document-understanding-mcp-server/CHANGELOG.md"
+
+[tool.hatch.build.targets.wheel]
+packages = ["oracle"]
+exclude = ["/oracle/**/tests/**"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-cov>=7.0.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["oracle/oci_document_understanding_mcp_server/tests"]
+pythonpath = ["."]
+
+[tool.coverage.run]
+omit = [
+    "**/__init__.py",
+    "**/__main__.py",
+    "**/tests/*",
+    "dist/*",
+    ".venv/*",
+]
+
+[tool.coverage.report]
+omit = [
+    "**/__init__.py",
+    "**/__main__.py",
+    "**/tests/*",
+]
+precision = 2
+fail_under = 90

--- a/src/oci-document-understanding-mcp-server/pyproject.toml
+++ b/src/oci-document-understanding-mcp-server/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
 dependencies = [
     "fastmcp==3.4.2",
     "oci==2.179.0",
+    "oracle-mcp-common>=0.1.2,<0.2.0",
     "pydantic==2.12.3",
 ]
 
@@ -34,6 +35,14 @@ Changelog = "https://github.com/oracle/mcp/blob/main/src/oci-document-understand
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.uv.sources]
+oracle-mcp-common = { workspace = true }
+
+[tool.uv.workspace]
+members = [
+    "../common"
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-document-understanding-mcp-server/uv.lock
+++ b/src/oci-document-understanding-mcp-server/uv.lock
@@ -1,0 +1,1466 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "aiofile"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload-time = "2026-05-16T08:18:32.051Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
+]
+
+[[package]]
+name = "circuitbreaker"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/ac/de7a92c4ed39cba31fe5ad9203b76a25ca67c530797f6bb420fff5f65ccb/circuitbreaker-2.1.3.tar.gz", hash = "sha256:1a4baee510f7bea3c91b194dcce7c07805fe96c4423ed5594b75af438531d084", size = 10787, upload-time = "2025-03-31T08:12:08.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl", hash = "sha256:87ba6a3ed03fdc7032bc175561c2b04d52ade9d5faf94ca2b035fbdc5e6b1dd1", size = 7737, upload-time = "2025-03-31T08:12:07.802Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/d5/f8c838e6b7282976f7c918884b792df7a0c42c5bba5d99c60ad2d221d56d/coverage-7.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1121caa19159a38b5463eaae4b1e1fde81e525b15ecc5e000cd5b1a108f743a8", size = 221606, upload-time = "2026-07-15T18:54:45.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/37/97c926376364f66298cc44893b89cdf17b8bc406376497c4061ae4b8a8ff/coverage-7.15.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a300c6934e0989c327b9e8a1e110329da4641149f872bbe9f70168be66da76c1", size = 221982, upload-time = "2026-07-15T18:54:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/a36050a6e83c2135ee0776f452ca3948224befc6d7f26acecc082d0c106a/coverage-7.15.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2617f8799d268fabdeef42a7e89ac3a23e1deee9025427db2df970f99a89a578", size = 252972, upload-time = "2026-07-15T18:54:49.2Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d3/06b5f1daf95f0f15ab05bd75f26ba5f3c8b33d0bb72f3aaa3cf41d1bad3a/coverage-7.15.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7dc2950a2992cd676d35c20ae63522836deeb034f08874699d14068710af3dc1", size = 255569, upload-time = "2026-07-15T18:54:51.098Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1c/9afb3f8de2b8d36960391c48559a2e3ff96594b58099f115921549ea8d0d/coverage-7.15.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e36686f7a442185db2400b3df171aac520869faf9deb59df687d28659eda2a6", size = 256806, upload-time = "2026-07-15T18:54:53.145Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d8/b989f96061a5e32d82fddd1b1b9ff48a7c8f8ae7606f0e80fd9de54b1e33/coverage-7.15.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d29ca7bd67af6e12e74632d65f026eabc1364da5c254494cd914446a28a3ef7", size = 258936, upload-time = "2026-07-15T18:54:55.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fa/f99771f5110457c7b511c1935ca49ddf288218eaa84322e028b9334146ae/coverage-7.15.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:db9c8438057e5b0f6a22a0af99c0c1d26b57fbbdbd1be5861ddb8f897fcc3a2d", size = 253178, upload-time = "2026-07-15T18:54:57.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/96/c098a6044d119c751ceede7be91035fa8310170ec24a6523aff72f0a5793/coverage-7.15.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:63022c4c8dec1d0342f05c3ede99842fe3d007689acc45e86f123a1746e4a026", size = 254934, upload-time = "2026-07-15T18:54:59.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a2/1457b3a7a50c8d77500103b97a046db863e2f59a1cf6d2f814595f349885/coverage-7.15.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6c0be82b4d4aa5b2704e08518e2252f3e3d110164bcca826816801052e48a7aa", size = 252898, upload-time = "2026-07-15T18:55:01.338Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/0e/76958874c471ecfcdde0d2b2747bb2c61bdbf34a40636f4ce9db9923e643/coverage-7.15.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4510fb9cdf6bb02dfa6af0be4a534b8102d086e22e4a33f8836df663da3d660d", size = 257056, upload-time = "2026-07-15T18:55:03.243Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/7c/3d7c4e3bf58baa40327dc7edc2272b17cf02299366d52763db1b0ca1556a/coverage-7.15.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:42ec3d989421b174a2ab607c1539f24127ad362757b7f1c0c0d7a2993f7eb37b", size = 252718, upload-time = "2026-07-15T18:55:05.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b8/1cecffed9ce14fb25be9ba42d37b6bb61485c9a3ddd43cd3dde36b6087d8/coverage-7.15.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8f91bce78e32343af184c3b7fa28fcf5a9e2641f4b6623d392038f804939188", size = 254490, upload-time = "2026-07-15T18:55:06.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2c/42984561bc7f4c045dca67516a0c50ee5ef8d84352dbeb5559dc86c4823e/coverage-7.15.2-cp313-cp313-win32.whl", hash = "sha256:434e68d531858205895eb0d74b73d20b84260de426387d53c422a5acda2cf050", size = 223647, upload-time = "2026-07-15T18:55:08.941Z" },
+    { url = "https://files.pythonhosted.org/packages/41/9f/39c7c9245efc583beddf89a87683574e663ed93637f3afb6cd7b88405676/coverage-7.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:26c3b04a6377fd7c09800921fa934e3a17c0020439cd59df73e73ae1d4b6a78c", size = 224190, upload-time = "2026-07-15T18:55:10.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/de/3a2883cf8a213659280ef4b403059e17a9acaeb7fc7fd4105e1226ff2e6d/coverage-7.15.2-cp313-cp313-win_arm64.whl", hash = "sha256:3ed010aa1b69cda8e827aabfca9866216c980e2dca82ab9a78c5f83689964c8b", size = 223583, upload-time = "2026-07-15T18:55:12.678Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5f/aed265fd7a3551a394f36dfe41868aee709b7f95db4052205b4ad1563ac3/coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a", size = 221650, upload-time = "2026-07-15T18:55:14.527Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/2c/222ba12a545189017120f8eddfc1a0bd4616b47d5d4a8d99421edb2fe4c6/coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2", size = 221988, upload-time = "2026-07-15T18:55:16.674Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/304b5877ab46e6c290b4292cfcf3fe28245f0e5597cad7f6acc91fc7e0a4/coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138", size = 253029, upload-time = "2026-07-15T18:55:18.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/58/821b533b8db9e44cf1d8a97bd525149ced40dde1d0093da02cb78e715244/coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f", size = 255536, upload-time = "2026-07-15T18:55:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f2/7aa06604c389d32ea7f0a6a988359a7eafc3cd3f8e7bc2e88cd2fdf0b877/coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984", size = 256881, upload-time = "2026-07-15T18:55:23.125Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4f/1ef342339c7916d0096bc5888cc0f653882cc7bc8f897d5cb89143287c9b/coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7", size = 259196, upload-time = "2026-07-15T18:55:25.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f4/7ed055d7a9c5ec13b161773a115a5ccc6b0081d568c31fad830806306cc7/coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3", size = 253036, upload-time = "2026-07-15T18:55:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/14/79/ea82cca18c242a3a38b6c017da39726aa62dcb64aa635abf79b92009975c/coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee", size = 254887, upload-time = "2026-07-15T18:55:29.084Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ba/a136db3c0d9562b00e10b72540dbf3a33cd3bc5b95060c9308e247494623/coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1", size = 252852, upload-time = "2026-07-15T18:55:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/17/17/ea334246b16b7d059953fad6fdefa11e33c68efbd3fe37b1098120a1fac2/coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a", size = 257128, upload-time = "2026-07-15T18:55:33.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c3/074fb66d46d607855f710876b117cbda562c5ab08363528e78820449f937/coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145", size = 252668, upload-time = "2026-07-15T18:55:35.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c1/f620850ada9b36435921c9a3a8057013422b1d964eb4bf37fe138724d192/coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446", size = 254325, upload-time = "2026-07-15T18:55:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/31/a729ca3689404493af82ef8e6ff70bd88bdda8da89aeef6ca9b387aeb2b4/coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243", size = 223844, upload-time = "2026-07-15T18:55:39.078Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/83/5d809dc808fb1698c671f3e372259bb9158e64b7ea526fc6ab7de64de9fe/coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc", size = 224331, upload-time = "2026-07-15T18:55:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4e/35e488548e952795829e129995c4174df33bf432b591d1aa42c8d9e4e7ad/coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635", size = 223760, upload-time = "2026-07-15T18:55:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/49/dd2c86cd6374038f6e415fb5bfb86db5218553209c081384a020369dee79/coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be", size = 222384, upload-time = "2026-07-15T18:55:45.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/173ff17a1c0808e5a438f549f6f145d5ac7528f2791310b63523e3200ac7/coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072", size = 222647, upload-time = "2026-07-15T18:55:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f8/b8cba872162356fb44ac79c10309d987206a4461e32072fc29228dad7331/coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328", size = 264013, upload-time = "2026-07-15T18:55:49.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/67/a807a7586d0b8cae485308ddd55756f0806c92f8e0b411bacbf23c48edf3/coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a", size = 266135, upload-time = "2026-07-15T18:55:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/cd78771dc985f7e4ebdcc82b1a96d9a932af9e806f01f2f91a89f4c72e80/coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0", size = 268555, upload-time = "2026-07-15T18:55:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3e/10134cf81275188c58568f324fc74aedff32c63ca4d5bbc513a91944a6f0/coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5", size = 269674, upload-time = "2026-07-15T18:55:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/771b77de446cba985dc414bbc5844bd21604da05dbc044286df8318a48a7/coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743", size = 263101, upload-time = "2026-07-15T18:55:58.107Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b5/70a7011da15f4071943361183aefa27847f3e3aec4fd335f1cb3d3a622b1/coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c", size = 266007, upload-time = "2026-07-15T18:56:00.468Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/f9547e804ce7ad49646ffeffac26699510efbe6c0f751b66fdc960c4e825/coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071", size = 263611, upload-time = "2026-07-15T18:56:02.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/59/f576a396659c0efd351f5c1544f67c3560e89c7761cabf7f65e412beeda5/coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a", size = 267344, upload-time = "2026-07-15T18:56:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5d/c2e4fce3579c0cb635024293f1a32bbe26df101b3e3a69f22243d1352b6c/coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d", size = 262456, upload-time = "2026-07-15T18:56:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/956287d69436b66094bc4b57ac2da71e43bfd2a5524e958900b9f582fcf8/coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c", size = 264771, upload-time = "2026-07-15T18:56:08.795Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5a/6f979530c2734c575de77cf58f5f28d51f7123a94b5030fd9156fe5f363c/coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688", size = 224151, upload-time = "2026-07-15T18:56:10.856Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7e/27f6b2a74d484742f4017553e710b01e396b23d809df3e95ca0bb9a2824b/coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199", size = 224981, upload-time = "2026-07-15T18:56:12.928Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/48/284863423aa474240f6842bd00d680da22f4e6ea2e466618ef7c9c9e69a9/coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658", size = 224294, upload-time = "2026-07-15T18:56:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
+]
+
+[[package]]
+name = "crc32c"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/4c/4e40cc26347ac8254d3f25b9f94710b8e8df24ee4dddc1ba41907a88a94d/crc32c-2.7.1.tar.gz", hash = "sha256:f91b144a21eef834d64178e01982bb9179c354b3e9e5f4c803b0e5096384968c", size = 45712, upload-time = "2024-09-24T06:20:17.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/98/1a6d60d5b3b5edc8382777b64100343cb4aa6a7e172fae4a6cfcb8ebbbd9/crc32c-2.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:24949bffb06fc411cc18188d33357923cb935273642164d0bb37a5f375654169", size = 49567, upload-time = "2024-09-24T06:18:44.485Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/56/0dd652d4e950e6348bbf16b964b3325e4ad8220470774128fc0b0dd069cb/crc32c-2.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2d5d326e7e118d4fa60187770d86b66af2fdfc63ce9eeb265f0d3e7d49bebe0b", size = 37018, upload-time = "2024-09-24T06:18:45.434Z" },
+    { url = "https://files.pythonhosted.org/packages/47/02/2bd65fdef10139b6a802d83a7f966b7750fe5ffb1042f7cbe5dbb6403869/crc32c-2.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba110df60c64c8e2d77a9425b982a520ccdb7abe42f06604f4d98a45bb1fff62", size = 35374, upload-time = "2024-09-24T06:18:46.304Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/0d/3e797d1ed92d357a6a4c5b41cea15a538b27a8fdf18c7863747eb50b73ad/crc32c-2.7.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c277f9d16a3283e064d54854af0976b72abaa89824955579b2b3f37444f89aae", size = 54641, upload-time = "2024-09-24T06:18:47.207Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/4ddeef755caaa75680c559562b6c71f5910fee4c4f3a2eb5ea8b57f0e48c/crc32c-2.7.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:881af0478a01331244e27197356929edbdeaef6a9f81b5c6bacfea18d2139289", size = 52338, upload-time = "2024-09-24T06:18:49.31Z" },
+    { url = "https://files.pythonhosted.org/packages/01/cf/32f019be5de9f6e180926a50ee5f08648e686c7d9a59f2c5d0806a77b1c7/crc32c-2.7.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:724d5ff4d29ff093a983ae656be3307093706d850ea2a233bf29fcacc335d945", size = 53447, upload-time = "2024-09-24T06:18:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8b/92f3f62f3bafe8f7ab4af7bfb7246dc683fd11ec0d6dfb73f91e09079f69/crc32c-2.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b2416c4d88696ac322632555c0f81ab35e15f154bc96055da6cf110d642dbc10", size = 54484, upload-time = "2024-09-24T06:18:51.311Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b2/113a50f8781f76af5ac65ffdb907e72bddbe974de8e02247f0d58bc48040/crc32c-2.7.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:60254251b88ec9b9795215f0f9ec015a6b5eef8b2c5fba1267c672d83c78fc02", size = 52703, upload-time = "2024-09-24T06:18:52.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/6c/309229e9acda8cf36a8ff4061d70b54d905f79b7037e16883ce6590a24ab/crc32c-2.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:edefc0e46f3c37372183f70338e5bdee42f6789b62fcd36ec53aa933e9dfbeaf", size = 53367, upload-time = "2024-09-24T06:18:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/6c6324d920396e1bd9f3efbe8753da071be0ca52bd22d6c82d446b8d6975/crc32c-2.7.1-cp313-cp313-win32.whl", hash = "sha256:813af8111218970fe2adb833c5e5239f091b9c9e76f03b4dd91aaba86e99b499", size = 38377, upload-time = "2024-09-24T06:18:54.487Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a0/f01ccfab538db07ef3f6b4ede46357ff147a81dd4f3c59ca6a34c791a549/crc32c-2.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:7d9ede7be8e4ec1c9e90aaf6884decbeef10e3473e6ddac032706d710cab5888", size = 39803, upload-time = "2024-09-24T06:18:55.419Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/80/61dcae7568b33acfde70c9d651c7d891c0c578c39cc049107c1cf61f1367/crc32c-2.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db9ac92294284b22521356715784b91cc9094eee42a5282ab281b872510d1831", size = 49386, upload-time = "2024-09-24T06:18:56.813Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f1/80f17c089799ab2b4c247443bdd101d6ceda30c46d7f193e16b5ca29c5a0/crc32c-2.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8fcd7f2f29a30dc92af64a9ee3d38bde0c82bd20ad939999427aac94bbd87373", size = 36937, upload-time = "2024-09-24T06:18:57.77Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/5fcfc71a3de493d920fd2590843762a2749981ea56b802b380e5df82309d/crc32c-2.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5c056ef043393085523e149276a7ce0cb534b872e04f3e20d74d9a94a75c0ad7", size = 35292, upload-time = "2024-09-24T06:18:58.676Z" },
+    { url = "https://files.pythonhosted.org/packages/03/de/fef962e898a953558fe1c55141644553e84ef4190693a31244c59a0856c7/crc32c-2.7.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03a92551a343702629af91f78d205801219692b6909f8fa126b830e332bfb0e0", size = 54223, upload-time = "2024-09-24T06:18:59.675Z" },
+    { url = "https://files.pythonhosted.org/packages/21/14/fceca1a6f45c0a1814fe8602a65657b75c27425162445925ba87438cad6b/crc32c-2.7.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb9424ec1a8ca54763155a703e763bcede82e6569fe94762614bb2de1412d4e1", size = 51588, upload-time = "2024-09-24T06:19:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3b/13d40a7dfbf9ef05c84a0da45544ee72080dca4ce090679e5105689984bd/crc32c-2.7.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88732070f6175530db04e0bb36880ac45c33d49f8ac43fa0e50cfb1830049d23", size = 52678, upload-time = "2024-09-24T06:19:02.661Z" },
+    { url = "https://files.pythonhosted.org/packages/36/09/65ffc4fb9fa60ff6714eeb50a92284a4525e5943f0b040b572c0c76368c1/crc32c-2.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:57a20dfc27995f568f64775eea2bbb58ae269f1a1144561df5e4a4955f79db32", size = 53847, upload-time = "2024-09-24T06:19:03.705Z" },
+    { url = "https://files.pythonhosted.org/packages/24/71/938e926085b7288da052db7c84416f3ce25e71baf7ab5b63824c7bcb6f22/crc32c-2.7.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f7186d098bfd2cff25eac6880b7c7ad80431b90610036131c1c7dd0eab42a332", size = 51860, upload-time = "2024-09-24T06:19:04.726Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d8/4526d5380189d6f2fa27256c204100f30214fe402f47cf6e9fb9a91ab890/crc32c-2.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55a77e29a265418fa34bef15bd0f2c60afae5348988aaf35ed163b4bbf93cf37", size = 52508, upload-time = "2024-09-24T06:19:05.731Z" },
+    { url = "https://files.pythonhosted.org/packages/19/30/15f7e35176488b77e5b88751947d321d603fccac273099ace27c7b2d50a6/crc32c-2.7.1-cp313-cp313t-win32.whl", hash = "sha256:ae38a4b6aa361595d81cab441405fbee905c72273e80a1c010fb878ae77ac769", size = 38319, upload-time = "2024-09-24T06:19:07.233Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c4/0b3eee04dac195f4730d102d7a9fbea894ae7a32ce075f84336df96a385d/crc32c-2.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:eee2a43b663feb6c79a6c1c6e5eae339c2b72cfac31ee54ec0209fa736cf7ee5", size = 39781, upload-time = "2024-09-24T06:19:08.182Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+]
+
+[[package]]
+name = "cyclopts"
+version = "4.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/32/155236695c49364b3718467038c01399b5b1e693d81d719d853a2ea40d1c/cyclopts-4.22.0.tar.gz", hash = "sha256:89a3fa10b1d2970a6690105ff2d567270734b1e743984b7c31e6d47ddc623ec0", size = 193397, upload-time = "2026-07-19T14:13:04.798Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/f9/945190b482533e44ff26071837d265e00dc97e3682c1f75c685d7bc923fd/cyclopts-4.22.0-py3-none-any.whl", hash = "sha256:a0c332cb37ec319087c8bbb375fdd26456b49a6b9108cf85b1a77b0db0b85a9e", size = 232798, upload-time = "2026-07-19T14:13:02.958Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/18/46beaec18c9f86a599ae3f9cdf6677dd6b50240cfd844d18233710b47f13/fastmcp-3.4.2.tar.gz", hash = "sha256:b468722946fc467c3796a6572f7a14d93d48c014cf8fea12910245220cbbe4e1", size = 28756849, upload-time = "2026-06-06T01:30:35.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/d627b28b7403ecc526991ef732921b08bde010006e6148635f053fd29f4c/fastmcp_slim-3.4.2.tar.gz", hash = "sha256:290646e0955a516235a317151034559aa48336cb843d3f006131aedad8759bb4", size = 576291, upload-time = "2026-06-06T01:30:12.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/58/22afebf18df7260b09148199cbeb90cdcc4b3a4e1b5d7460e3591c3a7add/fastmcp_slim-3.4.2-py3-none-any.whl", hash = "sha256:bdc72492212681ca502755fa8acc0457f559295da1fc3dfc0599adc1c04b82f3", size = 749195, upload-time = "2026-06-06T01:30:11.22Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
+]
+server = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "joserfc" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pyperclip" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "starlette" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837, upload-time = "2026-07-14T01:28:02.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677, upload-time = "2026-07-14T01:28:01.59Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/79/cd02a4df6d9270efdc7d3feefe6edd730b0820c39eeaa107a2faee8322d5/jsonschema_path-0.5.0.tar.gz", hash = "sha256:493b156ba895c97602655b620a8456caa2ce08c1aa389f5a7addec065e6e855c", size = 19597, upload-time = "2026-05-19T20:45:00.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/2c/9e69d73c4297508be9e3b64a970ea3971b3eb8db64ffc5802d40bd25981f/jsonschema_path-0.5.0-py3-none-any.whl", hash = "sha256:2790a070bc7abb08ea3dbe4d340ece4efadf639223001f020c7503229ba068e2", size = 24077, upload-time = "2026-05-19T20:44:59.225Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
+]
+
+[[package]]
+name = "oci"
+version = "2.179.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "circuitbreaker" },
+    { name = "crc32c" },
+    { name = "cryptography" },
+    { name = "pyopenssl" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/28/6f09d1fb1f1d7489b978c6dcbab7847941302f9d5ae45b1c2cdca0b42765/oci-2.179.0.tar.gz", hash = "sha256:0b276d22ddc6eabdf4f4c3d8beefbd1f9d9fc80134d739f51ee0c203f6238eba", size = 17459638, upload-time = "2026-06-16T06:20:44.175Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/fe/f5885e4338c2bb9ebcb9d9b2ace058105b46630d34906c2914de12772a62/oci-2.179.0-py3-none-any.whl", hash = "sha256:8d696afb94e7a4f803c4499d172573c36ffa7e685907190d070f353969dba28e", size = 35745640, upload-time = "2026-06-16T06:20:35.828Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "oracle-oci-document-understanding-mcp-server"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "oci" },
+    { name = "pydantic" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", specifier = "==3.4.2" },
+    { name = "oci", specifier = "==2.179.0" },
+    { name = "pydantic", specifier = "==2.12.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/cd/4f25b2f95b23f5d2c9c1fe43e49841bff5800562149b2666afc09309aa8f/platformdirs-4.10.1.tar.gz", hash = "sha256:ceab4084426fe6319ce18e86deada8ab1b7487c7aee7040c55e277c9ae793695", size = 31678, upload-time = "2026-07-18T03:53:43.808Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/73/6fd0bb9ce84138c3857f12e9de63bc901852975a092d545f18087a204aa2/platformdirs-4.10.1-py3-none-any.whl", hash = "sha256:0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443", size = 22906, upload-time = "2026-07-18T03:53:42.576Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "py-key-value-aio"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e2/d689d922894a7ecde73b6daeaf9b13dab5aae06fe6aaaf7514722644d382/py_key_value_aio-0.4.5.tar.gz", hash = "sha256:c6563a2c6abe5da5e20f4f9e875c2a9b425a2244a54fadbf46cf140a9eea45d7", size = 107547, upload-time = "2026-05-27T16:37:08.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/95/b8ba862968712caa12a19666175334fa979e1f198b896a430adb3bacfe87/py_key_value_aio-0.4.5-py3-none-any.whl", hash = "sha256:ab862adbcb8c72547d1c57821f22cbbb71ab86509039c96f36e914e0336c8dd7", size = 170005, upload-time = "2026-05-27T16:37:06.629Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/1e/4f0a3233767010308f2fd6bd0814597e3f63f1dc98304a9112b8759df4ff/pydantic-2.12.3.tar.gz", hash = "sha256:1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74", size = 819383, upload-time = "2025-10-17T15:04:21.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/6b/83661fa77dcefa195ad5f8cd9af3d1a7450fd57cc883ad04d65446ac2029/pydantic-2.12.3-py3-none-any.whl", hash = "sha256:6986454a854bc3bc6e5443e1369e06a3a456af9d339eda45510f517d9ea5c6bf", size = 462431, upload-time = "2025-10-17T15:04:19.346Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/18/d0944e8eaaa3efd0a91b0f1fc537d3be55ad35091b6a87638211ba691964/pydantic_core-2.41.4.tar.gz", hash = "sha256:70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5", size = 457557, upload-time = "2025-10-14T10:23:47.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/d0/c20adabd181a029a970738dfe23710b52a31f1258f591874fcdec7359845/pydantic_core-2.41.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:85e050ad9e5f6fe1004eec65c914332e52f429bc0ae12d6fa2092407a462c746", size = 2105688, upload-time = "2025-10-14T10:20:54.448Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b6/0ce5c03cec5ae94cca220dfecddc453c077d71363b98a4bbdb3c0b22c783/pydantic_core-2.41.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7393f1d64792763a48924ba31d1e44c2cfbc05e3b1c2c9abb4ceeadd912cced", size = 1910807, upload-time = "2025-10-14T10:20:56.115Z" },
+    { url = "https://files.pythonhosted.org/packages/68/3e/800d3d02c8beb0b5c069c870cbb83799d085debf43499c897bb4b4aaff0d/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94dab0940b0d1fb28bcab847adf887c66a27a40291eedf0b473be58761c9799a", size = 1956669, upload-time = "2025-10-14T10:20:57.874Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a4/24271cc71a17f64589be49ab8bd0751f6a0a03046c690df60989f2f95c2c/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de7c42f897e689ee6f9e93c4bec72b99ae3b32a2ade1c7e4798e690ff5246e02", size = 2051629, upload-time = "2025-10-14T10:21:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/68/de/45af3ca2f175d91b96bfb62e1f2d2f1f9f3b14a734afe0bfeff079f78181/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:664b3199193262277b8b3cd1e754fb07f2c6023289c815a1e1e8fb415cb247b1", size = 2224049, upload-time = "2025-10-14T10:21:01.801Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/ae4e1ff84672bf869d0a77af24fd78387850e9497753c432875066b5d622/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d95b253b88f7d308b1c0b417c4624f44553ba4762816f94e6986819b9c273fb2", size = 2342409, upload-time = "2025-10-14T10:21:03.556Z" },
+    { url = "https://files.pythonhosted.org/packages/18/62/273dd70b0026a085c7b74b000394e1ef95719ea579c76ea2f0cc8893736d/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1351f5bbdbbabc689727cb91649a00cb9ee7203e0a6e54e9f5ba9e22e384b84", size = 2069635, upload-time = "2025-10-14T10:21:05.385Z" },
+    { url = "https://files.pythonhosted.org/packages/30/03/cf485fff699b4cdaea469bc481719d3e49f023241b4abb656f8d422189fc/pydantic_core-2.41.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1affa4798520b148d7182da0615d648e752de4ab1a9566b7471bc803d88a062d", size = 2194284, upload-time = "2025-10-14T10:21:07.122Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/7e/c8e713db32405dfd97211f2fc0a15d6bf8adb7640f3d18544c1f39526619/pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7b74e18052fea4aa8dea2fb7dbc23d15439695da6cbe6cfc1b694af1115df09d", size = 2137566, upload-time = "2025-10-14T10:21:08.981Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f7/db71fd4cdccc8b75990f79ccafbbd66757e19f6d5ee724a6252414483fb4/pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:285b643d75c0e30abda9dc1077395624f314a37e3c09ca402d4015ef5979f1a2", size = 2316809, upload-time = "2025-10-14T10:21:10.805Z" },
+    { url = "https://files.pythonhosted.org/packages/76/63/a54973ddb945f1bca56742b48b144d85c9fc22f819ddeb9f861c249d5464/pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f52679ff4218d713b3b33f88c89ccbf3a5c2c12ba665fb80ccc4192b4608dbab", size = 2311119, upload-time = "2025-10-14T10:21:12.583Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/03/5d12891e93c19218af74843a27e32b94922195ded2386f7b55382f904d2f/pydantic_core-2.41.4-cp313-cp313-win32.whl", hash = "sha256:ecde6dedd6fff127c273c76821bb754d793be1024bc33314a120f83a3c69460c", size = 1981398, upload-time = "2025-10-14T10:21:14.584Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d8/fd0de71f39db91135b7a26996160de71c073d8635edfce8b3c3681be0d6d/pydantic_core-2.41.4-cp313-cp313-win_amd64.whl", hash = "sha256:d081a1f3800f05409ed868ebb2d74ac39dd0c1ff6c035b5162356d76030736d4", size = 2030735, upload-time = "2025-10-14T10:21:16.432Z" },
+    { url = "https://files.pythonhosted.org/packages/72/86/c99921c1cf6650023c08bfab6fe2d7057a5142628ef7ccfa9921f2dda1d5/pydantic_core-2.41.4-cp313-cp313-win_arm64.whl", hash = "sha256:f8e49c9c364a7edcbe2a310f12733aad95b022495ef2a8d653f645e5d20c1564", size = 1973209, upload-time = "2025-10-14T10:21:18.213Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0d/b5706cacb70a8414396efdda3d72ae0542e050b591119e458e2490baf035/pydantic_core-2.41.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ed97fd56a561f5eb5706cebe94f1ad7c13b84d98312a05546f2ad036bafe87f4", size = 1877324, upload-time = "2025-10-14T10:21:20.363Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2d/cba1fa02cfdea72dfb3a9babb067c83b9dff0bbcb198368e000a6b756ea7/pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a870c307bf1ee91fc58a9a61338ff780d01bfae45922624816878dce784095d2", size = 1884515, upload-time = "2025-10-14T10:21:22.339Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ea/3df927c4384ed9b503c9cc2d076cf983b4f2adb0c754578dfb1245c51e46/pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d25e97bc1f5f8f7985bdc2335ef9e73843bb561eb1fa6831fdfc295c1c2061cf", size = 2042819, upload-time = "2025-10-14T10:21:26.683Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ee/df8e871f07074250270a3b1b82aad4cd0026b588acd5d7d3eb2fcb1471a3/pydantic_core-2.41.4-cp313-cp313t-win_amd64.whl", hash = "sha256:d405d14bea042f166512add3091c1af40437c2e7f86988f3915fabd27b1e9cd2", size = 1995866, upload-time = "2025-10-14T10:21:28.951Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/de/b20f4ab954d6d399499c33ec4fafc46d9551e11dc1858fb7f5dca0748ceb/pydantic_core-2.41.4-cp313-cp313t-win_arm64.whl", hash = "sha256:19f3684868309db5263a11bace3c45d93f6f24afa2ffe75a647583df22a2ff89", size = 1970034, upload-time = "2025-10-14T10:21:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/54/28/d3325da57d413b9819365546eb9a6e8b7cbd9373d9380efd5f74326143e6/pydantic_core-2.41.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:e9205d97ed08a82ebb9a307e92914bb30e18cdf6f6b12ca4bedadb1588a0bfe1", size = 2102022, upload-time = "2025-10-14T10:21:32.809Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/24/b58a1bc0d834bf1acc4361e61233ee217169a42efbdc15a60296e13ce438/pydantic_core-2.41.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:82df1f432b37d832709fbcc0e24394bba04a01b6ecf1ee87578145c19cde12ac", size = 1905495, upload-time = "2025-10-14T10:21:34.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a4/71f759cc41b7043e8ecdaab81b985a9b6cad7cec077e0b92cff8b71ecf6b/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3b4cc4539e055cfa39a3763c939f9d409eb40e85813257dcd761985a108554", size = 1956131, upload-time = "2025-10-14T10:21:36.924Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/64/1e79ac7aa51f1eec7c4cda8cbe456d5d09f05fdd68b32776d72168d54275/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b1eb1754fce47c63d2ff57fdb88c351a6c0150995890088b33767a10218eaa4e", size = 2052236, upload-time = "2025-10-14T10:21:38.927Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e3/a3ffc363bd4287b80f1d43dc1c28ba64831f8dfc237d6fec8f2661138d48/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6ab5ab30ef325b443f379ddb575a34969c333004fca5a1daa0133a6ffaad616", size = 2223573, upload-time = "2025-10-14T10:21:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/28/27/78814089b4d2e684a9088ede3790763c64693c3d1408ddc0a248bc789126/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:31a41030b1d9ca497634092b46481b937ff9397a86f9f51bd41c4767b6fc04af", size = 2342467, upload-time = "2025-10-14T10:21:44.018Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/4de0e2a1159cb85ad737e03306717637842c88c7fd6d97973172fb183149/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a44ac1738591472c3d020f61c6df1e4015180d6262ebd39bf2aeb52571b60f12", size = 2063754, upload-time = "2025-10-14T10:21:46.466Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/50/8cb90ce4b9efcf7ae78130afeb99fd1c86125ccdf9906ef64b9d42f37c25/pydantic_core-2.41.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d72f2b5e6e82ab8f94ea7d0d42f83c487dc159c5240d8f83beae684472864e2d", size = 2196754, upload-time = "2025-10-14T10:21:48.486Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3b/ccdc77af9cd5082723574a1cc1bcae7a6acacc829d7c0a06201f7886a109/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c4d1e854aaf044487d31143f541f7aafe7b482ae72a022c664b2de2e466ed0ad", size = 2137115, upload-time = "2025-10-14T10:21:50.63Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ba/e7c7a02651a8f7c52dc2cff2b64a30c313e3b57c7d93703cecea76c09b71/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b568af94267729d76e6ee5ececda4e283d07bbb28e8148bb17adad93d025d25a", size = 2317400, upload-time = "2025-10-14T10:21:52.959Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ba/6c533a4ee8aec6b812c643c49bb3bd88d3f01e3cebe451bb85512d37f00f/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6d55fb8b1e8929b341cc313a81a26e0d48aa3b519c1dbaadec3a6a2b4fcad025", size = 2312070, upload-time = "2025-10-14T10:21:55.419Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ae/f10524fcc0ab8d7f96cf9a74c880243576fd3e72bd8ce4f81e43d22bcab7/pydantic_core-2.41.4-cp314-cp314-win32.whl", hash = "sha256:5b66584e549e2e32a1398df11da2e0a7eff45d5c2d9db9d5667c5e6ac764d77e", size = 1982277, upload-time = "2025-10-14T10:21:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/dc/e5aa27aea1ad4638f0c3fb41132f7eb583bd7420ee63204e2d4333a3bbf9/pydantic_core-2.41.4-cp314-cp314-win_amd64.whl", hash = "sha256:557a0aab88664cc552285316809cab897716a372afaf8efdbef756f8b890e894", size = 2024608, upload-time = "2025-10-14T10:21:59.557Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/51d89cc2612bd147198e120a13f150afbf0bcb4615cddb049ab10b81b79e/pydantic_core-2.41.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f1ea6f48a045745d0d9f325989d8abd3f1eaf47dd00485912d1a3a63c623a8d", size = 1967614, upload-time = "2025-10-14T10:22:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c2/472f2e31b95eff099961fa050c376ab7156a81da194f9edb9f710f68787b/pydantic_core-2.41.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6c1fe4c5404c448b13188dd8bd2ebc2bdd7e6727fa61ff481bcc2cca894018da", size = 1876904, upload-time = "2025-10-14T10:22:04.062Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/07/ea8eeb91173807ecdae4f4a5f4b150a520085b35454350fc219ba79e66a3/pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:523e7da4d43b113bf8e7b49fa4ec0c35bf4fe66b2230bfc5c13cc498f12c6c3e", size = 1882538, upload-time = "2025-10-14T10:22:06.39Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/29/b53a9ca6cd366bfc928823679c6a76c7a4c69f8201c0ba7903ad18ebae2f/pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5729225de81fb65b70fdb1907fcf08c75d498f4a6f15af005aabb1fdadc19dfa", size = 2041183, upload-time = "2025-10-14T10:22:08.812Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/3d/f8c1a371ceebcaf94d6dd2d77c6cf4b1c078e13a5837aee83f760b4f7cfd/pydantic_core-2.41.4-cp314-cp314t-win_amd64.whl", hash = "sha256:de2cfbb09e88f0f795fd90cf955858fc2c691df65b1f21f0aa00b99f3fbc661d", size = 1993542, upload-time = "2025-10-14T10:22:11.332Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ac/9fc61b4f9d079482a290afe8d206b8f490e9fd32d4fc03ed4fc698214e01/pydantic_core-2.41.4-cp314-cp314t-win_arm64.whl", hash = "sha256:d34f950ae05a83e0ede899c595f312ca976023ea1db100cd5aa188f7005e3ab0", size = 1973897, upload-time = "2025-10-14T10:22:13.444Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/d6/d0b9fafc73b65767200da027acab1db1bdb1048f4fea5ebf659df01c700e/rich_rst-2.1.0.tar.gz", hash = "sha256:f4d117b49697f338769759fa5cacf5197da4888b347b9fda2e50aef5cd8d93bd", size = 302732, upload-time = "2026-07-05T02:59:44.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/68/1fc93dd759605b5d00fc98b50200739e41ed32bd22d6ba35ca6c3932371b/rich_rst-2.1.0-py3-none-any.whl", hash = "sha256:7ecd1343ee12c879d0e7ae74c3eb6d263b023d2929c6d114212eb1fd91057255", size = 272987, upload-time = "2026-07-05T02:59:42.792Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.51.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl", hash = "sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b", size = 73219, upload-time = "2026-07-08T10:59:04.44Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/f7/bc3a25c5ec26ce62ce487690becc2f3710bbc7b33338f005ad390db0b986/websockets-16.1.1.tar.gz", hash = "sha256:db234eda965dcce15df96bb9709f587cd87d4d52aaf0e80e2f34ec04c7670c57", size = 182204, upload-time = "2026-07-17T22:51:05.858Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/fd/6ec6c6d2850aea25b1b2aa9901a016980bb87d01e89b3eb00470b1b5d471/websockets-16.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ab59169ace05dcb49a1d4118f0bde139557adf45091bd85747e36bf5de984dd1", size = 179587, upload-time = "2026-07-17T22:49:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d8/1d299d2dd34087db39831a34cc645ef8a6f89d78efada6983093513cd81c/websockets-16.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5e3b7d601f6f84156b08cc4a5e541c2b50ad7b36cfc302b657a12477c904a5df", size = 177272, upload-time = "2026-07-17T22:49:40.293Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/86/0a70d3ae2f0f2256bb41302d9804dbca65d4360281e7feb3e1f94102ac46/websockets-16.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cd2ca96a082a36964aca83e992f72abeb61b7306c1a6cba4c7d06a7b93750cac", size = 177530, upload-time = "2026-07-17T22:49:41.786Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c2/c676c69444d9db448b3f0a55a98dcc534affce0bce961d9d2f0b8499b10a/websockets-16.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f5d497865f05bb222cab7016c6034542e84e5f29f49c6fd3f4939cda7197b5b8", size = 187197, upload-time = "2026-07-17T22:49:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/13/88137fbaf726ebe29d62c1117fa11fa2bbb6209dc79d4ad738efbe36a2aa/websockets-16.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bae954c382e013d5ea5b190d2830526bfa45ad121c326da0049b8c769f185db6", size = 188433, upload-time = "2026-07-17T22:49:45.147Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6d/46c2f2ce6751cb26f39293e1ecbf8544cb01321397cd476c2756b98c216d/websockets-16.1.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e09f753a169951eb4f28c2c774f71069304f66e7277e0f5a2892423599cfa854", size = 189868, upload-time = "2026-07-17T22:49:46.581Z" },
+    { url = "https://files.pythonhosted.org/packages/29/2b/170a9e8097636cfde4dc3c592b6e00b18a44a2f5407606d96ca542dd5838/websockets-16.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:024193f8551a2b0eafbdd160911012c4e6c228c28430c84433253299a9e42d6a", size = 189059, upload-time = "2026-07-17T22:49:47.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/48/f0d4ebc9ab4b473b8861b9e20fdb663d515d42f7befdf62cdb60fee7a1ec/websockets-16.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:aabe464bfd13bd25f4821faf111da6fefdc389f870265a53105580e45b0a2e49", size = 187814, upload-time = "2026-07-17T22:49:49.344Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ba/39a41d3ae8e72696a9492581900611c5a91e2b07563b0bcd2523adea9854/websockets-16.1.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a28fcbc9b6baf54a2e23f8655f308e4ccc6afdd7266f8fe7954f320dcda0f785", size = 185229, upload-time = "2026-07-17T22:49:50.787Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/ac15b604f850d1907f0a85ed721cefe47cd45034b3620069b829746cccbe/websockets-16.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:79eace538c6a97e96d0d03d4f9d314f9677f5ed85a8a984992ffd90b13cb8a56", size = 187874, upload-time = "2026-07-17T22:49:52.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/3fbd5d71d59299c3770faa5884d4f45070236ca5a35ab3a61830812c409a/websockets-16.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:496af849a472b531f758dbd4d61338f5000538cb1a7b3d20d9d32a264517f509", size = 186469, upload-time = "2026-07-17T22:49:53.776Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/fc/dd90349bba58af2a53ef2ddd9c32716c81eb6d59a0687939fff561860878/websockets-16.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5283810d2646741a0d8da2aa733d6aefa0545809afccb2a5d105a26bc45125f1", size = 188347, upload-time = "2026-07-17T22:49:55.202Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f3/f73ba86427682da59b78c11d77ba56d5b801c32e84afe79b274bbd6a9bb2/websockets-16.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4e3b680b1e0a27457e727a0d572fd81dffa87b6dbf8b228ab57da64f7d85aead", size = 185903, upload-time = "2026-07-17T22:49:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7c/f95eb20e80104173b3a0a092291f89ea4047ef6e608e0a57ca06eb14eecb/websockets-16.1.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:69159730a823dde3ea8d08783e8d47ef135a6d7e8d44eb127e32b321c9db8e3e", size = 186855, upload-time = "2026-07-17T22:49:58.467Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/35/dd875b3e050ff232d60fa377707f890e369f74d134f1be32e8f68879747c/websockets-16.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ed5bb271084b46530ee2ddc0410537a9961152c5ccba2fc98c5276d992ccba87", size = 187140, upload-time = "2026-07-17T22:50:00.016Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/dc/5cbfcb41824502f6af93b8f3943a4d06c67c23c7d2e31eb18748c4a5b2a7/websockets-16.1.1-cp313-cp313-win32.whl", hash = "sha256:cfb70b4eb56cac4da0a83588f3ad50d46beb0690391082f3d4e2d488c70b68ea", size = 179928, upload-time = "2026-07-17T22:50:01.685Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c1/71e5deb5b7f8f226997ab64908c184ac3105c0155ce2d486f318e5dd08a8/websockets-16.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:d9531d9cbeac99af6f038fb1bc351403531f7d634a2c2e10e2f7c854c6ed5b68", size = 180242, upload-time = "2026-07-17T22:50:03.117Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a2/ba78a164eeea4620df4a4df4bd2ed6017438c4655cc0f36f2c0bc0432355/websockets-16.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:443aefe96b7fdb132e2a70806cca1f2af49bb3f28e47abcd7c2e9dcf4d8fa1b8", size = 179635, upload-time = "2026-07-17T22:50:05.001Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/08/d26d7a7628cd4ac34cbbdb63ac80914ca842ed8e42938c40a53567806df3/websockets-16.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6456ff333092d509127d75a638cb411afae8ff17f092635015d1902efec8a293", size = 177320, upload-time = "2026-07-17T22:50:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/45/ebec83e6269536aa5932533c67b0af5c781f3e73fdbcd68672dcf43f4f44/websockets-16.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fce6c48559c86d1ac3632ccb1bebc7d5442fbe79bd9bb0e40379ee54be2a4051", size = 177544, upload-time = "2026-07-17T22:50:07.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d5/abc614d2297f6c1c3e01e61260364457a47c25cc1cf6a879038902bc6aa8/websockets-16.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:92b820d345f7a3fc7b8163949ee92df910f290c3fc517b3d5301c78065adafe1", size = 187270, upload-time = "2026-07-17T22:50:09.275Z" },
+    { url = "https://files.pythonhosted.org/packages/52/71/4c99af3b87dff1b2927981f6876607d4acb45338c665242168d3982f7758/websockets-16.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a606d9c24035242a3e256e9d5b77ed9cd6bccfcb7cf993e5ca3c0f6f68fb6a7", size = 188509, upload-time = "2026-07-17T22:50:10.722Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b4/5c8ca14b0df7eb84ed0524165c5359150210140817a3312aee57bf62a1cf/websockets-16.1.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:414e596c75f74e0994084694189d7dc9229fb278e33064d6784b73ffbba3ca31", size = 189882, upload-time = "2026-07-17T22:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c1/bedfba9e70557129cb8083748d167bdcc01483dedf0f0df143676df05cbe/websockets-16.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:536676848fc5961aca9d20389951f59169508f765637a172403dc5434d722fa0", size = 189114, upload-time = "2026-07-17T22:50:13.789Z" },
+    { url = "https://files.pythonhosted.org/packages/df/09/aa835b2787835aebd839114be5de51b797cb480b63ba42b26d34dfe147cb/websockets-16.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:97fd3a0e8b53efa41970ac1dff3d8cf0d2884cadeb4caaf95db7ad1526926ee3", size = 187861, upload-time = "2026-07-17T22:50:15.179Z" },
+    { url = "https://files.pythonhosted.org/packages/20/26/f6408330694dbc9830857d9d23bc14ac4f6875127a480cfdda8d5ca21198/websockets-16.1.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7b1b19636af86a3c7995d4d028dbe376f39b4bf31541146f9c123582a6c94562", size = 185286, upload-time = "2026-07-17T22:50:16.741Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9a/e0675e70dd8a80762cf35bb18799d3f290a4890ffe6439bc51d222796083/websockets-16.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:41c8e77f17294c0ac18008a7309b99b34ee72247ef10b6dff4c3f8b5ac29896b", size = 187935, upload-time = "2026-07-17T22:50:18.213Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c1/3234cfb86afde01b81e9bddcc6e534c440975d60a13991259e833069ab3e/websockets-16.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:9f63bcef7f4b02b06b35fc01c93b96c43b5e88e1e8868676caacf493d5a31f3a", size = 186444, upload-time = "2026-07-17T22:50:19.67Z" },
+    { url = "https://files.pythonhosted.org/packages/89/87/9c15206e1d778923d8daa9657de07aa62ea815e13448319c98458c37b281/websockets-16.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dab9eb87869da2d6ed3af3f3adf28414baae6ec9d4df355ffc18889132f3436c", size = 188409, upload-time = "2026-07-17T22:50:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/cf5de5c67676de2d3eef8b2a518f168f6796595447a5b7161ba0d012915c/websockets-16.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:43e3a9fdd7cbf7ba6040c31fae0faf84ca1474fef777c4e37912f1540f854499", size = 185958, upload-time = "2026-07-17T22:50:22.719Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c0/731b6ddede2e4136912ec4cff2cffbda35af73546be4762c3d7bd3bd79af/websockets-16.1.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:056ae37939ed7e9974f364f5864e76e49182622d8f9751ac1903c0d09b013985", size = 186911, upload-time = "2026-07-17T22:50:24.108Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/7f/39c634472c4469a24a7c09cecddffb08fac6d0e74f73881a94ee8a40a196/websockets-16.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a0eadbbf2c30f01efa58e1f110eb6fa293261f6b0b1aa38f7f48707107690af9", size = 187204, upload-time = "2026-07-17T22:50:25.548Z" },
+    { url = "https://files.pythonhosted.org/packages/26/89/9667c256c256dafcc62d21328ce7a40067da857969b68ee9af375b0aaf72/websockets-16.1.1-cp314-cp314-win32.whl", hash = "sha256:195c978b065fa40910582464f99d6b15c8b314c68e0546549a55ed83f4735328", size = 179603, upload-time = "2026-07-17T22:50:27.086Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/dd/1c099d6c0fc5deb6b46ccdbb6981fdb4b12c917869cb3952408409dc18db/websockets-16.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:4e8d01cc3bcae7bbf8167f944aeafefed590fae5693552bba9794a9df68371cc", size = 179948, upload-time = "2026-07-17T22:50:28.521Z" },
+    { url = "https://files.pythonhosted.org/packages/35/25/9956b2d5e0529d5d23924f21bba1440d4c5c88a562e4f08550871ffa97a7/websockets-16.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0ffd3031ea8bda8d61762e84220186105ba3b748b3c8da2ae4f7816fac03e573", size = 179963, upload-time = "2026-07-17T22:50:29.982Z" },
+    { url = "https://files.pythonhosted.org/packages/17/06/55ffc976c488b6aee9ea05761ff7c4e88e7c1fd82818c8ca7b556ad2f90c/websockets-16.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:84a2cef8deffbd9ab8ee0ea546a2a6a7030c28f44e6cdd4547dbfeb489eb8999", size = 177497, upload-time = "2026-07-17T22:50:31.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/f7dac2e980bacc92bdc26cebae4ae4d50cae5380732c50980598fc0bbae4/websockets-16.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3df13f73af9b3b38ab1195eb299ecb67a4330c911c97ae04043ff74085728abe", size = 177698, upload-time = "2026-07-17T22:50:32.829Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/39/26762f734113e22da2b942c3aca85798e0c0405d64c256549540ff31e5a1/websockets-16.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:23253dd5bcae3f9aaee0a1d30967a8dbd52e5d3cff93a2e5b84df57b77d4750d", size = 187561, upload-time = "2026-07-17T22:50:34.24Z" },
+    { url = "https://files.pythonhosted.org/packages/11/94/c3f330851806b9b02138b774d593478323e73c99238681b4b93efe64e02d/websockets-16.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c1c5705e314449e3308872fe084b8571ce078ee4fc55a98a769bdefe5917392", size = 188732, upload-time = "2026-07-17T22:50:36.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f2/eb2c450f052de334ae33cf200ece6e87b0e14d186807074e4eb1cd2cdea2/websockets-16.1.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:69e52d175a0a7d1e13b4b67ad41c560b7d98e8c6f6126eb0bda496c784faf8c7", size = 190872, upload-time = "2026-07-17T22:50:38.008Z" },
+    { url = "https://files.pythonhosted.org/packages/70/31/2ac8cecf3a74f7fed9132129fc3d90b3998a1554570c11a69b2a8c20332d/websockets-16.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1f79c89b5eb034d1722938a891916582f8f7f503f58ca22518a63c3f2cd18499", size = 189305, upload-time = "2026-07-17T22:50:39.53Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/cf/8ab19650d3c0d4562c92e70ab47c257c4aa5c6a713ed87fe63766b31fefc/websockets-16.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39f2a024af5c345ffe8fcf1ee18c049c024c94df393bb09b044a6917c77bde43", size = 188033, upload-time = "2026-07-17T22:50:40.912Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d7/a49a38a6127a4acb134fb1912b215d900cc657605cff32445bf519f3acc4/websockets-16.1.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:952303a7318d4cbe1011400839bb2051c9f84fa0a35923267f5daba34b15d458", size = 185748, upload-time = "2026-07-17T22:50:42.559Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3e/ad1fa40388c7f2e0bb2c7930d0090b6c5498594bd1cdaec18864df3d9e97/websockets-16.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:249116b4a76063d930a46391ad56e135c286e4562a18309029fc2c73f4ed4c62", size = 188285, upload-time = "2026-07-17T22:50:43.974Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b8/d5db28ca264b9104f82196f92dc8843e35fd391f763d42e4ad358f5bc97e/websockets-16.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:61922544a0587a13fd3f53e4c0e5e606510c7b0d9d22c8444e5fae22a06b38cb", size = 186777, upload-time = "2026-07-17T22:50:45.474Z" },
+    { url = "https://files.pythonhosted.org/packages/42/9c/726cb39d0cc43ae848dce4aa2acb04eecc6738b1264ec6d700bf6bcfb9f8/websockets-16.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:46dcaa042cd1de6c59e7d9269fa63ff7572b6df40510600b678f0826b3c7af51", size = 188682, upload-time = "2026-07-17T22:50:46.973Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c7/1168704de8c2dd483edabe4a22cbe4465dd8be8dd95561d214f9fe092871/websockets-16.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:38565aca3e01ea8734e578fb2118dade0ecb0250533f29e22b8d1a7a196cf4d0", size = 186377, upload-time = "2026-07-17T22:50:48.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/40/f9ff2d630ffce4e7dfea0b2288e1caf9ebbf9ff8a9ec9396136ce8b94935/websockets-16.1.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:42f599f4d48c7e1a3338fdaac3acd075be3b3cf02d4b274f3bf2767aedd3d217", size = 187148, upload-time = "2026-07-17T22:50:49.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/71/e177c8299f78d7cbe2d14df228643c10c70c0e86e108e092056bbcc16e46/websockets-16.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dcc04fedf83effaeb9cce98abc9469bb1b42ef85f03e01c8c1f4438ef7555737", size = 187578, upload-time = "2026-07-17T22:50:51.619Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b2/b6987faf330f5af5c787a2610124c2e8403d51724f9001ec4fff6311fe7a/websockets-16.1.1-cp314-cp314t-win32.whl", hash = "sha256:8483c2096363120eea8b07c06ae7304d520f686665fffd4811fad423930a65d7", size = 179729, upload-time = "2026-07-17T22:50:53.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6e/fbac6ed878dd362fbad7d415fa4f84d38e3e33fed8cde45c64e783acf826/websockets-16.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bcce07e23e5769375158f5efdcdafa8d5cd014b93c6683865b840ed65b96f231", size = 180072, upload-time = "2026-07-17T22:50:54.969Z" },
+    { url = "https://files.pythonhosted.org/packages/be/4d/2d0d67834092e354d2b0498f014a41249a89556bc406cf86f3e1557bb463/websockets-16.1.1-py3-none-any.whl", hash = "sha256:6abbd3e82c731c8e531714466acd5d87b5e88ac3243465337ba71d68e23ae7e3", size = 173814, upload-time = "2026-07-17T22:51:04.184Z" },
+]

--- a/src/oci-document-understanding-mcp-server/uv.lock
+++ b/src/oci-document-understanding-mcp-server/uv.lock
@@ -8,6 +8,12 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
+[manifest]
+members = [
+    "oracle-mcp-common",
+    "oracle-oci-document-understanding-mcp-server",
+]
+
 [[package]]
 name = "aiofile"
 version = "3.11.1"
@@ -759,12 +765,40 @@ wheels = [
 ]
 
 [[package]]
+name = "oracle-mcp-common"
+version = "0.1.2"
+source = { editable = "../common" }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "oci" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", specifier = ">=3.2.4,<4.0.0" },
+    { name = "oci", specifier = ">=2.179.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+]
+
+[[package]]
 name = "oracle-oci-document-understanding-mcp-server"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "oci" },
+    { name = "oracle-mcp-common" },
     { name = "pydantic" },
 ]
 
@@ -778,6 +812,7 @@ dev = [
 requires-dist = [
     { name = "fastmcp", specifier = "==3.4.2" },
     { name = "oci", specifier = "==2.179.0" },
+    { name = "oracle-mcp-common", editable = "../common" },
     { name = "pydantic", specifier = "==2.12.3" },
 ]
 

--- a/src/oci-document-understanding-mcp-server/uv.lock
+++ b/src/oci-document-understanding-mcp-server/uv.lock
@@ -766,7 +766,7 @@ wheels = [
 
 [[package]]
 name = "oracle-mcp-common"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "../common" }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
# Description

Adds the OCI Document Understanding MCP server under `src/oci-document-understanding-mcp-server`.

This server provides stdio MCP tools for OCI Document Understanding extraction and classification workflows. It supports extracting text, key-value pairs, tables, and document elements, as well as document classification for inline base64 documents and OCI Object Storage document sources.

The implementation follows the repository MCP server structure and public packaging expectations:

- Adds `pyproject.toml`, `uv.lock`, `README.md`, `CHANGELOG.md`, `LICENSE.txt`, and `oracle/` package source.
- Exposes the package entry point as `oracle.oci-document-understanding-mcp-server`.
- Supports stdio transport only.
- Supports OCI SDK session-token, API-key, and instance-principal authentication, plus deterministic stub mode for local testing without OCI calls.
- Documents that HTTP, streamable HTTP, OAuth, IDCS bearer-token validation, `/mcp`, and `/.well-known/*` endpoints are not exposed.
- Adds `document_extract` for text, key-value, table, and document-element extraction.
- Adds `document_classify` for document classification and confidence-aware candidate results.
- Supports inline base64 and OCI Object Storage document sources.
- Adds request validation, OCI request mapping, response parsing, and structured error handling.
- Adds OCI SDK `additional_user_agent` telemetry derived from package metadata.
- Includes unit tests with a coverage threshold set to 90%.

Fixes: N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Validated locally from `src/oci-document-understanding-mcp-server`:

- [x] `uv run pytest --cov=. --cov-branch --cov-report=term-missing`
  - `39 passed`
  - Coverage: `93.73%`
- [x] `uv build`
  - Successfully built sdist and wheel.
- [x] MCP stub-mode smoke testing
  - Started the server locally with `DOCUMENT_MCP_MODE=stub` and `OCI_AUTH_MODE=none`.
  - Verified `document_extract` through the local stdio MCP server.
  - Verified `document_classify` through the local stdio MCP server.
  - Confirmed both tools completed without OCI credentials or OCI service calls.

**Test Configuration**:
- OS: macOS
- Python: 3.13.2
- Package manager: uv
- MCP transport: stdio
- Stub-mode auth: `OCI_AUTH_MODE=none`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A)