### PR TITLE
Release packaging and version metadata fixes

### DIFF
--- a/src/oci-database-mcp-server/CHANGELOG.md
+++ b/src/oci-database-mcp-server/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 All notable changes to OCI Database MCP Server are documented in this file.
 
-## Unreleased
+## 1.3.2
 
 ### Changed
 
 - Updated the FastMCP dependency and lockfile to 3.4.5.
+
+## 1.3.1
+
+### Changed
+
+- Updated `oracle-mcp-common` dependency minimum version to >=0.1.2,<0.2.0.
 
 ## 1.3.0
 

--- a/src/oci-database-mcp-server/oracle/oci_database_mcp_server/__init__.py
+++ b/src/oci-database-mcp-server/oracle/oci_database_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-database-mcp-server"
-__version__ = "1.3.1"
+__version__ = "1.3.2"

--- a/src/oci-database-mcp-server/pyproject.toml
+++ b/src/oci-database-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-database-mcp-server"
-version = "1.3.1"
+version = "1.3.2"
 description = "OCI Database Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/oci-database-mcp-server/uv.lock
+++ b/src/oci-database-mcp-server/uv.lock
@@ -813,7 +813,7 @@ dev = [
 
 [[package]]
 name = "oracle-oci-database-mcp-server"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-full-stack-disaster-recovery-mcp-server/CHANGELOG.md
+++ b/src/oci-full-stack-disaster-recovery-mcp-server/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.0.1
+
+### Fixed
+
+- Excluded generated coverage reports, local development artifacts, and the dependency lockfile from source distributions to produce stable publishable archives.
+
 ## 1.0.0
 
 ### Changed

--- a/src/oci-full-stack-disaster-recovery-mcp-server/oracle/oci_fsdr_mcp_server/__init__.py
+++ b/src/oci-full-stack-disaster-recovery-mcp-server/oracle/oci_fsdr_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-fsdr-mcp-server"
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/src/oci-full-stack-disaster-recovery-mcp-server/pyproject.toml
+++ b/src/oci-full-stack-disaster-recovery-mcp-server/pyproject.toml
@@ -1,10 +1,6 @@
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
 [project]
 name = "oracle.oci-fsdr-mcp-server"
-version = "1.0.0"
+version = "1.0.1"
 description = "OCI Full Stack Disaster Recovery MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -17,9 +13,22 @@ dependencies = [
     "pydantic>=2.0.0",
 ]
 
+classifiers = [
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.13",
+]
+
 [project.scripts]
 "oracle.oci-fsdr-mcp-server" = "oracle.oci_fsdr_mcp_server.server:main"
 oci-fsdr-mcp = "oracle.oci_fsdr_mcp_server.server:main"
+
+[project.urls]
+Changelog = "https://github.com/oracle/mcp/blob/main/src/oci-full-stack-disaster-recovery-mcp-server/CHANGELOG.md"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project.optional-dependencies]
 dev = [
@@ -37,6 +46,30 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
+exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/oci-full-stack-disaster-recovery-mcp-server/uv.lock
+++ b/src/oci-full-stack-disaster-recovery-mcp-server/uv.lock
@@ -780,7 +780,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-fsdr-mcp-server"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/__init__.py
+++ b/src/oracle-goldengate-mcp-server/oracle/oracle_goldengate_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oracle-goldengate-mcp-server"
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/oracle-goldengate-mcp-server/pyproject.toml
+++ b/src/oracle-goldengate-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oracle-goldengate-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 description = "Oracle GoldenGate MCP server"
 readme = "README.md"
 license = "UPL-1.0"

--- a/src/oracle-goldengate-mcp-server/uv.lock
+++ b/src/oracle-goldengate-mcp-server/uv.lock
@@ -449,7 +449,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -726,7 +726,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oracle-goldengate-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
# Description

Prepares patch releases for the OCI Database, Full Stack Disaster Recovery, and Oracle GoldenGate MCP servers.

- Releases OCI Database MCP Server 1.3.2 with updated FastMCP and `oracle-mcp-common` release metadata.
- Releases FSDR MCP Server 1.0.1 with explicit source-distribution exclusions for generated and local development artifacts.
- Releases Oracle GoldenGate MCP Server 1.0.2 with aligned package version metadata.

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- `env UV_CACHE_DIR=/private/tmp/fsdr-uv-cache uv build --out-dir /private/tmp/fsdr-pr-build.M6kt7R src/oci-full-stack-disaster-recovery-mcp-server`
  - Passed; built `oracle_oci_fsdr_mcp_server-1.0.1.tar.gz` and `oracle_oci_fsdr_mcp_server-1.0.1-py3-none-any.whl`.
- Unit test suites were not rerun; this branch changes release metadata and packaging configuration.

**Test Configuration**:
* Firmware version: Not applicable
* Hardware: Not applicable
* Toolchain: `uv build`
* SDK: Not applicable

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules