### PR TITLE
chore: update denylist to match OCI CLI and pin version

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,7 +15,8 @@ To generate an updated version of the deny list, follow these steps:
    uv run --project ../src/oci-api-mcp-server python oci-api-denylist-generator.py
    ```
 4. The script enumerates the installed OCI CLI's canonical Click command tree, generates a new
-   `denylist_<version>` file, and updates the `denylist` file for that CLI version.
+   `denylist_<version>` file, and atomically updates the generated files in the `scripts`
+   directory for that CLI version.
 5. Review the generated diff to confirm every candidate is a mutating operation and that no
    mutating command uses an action outside the configured action set.
 6. Copy the reviewed denylist to the [oci-api-mcp-server denylist](../src/oci-api-mcp-server/oracle/oci_api_mcp_server/denylist) and restart the `oci-api-mcp-server`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,12 +15,16 @@ To generate an updated version of the deny list, follow these steps:
    python oci-api-denylist-generator.py
    ```
 4. The script will generate a new `denylist_<version>` file and update the `denylist` file with the latest deny list based on the current OCI CLI version.
-5. To use the newly generated deny list, copy the denylist to the [oci-api-mcp-server denylist](../src/oci-api-mcp-server/oracle/oci_api_mcp_server/denylist) and restart the `oci-api-mcp-server`.
+5. Review the generated diff to confirm every candidate is a mutating operation and that no
+   mutating command uses an action outside the configured action set.
+6. Copy the reviewed denylist to the [oci-api-mcp-server denylist](../src/oci-api-mcp-server/oracle/oci_api_mcp_server/denylist) and restart the `oci-api-mcp-server`.
 
 ## Notes
 
 - The script automatically backs up the existing deny list file if it already exists for the current OCI CLI version.
-- The deny list includes commands that can potentially change the configuration of the cloud system.
+- Compound action names such as `bulk-delete` are included, while `create-*`, `get-*`,
+  `list-*`, and `cancel-*` commands are excluded from automatic classification.
+- The action-name classification produces review candidates; it is not a semantic guarantee.
 - The generated `denylist` file is used by the AI client to determine which commands to deny execution for.
 
 ----

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,13 +8,14 @@ The `oci-api-denylist-generator.py` script generates a deny list of OCI CLI comm
 
 To generate an updated version of the deny list, follow these steps:
 
-1. Ensure you have the OCI CLI installed and configured on your system.
+1. Sync the `oci-api-mcp-server` environment so its pinned OCI CLI is installed.
 2. Navigate to the `scripts` directory.
 3. Run the `oci-api-denylist-generator.py` script using Python:
    ```bash
-   python oci-api-denylist-generator.py
+   uv run --project ../src/oci-api-mcp-server python oci-api-denylist-generator.py
    ```
-4. The script will generate a new `denylist_<version>` file and update the `denylist` file with the latest deny list based on the current OCI CLI version.
+4. The script enumerates the installed OCI CLI's canonical Click command tree, generates a new
+   `denylist_<version>` file, and updates the `denylist` file for that CLI version.
 5. Review the generated diff to confirm every candidate is a mutating operation and that no
    mutating command uses an action outside the configured action set.
 6. Copy the reviewed denylist to the [oci-api-mcp-server denylist](../src/oci-api-mcp-server/oracle/oci_api_mcp_server/denylist) and restart the `oci-api-mcp-server`.

--- a/scripts/oci-api-denylist-generator.py
+++ b/scripts/oci-api-denylist-generator.py
@@ -5,9 +5,12 @@ https://oss.oracle.com/licenses/upl.
 """
 
 import os
-import re
-import subprocess
 from datetime import datetime
+from importlib.metadata import version
+
+import click
+from oci_cli import dynamic_loader
+from oci_cli.cli_root import cli
 
 
 DENIED_ACTIONS = frozenset(
@@ -43,78 +46,39 @@ def get_denied_commands(commands: list[str]) -> list[str]:
 
 
 def get_oci_version():
-    result = subprocess.run(["oci", "--version", "--raw-output"], capture_output=True, text=True)
-    return result.stdout.strip()
+    return version("oci-cli")
 
 
-def get_services():
-    result = subprocess.run(["oci", "--help"], capture_output=True, text=True)
-    output = result.stdout.splitlines()
-    services = []
-    for line in output:
-        match = re.match(r"^\s{4}(\w+(-\w+)*)", line)
-        if match:
-            services.append(match.group(1))
-    services = services[5:]  # Skipping the first 5 lines as they are not services
-    services.sort()
-    return services
-
-
-def get_sub_commands(command: str):
-    indentation_level = len(command.split())
-    print(f"{'  ' * indentation_level}Getting subcommands for: {command}")
-    try:
-        result = subprocess.run(f"oci {command} --help", shell=True, capture_output=True, text=True)
-        output = result.stdout.splitlines()
-        sub_commands = []
-        in_commands_section = False
-        for line in output:
-            if "Commands:" in line:
-                in_commands_section = True
-                continue
-            if in_commands_section:
-                if line.startswith("   "):
-                    continue
-                # match = re.match(r"^\s{2}(\w+)", line)
-                match = line.split()[0]
-                if match:
-                    print(f"{'  ' * indentation_level}Appending sub command {match}")
-                    sub_commands.append(match)
-        if not sub_commands:
-            return [command]
-        else:
-            commands = []
-            for sub_command in sub_commands:
-                commands.extend(get_sub_commands(f"{command} {sub_command}"))
-            return commands
-    except Exception as e:
-        print(f"Error getting sub-commands for {command}: {e}")
-        return []
+def get_canonical_commands() -> list[str]:
+    """Return every canonical leaf command from the installed OCI CLI."""
+    dynamic_loader.load_all_services()
+    commands = []
+    groups = [("", cli)]
+    while groups:
+        prefix, group = groups.pop()
+        for name, command in group.commands.items():
+            command_path = f"{prefix} {name}".strip()
+            if isinstance(command, click.Group):
+                groups.append((command_path, command))
+            else:
+                commands.append(command_path)
+    return sorted(commands)
 
 
 def get_commands(version):
     commands_file = f"commands_{version}.txt"
-    if not os.path.exists(commands_file):
-        print(f"Creating {commands_file} file..")
-        services = get_services()
-        with open(commands_file, "w") as f:
-            f.write(
-                (
-                    "# Copyright (c) 2025, Oracle and/or its affiliates.\n"
-                    "# Licensed under the Universal Permissive License v1.0 as shown at\n"
-                    "# https://oss.oracle.com/licenses/upl.\n\n"
-                    "# This list contains all OCI cli commands\n\n"
-                )
+    print(f"Creating {commands_file} file..")
+    with open(commands_file, "w") as f:
+        f.write(
+            (
+                "# Copyright (c) 2025, Oracle and/or its affiliates.\n"
+                "# Licensed under the Universal Permissive License v1.0 as shown at\n"
+                "# https://oss.oracle.com/licenses/upl.\n\n"
+                "# This list contains all OCI cli commands\n\n"
             )
-
-            for service in services:
-                print(f"Generating commands for service: {service}")
-                commands = get_sub_commands(service)
-                for command in commands:
-                    f.write(command + "\n")
-                    f.flush()
-    else:
-        print(f"Commands already exist for version {version}")
+        )
+        for command in get_canonical_commands():
+            f.write(command + "\n")
 
 
 def create_denylist(version):

--- a/scripts/oci-api-denylist-generator.py
+++ b/scripts/oci-api-denylist-generator.py
@@ -10,6 +10,38 @@ import subprocess
 from datetime import datetime
 
 
+DENIED_ACTIONS = frozenset(
+    {
+        "delete",
+        "patch",
+        "put",
+        "remove",
+        "replace",
+        "terminate",
+        "update",
+    }
+)
+EXCLUDED_ACTION_PREFIXES = ("cancel-", "create-", "get-", "list-")
+ALWAYS_DENIED_COMMANDS = frozenset({"raw-request"})
+
+
+def is_denied_command(command: str) -> bool:
+    """Return whether a canonical CLI path is a denylist candidate."""
+    action = command.rsplit(" ", 1)[-1]
+    if action.startswith(EXCLUDED_ACTION_PREFIXES):
+        return False
+    return bool(DENIED_ACTIONS.intersection(action.split("-")))
+
+
+def get_denied_commands(commands: list[str]) -> list[str]:
+    """Return the reviewed-action candidates plus mandatory denied commands."""
+    return sorted(
+        ALWAYS_DENIED_COMMANDS.union(
+            command for command in commands if is_denied_command(command)
+        )
+    )
+
+
 def get_oci_version():
     result = subprocess.run(["oci", "--version", "--raw-output"], capture_output=True, text=True)
     return result.stdout.strip()
@@ -97,22 +129,10 @@ def create_denylist(version):
     with open(commands_file, "r") as f:
         commands = [line.strip() for line in f if not line.strip().startswith("#") and len(line.strip()) > 0]
 
-    actions = [
-        "delete",
-        "terminate",
-        "put",
-        "update",
-        "replace",
-        "remove",
-        "patch",
-    ]
-
-    denied_commands = [
-        cmd.strip() for cmd in commands if any(cmd.split()[-1].startswith(action) for action in actions)
-    ]
+    denied_commands = get_denied_commands(commands)
 
     with open(denylist_filename, "w") as f:
-        for command in sorted(denied_commands):
+        for command in denied_commands:
             f.write(command + "\n")
 
     with open(denylist_prefix, "w") as f:
@@ -126,7 +146,7 @@ def create_denylist(version):
                 "# It should also stop suggesting any alternatives to the user\n\n"
             )
         )
-        f.write("\n".join(sorted(denied_commands)))
+        f.write("\n".join(denied_commands))
 
     print(f"{denylist_prefix} has been created successfully")
 

--- a/scripts/oci-api-denylist-generator.py
+++ b/scripts/oci-api-denylist-generator.py
@@ -7,6 +7,8 @@ https://oss.oracle.com/licenses/upl.
 import os
 from datetime import datetime
 from importlib.metadata import version
+from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 import click
 from oci_cli import dynamic_loader
@@ -26,6 +28,20 @@ DENIED_ACTIONS = frozenset(
 )
 EXCLUDED_ACTION_PREFIXES = ("cancel-", "create-", "get-", "list-")
 ALWAYS_DENIED_COMMANDS = frozenset({"raw-request"})
+OUTPUT_DIR = Path(__file__).resolve().parent
+
+
+def write_file(path: Path, content: str) -> None:
+    """Replace a generated file without following destination symlinks."""
+    temporary_path = None
+    try:
+        with NamedTemporaryFile("w", dir=path.parent, delete=False, encoding="utf-8") as f:
+            temporary_path = Path(f.name)
+            f.write(content)
+        temporary_path.replace(path)
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
 
 
 def is_denied_command(command: str) -> bool:
@@ -66,28 +82,26 @@ def get_canonical_commands() -> list[str]:
 
 
 def get_commands(version):
-    commands_file = f"commands_{version}.txt"
+    commands_file = OUTPUT_DIR / f"commands_{version}.txt"
     print(f"Creating {commands_file} file..")
-    with open(commands_file, "w") as f:
-        f.write(
-            (
-                "# Copyright (c) 2025, Oracle and/or its affiliates.\n"
-                "# Licensed under the Universal Permissive License v1.0 as shown at\n"
-                "# https://oss.oracle.com/licenses/upl.\n\n"
-                "# This list contains all OCI cli commands\n\n"
-            )
-        )
-        for command in get_canonical_commands():
-            f.write(command + "\n")
+    header = (
+        "# Copyright (c) 2025, Oracle and/or its affiliates.\n"
+        "# Licensed under the Universal Permissive License v1.0 as shown at\n"
+        "# https://oss.oracle.com/licenses/upl.\n\n"
+        "# This list contains all OCI cli commands\n\n"
+    )
+    write_file(commands_file, header + "\n".join(get_canonical_commands()) + "\n")
 
 
 def create_denylist(version):
-    denylist_prefix = "denylist"
-    denylist_filename = f"{denylist_prefix}_{version}"
-    commands_file = f"commands_{version}.txt"
+    denylist_prefix = OUTPUT_DIR / "denylist"
+    denylist_filename = OUTPUT_DIR / f"denylist_{version}"
+    commands_file = OUTPUT_DIR / f"commands_{version}.txt"
 
     if os.path.exists(denylist_filename):
-        backup_filename = f"{denylist_filename}_backup_{datetime.now().strftime('%d%b%y_%H%M')}"
+        backup_filename = denylist_filename.with_name(
+            f"{denylist_filename.name}_backup_{datetime.now().strftime('%d%b%y_%H%M')}"
+        )
         os.rename(denylist_filename, backup_filename)
 
     with open(commands_file, "r") as f:
@@ -95,22 +109,17 @@ def create_denylist(version):
 
     denied_commands = get_denied_commands(commands)
 
-    with open(denylist_filename, "w") as f:
-        for command in denied_commands:
-            f.write(command + "\n")
+    write_file(denylist_filename, "\n".join(denied_commands) + "\n")
 
-    with open(denylist_prefix, "w") as f:
-        f.write(
-            (
-                "# Copyright (c) 2025, Oracle and/or its affiliates.\n"
-                "# Licensed under the Universal Permissive License v1.0 as shown at\n"
-                "# https://oss.oracle.com/licenses/upl.\n\n"
-                "# This list contains the list of commands that can change the configuration of the cloud system.\n"  # noqa E501
-                "# These commands will be denied execution and the AI client should immediately stop processing the command.\n"  # noqa E501
-                "# It should also stop suggesting any alternatives to the user\n\n"
-            )
-        )
-        f.write("\n".join(denied_commands))
+    header = (
+        "# Copyright (c) 2025, Oracle and/or its affiliates.\n"
+        "# Licensed under the Universal Permissive License v1.0 as shown at\n"
+        "# https://oss.oracle.com/licenses/upl.\n\n"
+        "# This list contains the list of commands that can change the configuration of the cloud system.\n"  # noqa E501
+        "# These commands will be denied execution and the AI client should immediately stop processing the command.\n"  # noqa E501
+        "# It should also stop suggesting any alternatives to the user\n\n"
+    )
+    write_file(denylist_prefix, header + "\n".join(denied_commands) + "\n")
 
     print(f"{denylist_prefix} has been created successfully")
 

--- a/src/oci-api-mcp-server/CHANGELOG.md
+++ b/src/oci-api-mcp-server/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Security
 
-- Updated the denylist to match OCI CLI 3.89.3, supporting compound actions like `bulk-delete`.
+- Updated the denylist to match OCI CLI 3.89.3's complete canonical command tree,
+  supporting compound actions like `bulk-delete`.
 - Restricted execution to OCI CLI 3.89.3 installed in the MCP server environment.
 
 ## 2.1.4

--- a/src/oci-api-mcp-server/CHANGELOG.md
+++ b/src/oci-api-mcp-server/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Security
 
 - Updated the denylist to match OCI CLI 3.89.3, supporting compound actions like `bulk-delete`.
+- Restricted execution to OCI CLI 3.89.3 installed in the MCP server environment.
 
 ## 2.1.4
 

--- a/src/oci-api-mcp-server/CHANGELOG.md
+++ b/src/oci-api-mcp-server/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Updated the denylist to match OCI CLI 3.89.3's complete canonical command tree,
   supporting compound actions like `bulk-delete`.
+- Prevented the denylist generator from following destination symlinks when writing files.
 - Restricted execution to OCI CLI 3.89.3 installed in the MCP server environment.
 
 ## 2.1.4

--- a/src/oci-api-mcp-server/CHANGELOG.md
+++ b/src/oci-api-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.5
+
+### Security
+
+- Updated the denylist to match OCI CLI 3.89.3, supporting compound actions like `bulk-delete`.
+
 ## 2.1.4
 
 ### Changed

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/__init__.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-api-mcp-server"
-__version__ = "2.1.4"
+__version__ = "2.1.5"

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/denylist
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/denylist
@@ -50,9 +50,11 @@ ai-vision vision-private-endpoint delete
 ai-vision vision-private-endpoint update
 analytics analytics-instance delete
 analytics analytics-instance delete-private-access-channel
+analytics analytics-instance delete-resource-group
 analytics analytics-instance delete-vanity-url
 analytics analytics-instance update
 analytics analytics-instance update-private-access-channel
+analytics analytics-instance update-resource-group
 analytics analytics-instance update-vanity-url
 analytics work-request delete
 announce announcement-subscription delete
@@ -93,6 +95,8 @@ apm-config config update-macs-extension
 apm-config config update-metric-group
 apm-config config update-options
 apm-config config update-span-filter
+apm-config data-file delete
+apm-config data-file put
 apm-config match-agents-with-attribute-key update
 apm-control-plane apm-domain delete
 apm-control-plane apm-domain update
@@ -147,6 +151,7 @@ bastion session delete
 bastion session update
 batch batch-context delete
 batch batch-context update
+batch batch-context update-oci-logging-configuration
 batch batch-job update
 batch batch-job-pool delete
 batch batch-job-pool update
@@ -375,6 +380,11 @@ compute-management instance-pool update
 container-instances container update
 container-instances container-instance delete
 container-instances container-instance update
+costad cost-alert-subscription delete
+costad cost-alert-subscription update
+costad cost-anomaly-event update
+costad cost-anomaly-monitor delete
+costad cost-anomaly-monitor update
 cpg cluster-placement-group delete
 cpg cluster-placement-group update
 dashboard-service dashboard delete
@@ -595,10 +605,14 @@ data-safe unified-audit-policy-definition delete
 data-safe unified-audit-policy-definition update
 data-safe user-assessment delete
 data-safe user-assessment update
+data-science compute-target delete
+data-science compute-target update
+data-science compute-target update-compute-target-update-managed-compute-cluster-configuration-details
 data-science ds-private-endpoint delete
 data-science ds-private-endpoint update
 data-science job delete
 data-science job update
+data-science job update-job-managed-compute-cluster-job-infrastructure-configuration-details
 data-science job-run delete
 data-science job-run update
 data-science ml-app delete
@@ -619,6 +633,7 @@ data-science model update-model-provenance
 data-science model-deployment delete
 data-science model-deployment update
 data-science model-deployment update-model-deployment-update-model-group-deployment-configuration-details
+data-science model-deployment update-model-deployment-update-single-model-deployment-flex-configuration-details
 data-science model-group delete
 data-science model-group update
 data-science model-group-version-history delete
@@ -719,6 +734,13 @@ database-migration migration remove-mysql-objects
 database-migration migration remove-oracle-objects
 database-migration migration update-mysql-migration
 database-migration migration update-oracle-migration
+datacc infrastructure delete
+datacc infrastructure update
+datacc maintenance-run update
+datacc vm-cluster-network delete
+datacc vm-cluster-network update
+datacc vm-instance delete
+datacc vm-instance update
 db advanced-cluster-file-system delete
 db advanced-cluster-file-system update
 db application-vip delete
@@ -843,12 +865,34 @@ dbtools connection update-generic-jdbc
 dbtools connection update-mysql-database
 dbtools connection update-oracle-database
 dbtools connection update-postgresql
+dbtools database-api-gateway-config delete
+dbtools database-api-gateway-config remove-lock
+dbtools database-api-gateway-config update-database-api-gateway-config-default
 dbtools identity delete
 dbtools identity remove-lock
 dbtools identity update-oracle-database-resource-principal
+dbtools mcp-server cascading-delete
+dbtools mcp-server delete
+dbtools mcp-server remove-lock
+dbtools mcp-server update-mcp-server-default
+dbtools mcp-toolset delete
+dbtools mcp-toolset remove-lock
+dbtools mcp-toolset update-mcp-toolset-built-in-sql-tools
+dbtools mcp-toolset update-mcp-toolset-custom-sql-tool
+dbtools mcp-toolset update-mcp-toolset-customizable-reporting-tools
+dbtools mcp-toolset update-mcp-toolset-gen-ai-sql-assistant
 dbtools private-endpoint delete
 dbtools private-endpoint remove-lock
 dbtools private-endpoint update
+dbtools sql-report delete
+dbtools sql-report remove-lock
+dbtools sql-report update-sql-report-oracle-database
+dbtools-runtime credential delete
+dbtools-runtime database-api-gateway-config-pool delete
+dbtools-runtime database-api-gateway-config-pool-api-spec delete
+dbtools-runtime database-api-gateway-config-pool-auto-api-spec delete
+dbtools-runtime execute-grantee delete
+dbtools-runtime public-synonym delete
 delegate-access-control delegation-control delete
 delegate-access-control delegation-control update
 delegate-access-control delegation-subscription delete
@@ -1114,14 +1158,23 @@ fs replication-target delete
 fs snapshot delete
 fs snapshot remove
 fs snapshot update
+fusion-apps email-subdomain delete
+fusion-apps email-subdomain update
 fusion-apps fusion-environment delete
 fusion-apps fusion-environment delete-fusion-environment-admin-user
 fusion-apps fusion-environment update
 fusion-apps fusion-environment-family delete
 fusion-apps fusion-environment-family update
+fusion-apps marketing-brand delete
+fusion-apps marketing-brand update
+fusion-apps microsite delete
+fusion-apps microsite update
 fusion-apps refresh-activity delete
 fusion-apps service-attachment delete
 fusion-apps update-refresh-activity-details update-refresh-activity
+fusion-apps vanity-domain update
+fusion-apps vanity-domain-activity delete
+fusion-apps vanity-domain-activity update
 gdp pipeline delete
 gdp pipeline update
 generative-ai api-key delete
@@ -1136,6 +1189,8 @@ generative-ai generative-ai-project delete
 generative-ai generative-ai-project update
 generative-ai hosted-application delete
 generative-ai hosted-application update
+generative-ai hosted-application-iam delete
+generative-ai hosted-application-iam update
 generative-ai hosted-application-storage delete
 generative-ai hosted-deployment delete
 generative-ai hosted-deployment delete-hosted-deployment-artifact
@@ -1444,12 +1499,14 @@ jms-utils performance-tuning-analysis delete
 jms-utils subscription-acknowledgment-configuration update
 kafka cluster delete
 kafka cluster update
+kafka cluster update-public-connectivity-addon
 kafka cluster-config delete
 kafka cluster-config update
 kafka cluster-config-version delete
 kms ekm ekms-private-endpoint delete
 kms ekm ekms-private-endpoint update
 kms kms-hsm-cluster hsm-cluster update
+kms kms-hsm-cluster hsm-cluster update-audit-logging-destination
 kms management key update
 kms management vault delete-vault-replica
 kms management vault update
@@ -1667,6 +1724,7 @@ network ipv6 bulk-delete
 network ipv6 bulk-update
 network ipv6 delete
 network ipv6 update
+network letter-of-authority update-cross-connect
 network local-peering-gateway delete
 network local-peering-gateway update
 network nat-gateway delete
@@ -1693,11 +1751,13 @@ network security-list update
 network service-gateway delete
 network service-gateway update
 network subnet delete
+network subnet patch
 network subnet remove-ipv4-subnet-cidr
 network subnet remove-ipv6-subnet-cidr
 network subnet update
 network tunnel-cpe-device-config update
 network vcn delete
+network vcn patch
 network vcn remove-ipv6-vcn-cidr
 network vcn remove-vcn-cidr
 network vcn update
@@ -1956,6 +2016,10 @@ psql db-system delete
 psql db-system patch
 psql db-system update
 psql db-system update-db-system-db-instance
+psql db-system update-db-system-disabled-insight-details
+psql db-system update-db-system-disabled-kerberos-auth-details
+psql db-system update-db-system-enabled-insight-details
+psql db-system update-db-system-enabled-kerberos-auth-details
 queue messages delete-message
 queue messages delete-messages
 queue messages put-messages
@@ -1972,6 +2036,8 @@ recovery protection-policy delete
 recovery protection-policy update
 recovery recovery-service-subnet delete
 recovery recovery-service-subnet update
+redis oci-cache-backup oci-cache-backup delete
+redis oci-cache-backup oci-cache-backup update
 redis oci-cache-config-set oci-cache-config-set delete
 redis oci-cache-config-set oci-cache-config-set update
 redis oci-cache-user oci-cache-user delete
@@ -1987,7 +2053,7 @@ resource-analytics tenancy-attachment delete
 resource-analytics tenancy-attachment update
 resource-manager configuration-source-provider delete
 resource-manager configuration-source-provider update
-resource-manager configuration-source-provider update-bitbucket-cloud-username-app-password-provider
+resource-manager configuration-source-provider update-bitbucket-cloud-email-api-token-provider
 resource-manager configuration-source-provider update-bitbucket-server-access-token-provider
 resource-manager configuration-source-provider update-github-access-token-provider
 resource-manager configuration-source-provider update-gitlab-access-token-provider

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/denylist
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/denylist
@@ -145,15 +145,34 @@ bastion bastion delete
 bastion bastion update
 bastion session delete
 bastion session update
+batch batch-context delete
+batch batch-context update
+batch batch-job update
+batch batch-job-pool delete
+batch batch-job-pool update
+batch batch-task-environment delete
+batch batch-task-environment update
+batch batch-task-profile delete
+batch batch-task-profile update
 bds auto-scale-config delete
 bds bds-api-key delete
+bds bds-certificate-configuration delete
 bds bds-metastore-configuration delete
 bds bds-metastore-configuration update
 bds cloudsql remove
 bds identity-configuration delete
 bds identity-configuration update
 bds instance delete
+bds instance install-os-patch
+bds instance install-os-patch-batching-based-patching-configs
+bds instance install-os-patch-domain-based-patching-configs
+bds instance install-os-patch-downtime-based-patching-configs
+bds instance install-patch
+bds instance install-patch-batching-based-odh-patching-config
+bds instance install-patch-domain-based-odh-patching-config
+bds instance install-patch-downtime-based-odh-patching-config
 bds instance remove
+bds instance remove-nodes
 bds instance replace-node
 bds instance update
 bds instance update-node-backup-configuration
@@ -175,10 +194,15 @@ blockchain blockchain-platform update
 blockchain blockchain-platform update-osn
 blockchain blockchain-platform update-peer
 blockchain work-request delete
-budgets alert-rule delete
-budgets alert-rule update
-budgets budget delete
-budgets budget update
+budgets budget alert-rule delete
+budgets budget alert-rule update
+budgets budget budget delete
+budgets budget budget update
+budgets cost-ad cost-alert-subscription delete
+budgets cost-ad cost-alert-subscription update
+budgets cost-ad cost-anomaly-event update
+budgets cost-ad cost-anomaly-monitor delete
+budgets cost-ad cost-anomaly-monitor update
 bv backup delete
 bv backup update
 bv boot-volume delete
@@ -240,7 +264,9 @@ certs-mgmt certificate update-certificate-by-importing-config-details
 certs-mgmt certificate update-certificate-managed-externally
 certs-mgmt certificate update-certificate-managed-internally
 certs-mgmt certificate-authority update-root-ca-by-generating-config-details
+certs-mgmt certificate-authority update-root-ca-managed-externally
 certs-mgmt certificate-authority update-subordinate-ca-issued-by-internal-ca
+certs-mgmt certificate-authority update-subordinate-ca-managed-internally-issued-by-external-ca
 cloud-bridge discovery asset-source delete
 cloud-bridge discovery asset-source update
 cloud-bridge discovery discovery-schedule delete
@@ -307,6 +333,7 @@ cloud-migrations replication-schedule delete
 cloud-migrations replication-schedule update
 cloud-migrations target-asset delete
 cloud-migrations target-asset update
+cloud-migrations target-asset update-target-asset-update-olvm-target-asset-details
 compute capacity-reservation delete
 compute capacity-reservation update
 compute capacity-topology delete
@@ -394,6 +421,7 @@ data-catalog term delete
 data-catalog term update
 data-catalog term-relationship delete
 data-catalog term-relationship update
+data-flow application cascading-delete
 data-flow application delete
 data-flow application update
 data-flow pool delete
@@ -477,6 +505,7 @@ data-labeling-service-dataplane record update
 data-labeling-service-dataplane record update-record-document-metadata
 data-labeling-service-dataplane record update-record-image-metadata
 data-labeling-service-dataplane record update-record-text-metadata
+data-safe alert alerts-update
 data-safe alert patch
 data-safe alert update
 data-safe alert-policy delete
@@ -665,6 +694,20 @@ database-management tablespace remove-data-file-database-secret-credential-detai
 database-management tablespace remove-datafile-with-pwd
 database-management tablespace remove-datafile-with-secret
 database-management tablespace update
+database-migration advisor-report-check update
+database-migration advisor-report-check-collection update-advisor-report-check-objects
+database-migration advisor-report-check-collection update-advisor-report-check-objects-all-update-advisor-report-check-objects-details
+database-migration advisor-report-check-collection update-advisor-report-check-objects-list-update-advisor-report-check-objects-details
+database-migration advisor-report-check-collection update-check-action-update-object
+database-migration advisor-report-check-collection update-check-action-update-object-all-update-check-action-update-object-details
+database-migration advisor-report-check-collection update-check-action-update-object-list-update-check-action-update-object-details
+database-migration assessment delete
+database-migration assessment remove
+database-migration assessment remove-assessment-objects-my-sql-assessment-object-collection
+database-migration assessment remove-assessment-objects-oracle-assessment-object-collection
+database-migration assessment update
+database-migration assessment update-assessment-update-my-sql-assessment-details
+database-migration assessment update-assessment-update-oracle-assessment-details
 database-migration connection delete
 database-migration connection update-mysql-connection
 database-migration connection update-oracle-connection
@@ -676,12 +719,20 @@ database-migration migration remove-mysql-objects
 database-migration migration remove-oracle-objects
 database-migration migration update-mysql-migration
 database-migration migration update-oracle-migration
+db advanced-cluster-file-system delete
+db advanced-cluster-file-system update
 db application-vip delete
 db autonomous-container-database terminate
 db autonomous-container-database update
 db autonomous-container-database-dataguard update
 db autonomous-database delete
 db autonomous-database update
+db autonomous-database update-autonomous-database-aws-key-details
+db autonomous-database update-autonomous-database-azure-key-details
+db autonomous-database update-autonomous-database-gcp-key-details
+db autonomous-database update-autonomous-database-oci-key-details
+db autonomous-database update-autonomous-database-okv-key-details
+db autonomous-database update-autonomous-database-oracle-managed-key-details
 db autonomous-database-backup delete
 db autonomous-database-backup update
 db autonomous-database-software-image delete
@@ -709,12 +760,14 @@ db console-history update
 db data-guard-association update
 db database delete
 db database patch
+db database run-data-patch
 db database update
 db database update-data-guard
 db database-software-image delete
 db database-software-image update
 db db-home delete
 db db-home update
+db dbnode-snapshot delete
 db exadata-infrastructure delete
 db exadata-infrastructure update
 db exadb-vm-cluster delete
@@ -746,11 +799,13 @@ db pluggable-database delete-snapshot
 db pluggable-database update
 db scheduled-action delete
 db scheduled-action update
+db scheduling-plan cascading-delete
 db scheduling-plan delete
 db scheduling-policy delete
 db scheduling-policy update
 db scheduling-window delete
 db scheduling-window update
+db system execute-db-system-os-patch
 db system patch
 db system terminate
 db system update
@@ -762,6 +817,10 @@ db vm-cluster-network delete
 db vm-cluster-network update
 dbmulticloud multi-cloud-resource-discovery delete
 dbmulticloud multi-cloud-resource-discovery update
+dbmulticloud oracle-db-aws-identity-connector delete
+dbmulticloud oracle-db-aws-identity-connector update
+dbmulticloud oracle-db-aws-key delete
+dbmulticloud oracle-db-aws-key update
 dbmulticloud oracle-db-azure-blob-container delete
 dbmulticloud oracle-db-azure-blob-container update
 dbmulticloud oracle-db-azure-blob-mount delete
@@ -771,6 +830,7 @@ dbmulticloud oracle-db-azure-connector patch
 dbmulticloud oracle-db-azure-connector update
 dbmulticloud oracle-db-azure-vault delete
 dbmulticloud oracle-db-azure-vault update
+dbmulticloud oracle-db-azure-vault-association cascading-delete
 dbmulticloud oracle-db-azure-vault-association delete
 dbmulticloud oracle-db-azure-vault-association update
 dbmulticloud oracle-db-gcp-identity-connector delete
@@ -783,6 +843,9 @@ dbtools connection update-generic-jdbc
 dbtools connection update-mysql-database
 dbtools connection update-oracle-database
 dbtools connection update-postgresql
+dbtools identity delete
+dbtools identity remove-lock
+dbtools identity update-oracle-database-resource-principal
 dbtools private-endpoint delete
 dbtools private-endpoint remove-lock
 dbtools private-endpoint update
@@ -793,6 +856,8 @@ delegate-access-control delegation-subscription update
 demand-signal occ-demand-signal delete
 demand-signal occ-demand-signal patch
 demand-signal occ-demand-signal update
+demand-signal occ-metric-alarm delete
+demand-signal occ-metric-alarm update
 desktops desktop delete
 desktops desktop update
 desktops desktop-pool delete
@@ -851,6 +916,7 @@ devops deployment update
 devops deployment update-single-stage-redeployment
 devops project delete
 devops project delete-project-settings
+devops project schedule-cascading-delete
 devops project update
 devops project update-notification-preference
 devops project update-project-settings
@@ -879,6 +945,10 @@ devops trigger update-github-trigger
 devops trigger update-gitlab-server-trigger
 devops trigger update-gitlab-trigger
 devops trigger update-vbs-trigger
+dif stack delete
+dif stack update
+disaster-recovery automatic-dr-configuration delete
+disaster-recovery automatic-dr-configuration update
 disaster-recovery dr-plan delete
 disaster-recovery dr-plan update
 disaster-recovery dr-plan-execution delete
@@ -922,6 +992,9 @@ email dkim update
 email domain delete
 email domain remove
 email domain update
+email email-ip-pool delete
+email email-ip-pool remove
+email email-ip-pool update
 email email-return-path delete
 email email-return-path remove
 email email-return-path update
@@ -997,6 +1070,7 @@ fleet-software-update fsu-collection update
 fleet-software-update fsu-cycle delete
 fleet-software-update fsu-cycle update
 fleet-software-update fsu-cycle update-fifty-batch
+fleet-software-update fsu-cycle update-fsu-cycle-exadb-stack-fsu-goal-version-details
 fleet-software-update fsu-cycle update-fsu-cycle-update-upgrade-fsu-cycle
 fleet-software-update fsu-cycle update-image-id-target
 fleet-software-update fsu-cycle update-non-rolling-batch
@@ -1009,6 +1083,8 @@ fleet-software-update fsu-discovery delete
 fleet-software-update fsu-discovery update
 fleet-software-update fsu-job delete
 fleet-software-update fsu-job update
+fleet-software-update fsu-readiness-check delete
+fleet-software-update fsu-readiness-check update
 fn application delete
 fn application update
 fn function delete
@@ -1046,17 +1122,35 @@ fusion-apps fusion-environment-family update
 fusion-apps refresh-activity delete
 fusion-apps service-attachment delete
 fusion-apps update-refresh-activity-details update-refresh-activity
-gdd private-endpoint delete
-gdd private-endpoint update
-gdd sharded-database delete
-gdd sharded-database patch
-gdd sharded-database update
+gdp pipeline delete
+gdp pipeline update
+generative-ai api-key delete
+generative-ai api-key update
 generative-ai dedicated-ai-cluster delete
 generative-ai dedicated-ai-cluster update
 generative-ai endpoint delete
 generative-ai endpoint update
+generative-ai generative-ai-private-endpoint delete
+generative-ai generative-ai-private-endpoint update
+generative-ai generative-ai-project delete
+generative-ai generative-ai-project update
+generative-ai hosted-application delete
+generative-ai hosted-application update
+generative-ai hosted-application-storage delete
+generative-ai hosted-deployment delete
+generative-ai hosted-deployment delete-hosted-deployment-artifact
+generative-ai hosted-deployment update
+generative-ai imported-model delete
+generative-ai imported-model update
 generative-ai model delete
 generative-ai model update
+generative-ai semantic-store delete
+generative-ai semantic-store update
+generative-ai vector-store-connector delete
+generative-ai vector-store-connector update
+generative-ai vector-store-connector update-vector-store-connector-oci-object-storage-configuration
+generative-ai vector-store-connector update-vector-store-connector-schedule-cron-config
+generative-ai vector-store-connector update-vector-store-connector-schedule-interval-config
 generative-ai-agent agent delete
 generative-ai-agent agent update
 generative-ai-agent agent-endpoint delete
@@ -1069,6 +1163,8 @@ generative-ai-agent knowledge-base delete
 generative-ai-agent knowledge-base update
 generative-ai-agent knowledge-base update-oci-database-kb
 generative-ai-agent knowledge-base update-oci-open-search-kb
+generative-ai-agent provisioned-capacity delete
+generative-ai-agent provisioned-capacity update
 generative-ai-agent tool delete
 generative-ai-agent tool update
 generative-ai-agent tool update-tool-agent-tool-config
@@ -1104,6 +1200,7 @@ goldengate connection update-microsoft-sqlserver-connection
 goldengate connection update-mongo-db-connection
 goldengate connection update-mysql-connection
 goldengate connection update-object-storage-connection
+goldengate connection update-oracle-ai-data-platform-connection
 goldengate connection update-oracle-connection
 goldengate connection update-oracle-nosql-connection
 goldengate connection update-postgresql-connection
@@ -1134,6 +1231,7 @@ health-checks ping-monitor update
 iam auth-token delete
 iam auth-token update
 iam authentication-policy update
+iam compartment bulk-delete-resources
 iam compartment delete
 iam compartment update
 iam customer-secret-key delete
@@ -1154,11 +1252,13 @@ iam policy delete
 iam policy update
 iam smtp-credential delete
 iam smtp-credential update
+iam tag bulk-delete
 iam tag delete
 iam tag update
 iam tag-default delete
 iam tag-default remove
 iam tag-default update
+iam tag-namespace cascade-delete
 iam tag-namespace delete
 iam tag-namespace remove
 iam tag-namespace update
@@ -1213,6 +1313,12 @@ identity-domains grant patch
 identity-domains group delete
 identity-domains group patch
 identity-domains group put
+identity-domains identity-proofing-provider delete
+identity-domains identity-proofing-provider patch
+identity-domains identity-proofing-provider put
+identity-domains identity-proofing-provider-template delete
+identity-domains identity-proofing-provider-template patch
+identity-domains identity-proofing-provider-template put
 identity-domains identity-propagation-trust delete
 identity-domains identity-propagation-trust patch
 identity-domains identity-propagation-trust put
@@ -1223,6 +1329,8 @@ identity-domains identity-setting patch
 identity-domains identity-setting put
 identity-domains kmsi-setting patch
 identity-domains kmsi-setting put
+identity-domains mapped-attribute patch
+identity-domains mapped-attribute put
 identity-domains me patch
 identity-domains me put
 identity-domains me-password-changer put
@@ -1288,6 +1396,18 @@ identity-domains user-status-changer put
 integration integration-instance delete
 integration integration-instance remove
 integration integration-instance update
+iot digital-twin-adapter delete
+iot digital-twin-adapter update
+iot digital-twin-instance delete
+iot digital-twin-instance update
+iot digital-twin-model delete
+iot digital-twin-model update
+iot digital-twin-relationship delete
+iot digital-twin-relationship update
+iot domain delete
+iot domain update
+iot domain-group delete
+iot domain-group update
 jms blocklist delete
 jms crypto-analysis-result delete
 jms drs-file delete
@@ -1302,11 +1422,26 @@ jms java-migration-analysis-result delete
 jms jms-plugin delete
 jms jms-plugin update
 jms performance-tuning-analysis-result delete
+jms task-schedule delete
+jms task-schedule update
+jms task-schedule update-task-schedule-add-installation-site-task-details
+jms task-schedule update-task-schedule-crypto-task-details
+jms task-schedule update-task-schedule-deployed-application-migration-task-details
+jms task-schedule update-task-schedule-java-migration-task-details
+jms task-schedule update-task-schedule-jfr-task-details
+jms task-schedule update-task-schedule-performance-tuning-task-details
+jms task-schedule update-task-schedule-remove-installation-site-task-details
+jms task-schedule update-task-schedule-scan-java-server-task-details
+jms task-schedule update-task-schedule-scan-library-task-details
 jms-java-downloads java-download-report delete
 jms-java-downloads java-download-token delete
 jms-java-downloads java-download-token update
 jms-java-downloads java-license-acceptance-record delete
 jms-java-downloads java-license-acceptance-record update
+jms-utils analyze-applications-configuration update
+jms-utils java-migration-analysis delete
+jms-utils performance-tuning-analysis delete
+jms-utils subscription-acknowledgment-configuration update
 kafka cluster delete
 kafka cluster update
 kafka cluster-config delete
@@ -1342,14 +1477,18 @@ lb ssl-cipher-suite delete
 lb ssl-cipher-suite update
 lfs lustre-file-system delete
 lfs lustre-file-system update
+lfs object-storage-link delete
+lfs object-storage-link update
 license-manager configuration update
 license-manager license-record delete
 license-manager license-record update
 license-manager product-license delete
 license-manager product-license update
 limits quota delete
-limits quota removelock
 limits quota update
+limits-increase limits-increase-request delete
+limits-increase limits-increase-request patch
+limits-increase limits-increase-request update
 log-analytics assoc delete-assocs
 log-analytics category remove-resource-category
 log-analytics category update-resource-category
@@ -1420,8 +1559,10 @@ marketplace-publisher artifact update-artifact-update-container-image-artifact-d
 marketplace-publisher artifact update-artifact-update-kubernetes-image-artifact-details
 marketplace-publisher artifact update-artifact-update-machine-image-artifact-details
 marketplace-publisher artifact update-artifact-update-stack-artifact-details
+marketplace-publisher listing cascading-delete
 marketplace-publisher listing delete
 marketplace-publisher listing update
+marketplace-publisher listing-revision cascading-delete
 marketplace-publisher listing-revision delete
 marketplace-publisher listing-revision update
 marketplace-publisher listing-revision update-listing-revision-icon-content
@@ -1481,6 +1622,7 @@ mysql channel delete
 mysql channel update-from-mysql
 mysql configuration delete
 mysql configuration update
+mysql db-system controlled-update
 mysql db-system delete
 mysql db-system heatwave-cluster delete
 mysql db-system heatwave-cluster update
@@ -1521,6 +1663,8 @@ network ip-sec-connection delete
 network ip-sec-connection update
 network ip-sec-psk update
 network ip-sec-tunnel update
+network ipv6 bulk-delete
+network ipv6 bulk-update
 network ipv6 delete
 network ipv6 update
 network local-peering-gateway delete
@@ -1531,6 +1675,8 @@ network nsg delete
 network nsg rules remove
 network nsg rules update
 network nsg update
+network private-ip bulk-delete
+network private-ip bulk-update
 network private-ip delete
 network private-ip update
 network public-ip delete
@@ -1547,6 +1693,7 @@ network security-list update
 network service-gateway delete
 network service-gateway update
 network subnet delete
+network subnet remove-ipv4-subnet-cidr
 network subnet remove-ipv6-subnet-cidr
 network subnet update
 network tunnel-cpe-device-config update
@@ -1556,6 +1703,7 @@ network vcn remove-vcn-cidr
 network vcn update
 network virtual-circuit delete
 network virtual-circuit update
+network virtual-circuit-public-prefix bulk-delete
 network vlan delete
 network vlan update
 network vnic update
@@ -1611,11 +1759,22 @@ nosql table update
 nosql work-request delete
 oce oce-instance delete
 oce oce-instance update
-ocvs cluster cluster delete
-ocvs cluster cluster update
+ocvs byol delete
+ocvs byol update
+ocvs byol-allocation delete
+ocvs byol-allocation update
+ocvs cluster delete
+ocvs cluster update
+ocvs datastore delete
+ocvs datastore update
+ocvs datastore-cluster delete
+ocvs datastore-cluster remove-datastore
+ocvs datastore-cluster update
 ocvs esxi-host delete
 ocvs esxi-host replace-host
 ocvs esxi-host update
+ocvs management-appliance delete
+ocvs management-appliance update
 ocvs sddc delete
 ocvs sddc update
 oda instance delete
@@ -1645,6 +1804,7 @@ oda management oda-private-endpoint delete
 oda management oda-private-endpoint update
 oda management oda-private-endpoint-attachment delete
 oda management oda-private-endpoint-scan-proxy delete
+oda management skill cascading-delete-skill-custom-entities
 oda management skill delete
 oda management skill update
 oda management skill-parameter delete
@@ -1681,6 +1841,10 @@ opsi awr-hub-sources delete
 opsi awr-hub-sources update
 opsi awr-hubs delete
 opsi awr-hubs update
+opsi chargeback-plan delete
+opsi chargeback-plan delete-chargeback-plan-report
+opsi chargeback-plan update
+opsi chargeback-plan update-chargeback-plan-report
 opsi database-insights delete
 opsi database-insights update-autonomous-db
 opsi database-insights update-em-external-db
@@ -1731,8 +1895,12 @@ organizations subscription-mapping delete
 os bucket delete
 os bucket update
 os ns update-metadata
+os object batch-delete
+os object bulk-delete
+os object bulk-delete-versions
 os object delete
 os object put
+os object resume-put
 os object update-storage-tier
 os object-lifecycle-policy delete
 os object-lifecycle-policy put
@@ -1742,6 +1910,10 @@ os private-endpoint update
 os replication delete-replication-policy
 os retention-rule delete
 os retention-rule update
+os-management-hub dynamic-set delete
+os-management-hub dynamic-set remove
+os-management-hub dynamic-set update
+os-management-hub dynamic-set update-packages
 os-management-hub event delete
 os-management-hub event delete-event-content
 os-management-hub event update
@@ -1750,6 +1922,7 @@ os-management-hub lifecycle-environment update
 os-management-hub managed-instance delete
 os-management-hub managed-instance remove-module-profile
 os-management-hub managed-instance remove-packages
+os-management-hub managed-instance remove-snaps
 os-management-hub managed-instance update
 os-management-hub managed-instance update-packages
 os-management-hub managed-instance-group delete
@@ -1773,6 +1946,8 @@ os-management-hub software-source update-third-party-swsrc
 os-management-hub software-source update-versioned-custom-swsrc
 os-management-hub update-all-packages-in-compartment
 osp-gateway subscription-service subscription update
+psa private-service-access delete
+psa private-service-access update
 psql backup delete
 psql backup update
 psql configuration delete
@@ -1786,6 +1961,8 @@ queue messages delete-messages
 queue messages put-messages
 queue messages update-message
 queue messages update-messages
+queue queue-admin consumer-group delete
+queue queue-admin consumer-group update
 queue queue-admin queue delete
 queue queue-admin queue update
 raw-request
@@ -1803,6 +1980,11 @@ redis oci-cache-user oci-cache-user update-oci-cache-user-iam-authentication-mod
 redis oci-cache-user oci-cache-user update-oci-cache-user-password-authentication-mode
 redis redis-cluster redis-cluster delete
 redis redis-cluster redis-cluster update
+resource-analytics monitored-region delete
+resource-analytics resource-analytics-instance delete
+resource-analytics resource-analytics-instance update
+resource-analytics tenancy-attachment delete
+resource-analytics tenancy-attachment update
 resource-manager configuration-source-provider delete
 resource-manager configuration-source-provider update
 resource-manager configuration-source-provider update-bitbucket-cloud-username-app-password-provider
@@ -1837,15 +2019,21 @@ rover station-cluster delete-workload
 rover station-cluster update
 sch service-connector delete
 sch service-connector update
+security-attribute security-attribute bulk-delete
 security-attribute security-attribute delete
 security-attribute security-attribute update
+security-attribute security-attribute-namespace cascade-delete
 security-attribute security-attribute-namespace delete
 security-attribute security-attribute-namespace update
+self subscription subscription delete
+self subscription subscription update
 service-catalog private-application delete
 service-catalog private-application update
 service-catalog service-catalog delete
 service-catalog service-catalog update
+service-catalog service-catalog-association bulk-replace
 service-catalog service-catalog-association delete
+session terminate
 speech customization delete
 speech customization update
 speech customization update-customization-entity-list-dataset

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/server.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/server.py
@@ -43,10 +43,16 @@ _OCI_COMMAND_TOKEN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 _OCI_HELP_COMMAND_ERROR = "OCI help accepts command paths only without options or values"
 _OCI_COMMAND_ERROR = "OCI command contains a server-managed global option"
 _OCI_CLI_VERSION = "3.89.3"
-_OCI_CLI_EXECUTABLE = shutil.which("oci", path=os.path.dirname(sys.executable))
-if _OCI_CLI_EXECUTABLE is None or importlib.metadata.version("oci-cli") != _OCI_CLI_VERSION:
-    raise RuntimeError(f"OCI CLI {_OCI_CLI_VERSION} is required in the MCP server environment")
-_OCI_CLI_BASE_COMMAND = (_OCI_CLI_EXECUTABLE, "--cli-rc-file", os.devnull)
+
+
+def _resolve_oci_cli() -> str:
+    executable = shutil.which("oci", path=os.path.dirname(sys.executable))
+    if executable is None or importlib.metadata.version("oci-cli") != _OCI_CLI_VERSION:
+        raise RuntimeError(f"OCI CLI {_OCI_CLI_VERSION} is required in the MCP server environment")
+    return executable
+
+
+_OCI_CLI_BASE_COMMAND = (_resolve_oci_cli(), "--cli-rc-file", os.devnull)
 _SERVER_MANAGED_OCI_OPTIONS = frozenset(
     {
         "--auth",

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/server.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/server.py
@@ -4,12 +4,15 @@ Licensed under the Universal Permissive License v1.0 as shown at
 https://oss.oracle.com/licenses/upl.
 """
 
+import importlib.metadata
 import json
 import os
 import re
+import shutil
 import subprocess
 from logging import Logger
 import shlex
+import sys
 from typing import Annotated
 
 from fastmcp import FastMCP
@@ -39,7 +42,11 @@ denylist_manager = Denylist(logger)
 _OCI_COMMAND_TOKEN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 _OCI_HELP_COMMAND_ERROR = "OCI help accepts command paths only without options or values"
 _OCI_COMMAND_ERROR = "OCI command contains a server-managed global option"
-_OCI_CLI_BASE_COMMAND = ("oci", "--cli-rc-file", os.devnull)
+_OCI_CLI_VERSION = "3.89.3"
+_OCI_CLI_EXECUTABLE = shutil.which("oci", path=os.path.dirname(sys.executable))
+if _OCI_CLI_EXECUTABLE is None or importlib.metadata.version("oci-cli") != _OCI_CLI_VERSION:
+    raise RuntimeError(f"OCI CLI {_OCI_CLI_VERSION} is required in the MCP server environment")
+_OCI_CLI_BASE_COMMAND = (_OCI_CLI_EXECUTABLE, "--cli-rc-file", os.devnull)
 _SERVER_MANAGED_OCI_OPTIONS = frozenset(
     {
         "--auth",

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
@@ -7,13 +7,17 @@ https://oss.oracle.com/licenses/upl.
 import importlib.metadata
 import json
 import os
+from pathlib import Path
+import runpy
 import subprocess
 from unittest.mock import ANY, MagicMock, patch
 
+import click
 import pytest
 from fastmcp import Client
 from fastmcp.exceptions import ToolError
 from oci.config import DEFAULT_LOCATION
+from oci_cli import dynamic_loader
 from oci_cli.cli_root import cli as oci_cli
 import oracle.oci_api_mcp_server.server as server
 from oracle.oci_api_mcp_server import __project__
@@ -23,6 +27,9 @@ from oracle.oci_api_mcp_server.server import mcp
 __version__ = importlib.metadata.version(__project__)
 user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
 USER_AGENT = f"{user_agent_name}/{__version__}"
+DENYLIST_GENERATOR = runpy.run_path(
+    str(Path(__file__).parents[5] / "scripts" / "oci-api-denylist-generator.py")
+)
 
 
 class TestOCITools:
@@ -650,6 +657,31 @@ class TestOCITools:
         mock_run.assert_not_called()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "os object bulk-delete --namespace n --bucket-name b --force",
+            "ocvs cluster delete --cluster-id ocid1.cluster.oc1..example --force",
+            "generative-ai api-key delete --api-key-id ocid1.generativeaiapikey.oc1..example",
+            "budgets budget budget update --budget-id ocid1.budget.oc1..example",
+            (
+                "mysql db-system controlled-update "
+                "--db-system-id ocid1.mysqldbsystem.oc1..example"
+            ),
+            "session terminate",
+        ],
+    )
+    @patch("oracle.oci_api_mcp_server.server.subprocess.run")
+    async def test_run_oci_command_denies_canonical_destructive_actions(
+        self, mock_run, command
+    ):
+        async with Client(mcp) as client:
+            result = (await client.call_tool("run_oci_command", {"command": command})).data
+
+        assert "denied by denylist" in result["error"]
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
     @patch("oracle.oci_api_mcp_server.server.subprocess.run")
     async def test_get_oci_commands_success(self, mock_run):
         mock_result = MagicMock()
@@ -816,6 +848,68 @@ class TestDenylist:
 
         with pytest.raises(RuntimeError, match="Denylist file not found"):
             Denylist(MagicMock(), str(missing_denylist))
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "db cloud-vm-cluster get-update --update-id update-id",
+            "db cloud-vm-cluster list-update-histories --cloud-vm-cluster-id cluster-id",
+            "devops repository create-or-update-git-branch-details",
+            "devops project cancel-cascading-delete --project-id project-id",
+            (
+                "db autonomous-database "
+                "create-autonomous-database-undelete-autonomous-database-details"
+            ),
+        ],
+    )
+    def test_reviewed_denylist_excludes_read_cancel_and_create_commands(self, command):
+        denylist = Denylist(MagicMock())
+
+        assert denylist.isCommandInDenyList(command) is False
+
+    @pytest.mark.parametrize(
+        "command_path",
+        [
+            ("os", "object", "bulk-delete"),
+            ("ocvs", "cluster", "delete"),
+            ("generative-ai", "api-key", "delete"),
+            ("budgets", "budget", "budget", "update"),
+            ("mysql", "db-system", "controlled-update"),
+            ("session", "terminate"),
+        ],
+    )
+    def test_destructive_action_regressions_are_canonical_cli_paths(self, command_path):
+        dynamic_loader.load_service(command_path[0])
+        command = oci_cli
+
+        for command_word in command_path:
+            assert isinstance(command, click.Group)
+            command = click.Group.get_command(command, None, command_word)
+            assert command is not None
+
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        [
+            ("os object bulk-delete", True),
+            ("data-safe alert alerts-update", True),
+            ("identity-domains mapped-attribute patch", True),
+            ("os object resume-put", True),
+            ("service-catalog service-catalog-association bulk-replace", True),
+            ("devops repository create-or-update-git-branch-details", False),
+            ("db cloud-vm-cluster get-update", False),
+            ("devops project cancel-cascading-delete", False),
+            (
+                "db autonomous-database "
+                "create-autonomous-database-undelete-autonomous-database-details",
+                False,
+            ),
+        ],
+    )
+    def test_denylist_generator_classifies_compound_actions(self, command, expected):
+        assert DENYLIST_GENERATOR["is_denied_command"](command) is expected
+
+    def test_denylist_generator_preserves_mandatory_commands(self):
+        assert DENYLIST_GENERATOR["get_denied_commands"]([]) == ["raw-request"]
 
 
 class TestServer:

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
@@ -912,6 +912,21 @@ class TestDenylist:
     def test_denylist_generator_preserves_mandatory_commands(self):
         assert DENYLIST_GENERATOR["get_denied_commands"]([]) == ["raw-request"]
 
+    def test_denylist_generator_does_not_follow_output_symlinks(self, tmp_path):
+        target = tmp_path / "target"
+        output = tmp_path / "denylist"
+        target.write_text("keep me")
+        try:
+            output.symlink_to(target)
+        except OSError:
+            pytest.skip("Symbolic links are not available")
+
+        DENYLIST_GENERATOR["write_file"](output, "replacement")
+
+        assert target.read_text() == "keep me"
+        assert output.read_text() == "replacement"
+        assert not output.is_symlink()
+
     def test_packaged_denylist_matches_classified_cli_commands(self):
         expected = set(
             DENYLIST_GENERATOR["get_denied_commands"](

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
@@ -912,6 +912,20 @@ class TestDenylist:
     def test_denylist_generator_preserves_mandatory_commands(self):
         assert DENYLIST_GENERATOR["get_denied_commands"]([]) == ["raw-request"]
 
+    def test_packaged_denylist_matches_classified_cli_commands(self):
+        expected = set(
+            DENYLIST_GENERATOR["get_denied_commands"](
+                DENYLIST_GENERATOR["get_canonical_commands"]()
+            )
+        )
+        actual = set(Denylist(MagicMock()).denylist)
+        missing = sorted(expected - actual)
+        stale = sorted(actual - expected)
+
+        assert not missing and not stale, (
+            f"Missing denylist paths: {missing}; stale paths: {stale}"
+        )
+
 
 class TestServer:
     def test_oci_cli_uses_server_environment(self):

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
@@ -948,6 +948,28 @@ class TestServer:
         assert importlib.metadata.version("oci-cli") == server._OCI_CLI_VERSION
         assert f"oci-cli=={server._OCI_CLI_VERSION}" in importlib.metadata.requires(__project__)
 
+    @patch("oracle.oci_api_mcp_server.server.importlib.metadata.version")
+    @patch("oracle.oci_api_mcp_server.server.shutil.which")
+    def test_resolve_oci_cli_success(self, mock_which, mock_version):
+        mock_which.return_value = "/server-environment/bin/oci"
+        mock_version.return_value = server._OCI_CLI_VERSION
+
+        assert server._resolve_oci_cli() == "/server-environment/bin/oci"
+
+    @patch("oracle.oci_api_mcp_server.server.importlib.metadata.version")
+    @patch("oracle.oci_api_mcp_server.server.shutil.which", return_value=None)
+    def test_resolve_oci_cli_fails_when_executable_is_missing(self, _, mock_version):
+        with pytest.raises(RuntimeError, match="OCI CLI 3.89.3 is required"):
+            server._resolve_oci_cli()
+
+        mock_version.assert_not_called()
+
+    @patch("oracle.oci_api_mcp_server.server.importlib.metadata.version", return_value="3.89.2")
+    @patch("oracle.oci_api_mcp_server.server.shutil.which", return_value="/server/bin/oci")
+    def test_resolve_oci_cli_fails_when_version_mismatches(self, *_):
+        with pytest.raises(RuntimeError, match="OCI CLI 3.89.3 is required"):
+            server._resolve_oci_cli()
+
     @patch("oracle.oci_api_mcp_server.server.mcp.run")
     @patch("os.getenv")
     def test_main_without_host_and_port(self, mock_getenv, mock_mcp_run):

--- a/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
+++ b/src/oci-api-mcp-server/oracle/oci_api_mcp_server/tests/test_oci_api_tools.py
@@ -27,6 +27,7 @@ from oracle.oci_api_mcp_server.server import mcp
 __version__ = importlib.metadata.version(__project__)
 user_agent_name = __project__.split("oracle.", 1)[1].split("-server", 1)[0]
 USER_AGENT = f"{user_agent_name}/{__version__}"
+OCI_CLI = server._OCI_CLI_BASE_COMMAND[0]
 DENYLIST_GENERATOR = runpy.run_path(
     str(Path(__file__).parents[5] / "scripts" / "oci-api-denylist-generator.py")
 )
@@ -66,7 +67,7 @@ class TestOCITools:
             assert mock_run.call_args.kwargs["env"]["OCI_SDK_APPEND_USER_AGENT"] == USER_AGENT
             mock_run.assert_called_once_with(
                 [
-                    "oci",
+                    OCI_CLI,
                     "--cli-rc-file",
                     os.devnull,
                     "compute",
@@ -106,7 +107,7 @@ class TestOCITools:
             assert result == "Help output"
             mock_run.assert_called_once_with(
                 [
-                    "oci",
+                    OCI_CLI,
                     "--cli-rc-file",
                     os.devnull,
                     "recovery",
@@ -184,7 +185,7 @@ class TestOCITools:
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1,
             cmd=[
-                "oci",
+                OCI_CLI,
                 "--cli-rc-file",
                 os.devnull,
                 "compute",
@@ -270,7 +271,7 @@ class TestOCITools:
             }
             mock_run.assert_called_once_with(
                 [
-                    "oci",
+                    OCI_CLI,
                     "--cli-rc-file",
                     os.devnull,
                     "--config-file",
@@ -310,7 +311,7 @@ class TestOCITools:
 
         mock_run.assert_called_once_with(
             [
-                "oci",
+                OCI_CLI,
                 "--cli-rc-file",
                 os.devnull,
                 "--config-file",
@@ -351,7 +352,7 @@ class TestOCITools:
             await client.call_tool("run_oci_command", {"command": "compute instance list"})
 
         assert mock_run.call_args.args[0] == [
-            "oci",
+            OCI_CLI,
             "--cli-rc-file",
             os.devnull,
             "--config-file",
@@ -383,7 +384,7 @@ class TestOCITools:
             await client.call_tool("run_oci_command", {"command": "compute instance list"})
 
         assert mock_run.call_args.args[0] == [
-            "oci",
+            OCI_CLI,
             "--cli-rc-file",
             os.devnull,
             "--config-file",
@@ -414,7 +415,7 @@ class TestOCITools:
             await client.call_tool("run_oci_command", {"command": "compute instance list"})
 
         assert mock_run.call_args.args[0] == [
-            "oci",
+            OCI_CLI,
             "--cli-rc-file",
             os.devnull,
             "--config-file",
@@ -464,7 +465,7 @@ class TestOCITools:
             await client.call_tool("run_oci_command", {"command": "compute instance list"})
 
         assert mock_run.call_args.args[0] == [
-            "oci",
+            OCI_CLI,
             "--cli-rc-file",
             os.devnull,
             "--config-file",
@@ -563,7 +564,7 @@ class TestOCITools:
 
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=mock_result.returncode,
-            cmd=["oci", "--cli-rc-file", os.devnull] + command.split(),
+            cmd=[OCI_CLI, "--cli-rc-file", os.devnull] + command.split(),
             output=mock_result.stdout,
             stderr=mock_result.stderr,
         )
@@ -623,7 +624,7 @@ class TestOCITools:
 
         assert result["returncode"] == 0
         assert mock_run.call_args.args[0] == [
-            "oci",
+            OCI_CLI,
             "--cli-rc-file",
             os.devnull,
             "--config-file",
@@ -695,7 +696,7 @@ class TestOCITools:
             assert result == "OCI commands output"
             assert mock_run.call_args.kwargs["env"]["OCI_SDK_APPEND_USER_AGENT"] == USER_AGENT
             mock_run.assert_called_once_with(
-                ["oci", "--cli-rc-file", os.devnull, "--help"],
+                [OCI_CLI, "--cli-rc-file", os.devnull, "--help"],
                 env=ANY,
                 stdin=subprocess.DEVNULL,
                 capture_output=True,
@@ -711,7 +712,7 @@ class TestOCITools:
         mock_result.stderr = "Some error"
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1,
-            cmd=["oci", "--cli-rc-file", os.devnull, "--help"],
+            cmd=[OCI_CLI, "--cli-rc-file", os.devnull, "--help"],
             output=None,
             stderr=mock_result.stderr,
         )
@@ -913,6 +914,11 @@ class TestDenylist:
 
 
 class TestServer:
+    def test_oci_cli_uses_server_environment(self):
+        assert Path(OCI_CLI).parent == Path(server.sys.executable).parent
+        assert importlib.metadata.version("oci-cli") == server._OCI_CLI_VERSION
+        assert f"oci-cli=={server._OCI_CLI_VERSION}" in importlib.metadata.requires(__project__)
+
     @patch("oracle.oci_api_mcp_server.server.mcp.run")
     @patch("os.getenv")
     def test_main_without_host_and_port(self, mock_getenv, mock_mcp_run):

--- a/src/oci-api-mcp-server/pyproject.toml
+++ b/src/oci-api-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-api-mcp-server"
-version = "2.1.4"
+version = "2.1.5"
 description = "OCI CLI MCP server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/oci-api-mcp-server/uv.lock
+++ b/src/oci-api-mcp-server/uv.lock
@@ -860,7 +860,7 @@ dev = [
 
 [[package]]
 name = "oracle-oci-api-mcp-server"
-version = "2.1.4"
+version = "2.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
# Description

- Updated the denylist to match OCI CLI 3.89.3, supporting compound actions like `bulk-delete`.
- Restricted execution to OCI CLI 3.89.3 installed in the MCP server environment.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
