### PR TITLE
Harden package artifacts and release metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SERVER_DIRS := $(filter-out $(COMMON_PROJECT_PATH),$(SUBDIRS))
 # Releasing a server also releases the common dependency first, even when a
 # single server is selected with `project=`.
 RELEASE_DIRS := $(if $(SERVER_DIRS),$(COMMON_PROJECT_PATH) $(SERVER_DIRS),$(COMMON_DIRS))
-COMMON_VERSION := $(shell python -c "import tomllib; print(tomllib.load(open('$(COMMON_PROJECT_PATH)/pyproject.toml', 'rb'))['project']['version'])")
+COMMON_VERSION := $(shell uv run --isolated --no-project --python 3.13 python -c "import tomllib; print(tomllib.load(open('$(COMMON_PROJECT_PATH)/pyproject.toml', 'rb'))['project']['version'])")
 
 PYPI_PUBLISH_URL := https://upload.pypi.org/legacy/
 PYPI_CHECK_URL := https://pypi.org/simple/

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ _build:
 	@set -eu; \
 	for dir in $(BUILD_DIRS); do \
 		if [ -f $$dir/pyproject.toml ]; then \
-			name=$$(python -c "import tomllib; print(tomllib.load(open('$$dir/pyproject.toml', 'rb'))['project']['name'])"); \
-			version=$$(python -c "import tomllib; print(tomllib.load(open('$$dir/pyproject.toml', 'rb'))['project']['version'])"); \
+			name=$$(uv run --isolated --no-project --python 3.13 python -c "import sys, tomllib; print(tomllib.load(open(sys.argv[1], 'rb'))['project']['name'])" "$$dir/pyproject.toml") || exit 1; \
+			version=$$(uv run --isolated --no-project --python 3.13 python -c "import sys, tomllib; print(tomllib.load(open(sys.argv[1], 'rb'))['project']['version'])" "$$dir/pyproject.toml") || exit 1; \
 			echo "Building $$dir: $$name==$$version"; \
 			if [ -d $$dir/oracle/*_mcp_server ]; then \
 				init_py_file=$$(echo $$dir/oracle/*_mcp_server/__init__.py); \
@@ -167,8 +167,8 @@ verify-published:
 	@set -eu; \
 	for dir in $(RELEASE_DIRS); do \
 		if [ -f $$dir/pyproject.toml ]; then \
-			name=$$(python -c "import tomllib; print(tomllib.load(open('$$dir/pyproject.toml', 'rb'))['project']['name'])"); \
-			version=$$(python -c "import tomllib; print(tomllib.load(open('$$dir/pyproject.toml', 'rb'))['project']['version'])"); \
+			name=$$(uv run --isolated --no-project --python 3.13 python -c "import sys, tomllib; print(tomllib.load(open(sys.argv[1], 'rb'))['project']['name'])" "$$dir/pyproject.toml") || exit 1; \
+			version=$$(uv run --isolated --no-project --python 3.13 python -c "import sys, tomllib; print(tomllib.load(open(sys.argv[1], 'rb'))['project']['version'])" "$$dir/pyproject.toml") || exit 1; \
 			echo "Verifying $$name==$$version from $(VERIFY_INDEX)"; \
 			uv run --isolated --no-project --python 3.13 --refresh-package "$$name" --index "$(VERIFY_INDEX)" --with "$$name==$$version" python -c "from importlib.metadata import version; assert version('$$name') == '$$version'"; \
 		fi; \
@@ -192,8 +192,8 @@ e2e-tests: build install
 containerize:
 	@for dir in $(SUBDIRS); do \
 		if [[ -f $$dir/Containerfile && (-f $$dir/pyproject.toml) ]]; then \
-			name=$$(uv run tomlq -r '.project.name' $$dir/pyproject.toml); \
-			version=$$(uv run tomlq -r '.project.version' $$dir/pyproject.toml); \
+			name=$$(uv run --isolated --no-project --python 3.13 python -c "import sys, tomllib; print(tomllib.load(open(sys.argv[1], 'rb'))['project']['name'])" "$$dir/pyproject.toml") || exit 1; \
+			version=$$(uv run --isolated --no-project --python 3.13 python -c "import sys, tomllib; print(tomllib.load(open(sys.argv[1], 'rb'))['project']['version'])" "$$dir/pyproject.toml") || exit 1; \
 			echo "Building container image for $$dir with version $$version"; \
 			cd $$dir && \
 				podman build -t $$name:$$version . && \

--- a/src/common/CHANGELOG.md
+++ b/src/common/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `oracle-mcp-common` are documented in this file.
 
+## 0.1.3
+
+### Changed
+
+- Excluded development artifacts and local configuration from the shared library’s source distribution.
+
 ## 0.1.2
 
 ### Fixed

--- a/src/common/oracle_mcp_common/__init__.py
+++ b/src/common/oracle_mcp_common/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
 ]
 
 __project__ = "oracle_mcp_common"
-__version__ = "0.1.1"
+__version__ = "0.1.3"

--- a/src/common/pyproject.toml
+++ b/src/common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle-mcp-common"
-version = "0.1.2"
+version = "0.1.3"
 description = "Shared utilities for Oracle MCP Python servers"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -29,6 +29,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle_mcp_common"]
 exclude = ["/oracle_mcp_common/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/common/uv.lock
+++ b/src/common/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-mcp-common"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/mysql-mcp-server/pyproject.toml
+++ b/src/mysql-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.mysql-mcp-server"
-version = "1.0.7"
+version = "1.0.8"
 description = "MySql Service MCP server"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -29,3 +29,28 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]

--- a/src/oci-api-mcp-server/CHANGELOG.md
+++ b/src/oci-api-mcp-server/CHANGELOG.md
@@ -8,6 +8,7 @@
   supporting compound actions like `bulk-delete`.
 - Prevented the denylist generator from following destination symlinks when writing files.
 - Restricted execution to OCI CLI 3.89.3 installed in the MCP server environment.
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
 
 ## 2.1.4
 

--- a/src/oci-api-mcp-server/Containerfile
+++ b/src/oci-api-mcp-server/Containerfile
@@ -16,7 +16,7 @@ COPY --chown=oracle:oracle . /app
 
 # Install dependencies
 RUN pip3.13 install --no-cache-dir uv && \
-  uv --no-cache sync --locked --all-extras
+  uv --no-cache sync --no-sources --all-extras --no-editable
 
 # Change user
 USER oracle

--- a/src/oci-api-mcp-server/pyproject.toml
+++ b/src/oci-api-mcp-server/pyproject.toml
@@ -35,6 +35,31 @@ build-backend = "hatchling.build"
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
+
 [tool.uv.sources]
 oracle-mcp-common = { workspace = true }
 

--- a/src/oci-api-mcp-server/uv.lock
+++ b/src/oci-api-mcp-server/uv.lock
@@ -833,7 +833,7 @@ wheels = [
 
 [[package]]
 name = "oracle-mcp-common"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "../common" }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-cloud-guard-mcp-server/CHANGELOG.md
+++ b/src/oci-cloud-guard-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 2.0.1
 
 ### Changed

--- a/src/oci-cloud-guard-mcp-server/oracle/oci_cloud_guard_mcp_server/__init__.py
+++ b/src/oci-cloud-guard-mcp-server/oracle/oci_cloud_guard_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-cloud-guard-mcp-server"
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/src/oci-cloud-guard-mcp-server/pyproject.toml
+++ b/src/oci-cloud-guard-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-cloud-guard-mcp-server"
-version = "2.0.1"
+version = "2.0.2"
 description = "OCI Cloud Guard Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -34,6 +34,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-cloud-guard-mcp-server/uv.lock
+++ b/src/oci-cloud-guard-mcp-server/uv.lock
@@ -780,7 +780,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-cloud-guard-mcp-server"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-cloud-mcp-server/CHANGELOG.md
+++ b/src/oci-cloud-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.2.3
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 2.2.2
 
 ### Changed

--- a/src/oci-cloud-mcp-server/Containerfile
+++ b/src/oci-cloud-mcp-server/Containerfile
@@ -16,7 +16,7 @@ COPY --chown=oracle:oracle . /app
 
 # Install dependencies
 RUN pip3.13 install --no-cache-dir uv && \
-  uv --no-cache sync --locked --all-extras
+  uv --no-cache sync --no-sources --all-extras --no-editable
 
 # Change user
 USER oracle

--- a/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/__init__.py
+++ b/src/oci-cloud-mcp-server/oracle/oci_cloud_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-cloud-mcp-server"
-__version__ = "2.2.2"
+__version__ = "2.2.3"

--- a/src/oci-cloud-mcp-server/pyproject.toml
+++ b/src/oci-cloud-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-cloud-mcp-server"
-version = "2.2.2"
+version = "2.2.3"
 description = "OCI Python SDK MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -34,6 +34,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [tool.uv.sources]
 oracle-mcp-common = { workspace = true }

--- a/src/oci-cloud-mcp-server/uv.lock
+++ b/src/oci-cloud-mcp-server/uv.lock
@@ -786,7 +786,7 @@ wheels = [
 
 [[package]]
 name = "oracle-mcp-common"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "../common" }
 dependencies = [
     { name = "fastmcp" },
@@ -813,7 +813,7 @@ dev = [
 
 [[package]]
 name = "oracle-oci-cloud-mcp-server"
-version = "2.2.2"
+version = "2.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-compute-instance-agent-mcp-server/CHANGELOG.md
+++ b/src/oci-compute-instance-agent-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 3.0.1
 
 ### Changed

--- a/src/oci-compute-instance-agent-mcp-server/oracle/oci_compute_instance_agent_mcp_server/__init__.py
+++ b/src/oci-compute-instance-agent-mcp-server/oracle/oci_compute_instance_agent_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-compute-instance-agent-mcp-server"
-__version__ = "3.0.1"
+__version__ = "3.0.2"

--- a/src/oci-compute-instance-agent-mcp-server/pyproject.toml
+++ b/src/oci-compute-instance-agent-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-compute-instance-agent-mcp-server"
-version = "3.0.1"
+version = "3.0.2"
 description = "OCI Compute Instance Agent MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,6 +33,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-compute-instance-agent-mcp-server/uv.lock
+++ b/src/oci-compute-instance-agent-mcp-server/uv.lock
@@ -780,7 +780,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-compute-instance-agent-mcp-server"
-version = "3.0.1"
+version = "3.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-compute-mcp-server/CHANGELOG.md
+++ b/src/oci-compute-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 2.0.1
 
 ### Changed

--- a/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/__init__.py
+++ b/src/oci-compute-mcp-server/oracle/oci_compute_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-compute-mcp-server"
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/src/oci-compute-mcp-server/pyproject.toml
+++ b/src/oci-compute-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-compute-mcp-server"
-version = "2.0.1"
+version = "2.0.2"
 description = "OCI Compute Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -34,6 +34,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-compute-mcp-server/uv.lock
+++ b/src/oci-compute-mcp-server/uv.lock
@@ -780,7 +780,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-compute-mcp-server"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-database-mcp-server/CHANGELOG.md
+++ b/src/oci-database-mcp-server/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OCI Database MCP Server are documented in this file.
 
+## 1.3.3
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 1.3.2
 
 ### Changed

--- a/src/oci-database-mcp-server/oracle/oci_database_mcp_server/__init__.py
+++ b/src/oci-database-mcp-server/oracle/oci_database_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-database-mcp-server"
-__version__ = "1.3.2"
+__version__ = "1.3.3"

--- a/src/oci-database-mcp-server/pyproject.toml
+++ b/src/oci-database-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-database-mcp-server"
-version = "1.3.2"
+version = "1.3.3"
 description = "OCI Database Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,6 +32,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [tool.uv.sources]
 oracle-mcp-common = { workspace = true }

--- a/src/oci-database-mcp-server/uv.lock
+++ b/src/oci-database-mcp-server/uv.lock
@@ -786,7 +786,7 @@ wheels = [
 
 [[package]]
 name = "oracle-mcp-common"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "../common" }
 dependencies = [
     { name = "fastmcp" },
@@ -813,7 +813,7 @@ dev = [
 
 [[package]]
 name = "oracle-oci-database-mcp-server"
-version = "1.3.2"
+version = "1.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-faaas-mcp-server/CHANGELOG.md
+++ b/src/oci-faaas-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.7
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 1.0.6
 
 ### Changed

--- a/src/oci-faaas-mcp-server/oracle/oci_faaas_mcp_server/__init__.py
+++ b/src/oci-faaas-mcp-server/oracle/oci_faaas_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-faaas-mcp-server"
-__version__ = "1.0.6"
+__version__ = "1.0.7"

--- a/src/oci-faaas-mcp-server/pyproject.toml
+++ b/src/oci-faaas-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-faaas-mcp-server"
-version = "1.0.6"
+version = "1.0.7"
 description = "OCI Fusion Applications (FAaaS) MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -30,6 +30,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-faaas-mcp-server/uv.lock
+++ b/src/oci-faaas-mcp-server/uv.lock
@@ -780,7 +780,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-faaas-mcp-server"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-full-stack-disaster-recovery-mcp-server/pyproject.toml
+++ b/src/oci-full-stack-disaster-recovery-mcp-server/pyproject.toml
@@ -69,6 +69,8 @@ exclude = [
   "/.roo/**",
   "/.cursor/**",
   "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
 ]
 
 [tool.pytest.ini_options]

--- a/src/oci-identity-mcp-server/CHANGELOG.md
+++ b/src/oci-identity-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.3
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 3.0.2
 
 ### Changed

--- a/src/oci-identity-mcp-server/oracle/oci_identity_mcp_server/__init__.py
+++ b/src/oci-identity-mcp-server/oracle/oci_identity_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-identity-mcp-server"
-__version__ = "3.0.2"
+__version__ = "3.0.3"

--- a/src/oci-identity-mcp-server/pyproject.toml
+++ b/src/oci-identity-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-identity-mcp-server"
-version = "3.0.2"
+version = "3.0.3"
 description = "OCI Identity Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,6 +33,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-identity-mcp-server/uv.lock
+++ b/src/oci-identity-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-identity-mcp-server"
-version = "3.0.2"
+version = "3.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-iot-mcp-server/CHANGELOG.md
+++ b/src/oci-iot-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 1.0.1
 
 ### Changed

--- a/src/oci-iot-mcp-server/oracle/oci_iot_mcp_server/__init__.py
+++ b/src/oci-iot-mcp-server/oracle/oci_iot_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-iot-mcp-server"
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/oci-iot-mcp-server/pyproject.toml
+++ b/src/oci-iot-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-iot-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 description = "OCI IoT Platform MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -32,6 +32,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-iot-mcp-server/uv.lock
+++ b/src/oci-iot-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-iot-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-limits-mcp-server/CHANGELOG.md
+++ b/src/oci-limits-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.5
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 1.0.4
 
 ### Changed

--- a/src/oci-limits-mcp-server/oracle/oci_limits_mcp_server/__init__.py
+++ b/src/oci-limits-mcp-server/oracle/oci_limits_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-limits-mcp-server"
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/src/oci-limits-mcp-server/pyproject.toml
+++ b/src/oci-limits-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-limits-mcp-server"
-version = "1.0.4"
+version = "1.0.5"
 description = "OCI Limits MCP server"
 readme = "README.md"
 license = "UPL-1.0"
@@ -30,6 +30,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-limits-mcp-server/uv.lock
+++ b/src/oci-limits-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-limits-mcp-server"
-version = "1.0.4"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-load-balancer-mcp-server/CHANGELOG.md
+++ b/src/oci-load-balancer-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 1.0.1
 
 ### Changed

--- a/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/__init__.py
+++ b/src/oci-load-balancer-mcp-server/oracle/oci_load_balancer_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-load-balancer-mcp-server"
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/oci-load-balancer-mcp-server/pyproject.toml
+++ b/src/oci-load-balancer-mcp-server/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oracle.oci-load-balancer-mcp-server"
 
-version = "1.0.1"
+version = "1.0.2"
 description = "An OCI Model Context Protocol server for load-balancer"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -42,6 +42,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [tool.coverage.run]
 omit = [

--- a/src/oci-load-balancer-mcp-server/uv.lock
+++ b/src/oci-load-balancer-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-load-balancer-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-logging-mcp-server/CHANGELOG.md
+++ b/src/oci-logging-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.3
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 2.0.2
 
 ### Changed

--- a/src/oci-logging-mcp-server/oracle/oci_logging_mcp_server/__init__.py
+++ b/src/oci-logging-mcp-server/oracle/oci_logging_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-logging-mcp-server"
-__version__ = "2.0.2"
+__version__ = "2.0.3"

--- a/src/oci-logging-mcp-server/pyproject.toml
+++ b/src/oci-logging-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-logging-mcp-server"
-version = "2.0.2"
+version = "2.0.3"
 description = "OCI Logging Service MCP server"
 readme = "README.md"
 authors = [
@@ -34,6 +34,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-logging-mcp-server/uv.lock
+++ b/src/oci-logging-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-logging-mcp-server"
-version = "2.0.2"
+version = "2.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-migration-mcp-server/CHANGELOG.md
+++ b/src/oci-migration-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 3.0.1
 
 ### Changed

--- a/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/__init__.py
+++ b/src/oci-migration-mcp-server/oracle/oci_migration_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-migration-mcp-server"
-__version__ = "3.0.1"
+__version__ = "3.0.2"

--- a/src/oci-migration-mcp-server/pyproject.toml
+++ b/src/oci-migration-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-migration-mcp-server"
-version = "3.0.1"
+version = "3.0.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,6 +33,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-migration-mcp-server/uv.lock
+++ b/src/oci-migration-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-migration-mcp-server"
-version = "3.0.1"
+version = "3.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-monitoring-mcp-server/CHANGELOG.md
+++ b/src/oci-monitoring-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.3
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 2.0.2
 
 ### Changed

--- a/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/__init__.py
+++ b/src/oci-monitoring-mcp-server/oracle/oci_monitoring_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-monitoring-mcp-server"
-__version__ = "2.0.2"
+__version__ = "2.0.3"

--- a/src/oci-monitoring-mcp-server/pyproject.toml
+++ b/src/oci-monitoring-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-monitoring-mcp-server"
-version = "2.0.2"
+version = "2.0.3"
 description = "OCI Monitoring Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,6 +33,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-monitoring-mcp-server/uv.lock
+++ b/src/oci-monitoring-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-monitoring-mcp-server"
-version = "2.0.2"
+version = "2.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-network-load-balancer-mcp-server/CHANGELOG.md
+++ b/src/oci-network-load-balancer-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 3.0.1
 
 ### Changed

--- a/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/__init__.py
+++ b/src/oci-network-load-balancer-mcp-server/oracle/oci_network_load_balancer_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-network-load-balancer-mcp-server"
-__version__ = "3.0.1"
+__version__ = "3.0.2"

--- a/src/oci-network-load-balancer-mcp-server/pyproject.toml
+++ b/src/oci-network-load-balancer-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-network-load-balancer-mcp-server"
-version = "3.0.1"
+version = "3.0.2"
 description = "OCI Network Load Balancer MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,6 +33,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-network-load-balancer-mcp-server/uv.lock
+++ b/src/oci-network-load-balancer-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-network-load-balancer-mcp-server"
-version = "3.0.1"
+version = "3.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-networking-mcp-server/CHANGELOG.md
+++ b/src/oci-networking-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 2.0.1
 
 ### Changed

--- a/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/__init__.py
+++ b/src/oci-networking-mcp-server/oracle/oci_networking_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-networking-mcp-server"
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/src/oci-networking-mcp-server/pyproject.toml
+++ b/src/oci-networking-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-networking-mcp-server"
-version = "2.0.1"
+version = "2.0.2"
 description = "OCI Networking Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,6 +33,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-networking-mcp-server/uv.lock
+++ b/src/oci-networking-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-networking-mcp-server"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-object-storage-mcp-server/CHANGELOG.md
+++ b/src/oci-object-storage-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 2.0.1
 
 ### Changed

--- a/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/__init__.py
+++ b/src/oci-object-storage-mcp-server/oracle/oci_object_storage_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-object-storage-mcp-server"
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/src/oci-object-storage-mcp-server/pyproject.toml
+++ b/src/oci-object-storage-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-object-storage-mcp-server"
-version = "2.0.1"
+version = "2.0.2"
 description = "OCI Object Storage Service MCP server"
 readme = "README.md"
 authors = [
@@ -33,6 +33,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-object-storage-mcp-server/uv.lock
+++ b/src/oci-object-storage-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-object-storage-mcp-server"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-opensearch-mcp-server/CHANGELOG.md
+++ b/src/oci-opensearch-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 1.0.1
 
 ### Changed

--- a/src/oci-opensearch-mcp-server/oracle/oci_opensearch_mcp_server/__init__.py
+++ b/src/oci-opensearch-mcp-server/oracle/oci_opensearch_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-opensearch-mcp-server"
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/oci-opensearch-mcp-server/pyproject.toml
+++ b/src/oci-opensearch-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-opensearch-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 description = "OCI OpenSearch Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,6 +31,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-opensearch-mcp-server/uv.lock
+++ b/src/oci-opensearch-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-opensearch-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-recovery-mcp-server/CHANGELOG.md
+++ b/src/oci-recovery-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 2.1.1
 
 ### Changed

--- a/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/__init__.py
+++ b/src/oci-recovery-mcp-server/oracle/oci_recovery_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-recovery-mcp-server"
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/src/oci-recovery-mcp-server/pyproject.toml
+++ b/src/oci-recovery-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-recovery-mcp-server"
-version = "2.1.1"
+version = "2.1.2"
 description = "OCI Recovery Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -36,6 +36,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-recovery-mcp-server/uv.lock
+++ b/src/oci-recovery-mcp-server/uv.lock
@@ -808,7 +808,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-recovery-mcp-server"
-version = "2.1.1"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-registry-mcp-server/CHANGELOG.md
+++ b/src/oci-registry-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 3.0.1
 
 ### Changed

--- a/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/__init__.py
+++ b/src/oci-registry-mcp-server/oracle/oci_registry_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-registry-mcp-server"
-__version__ = "3.0.1"
+__version__ = "3.0.2"

--- a/src/oci-registry-mcp-server/pyproject.toml
+++ b/src/oci-registry-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-registry-mcp-server"
-version = "3.0.1"
+version = "3.0.2"
 description = "OCI Registry Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,6 +33,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-registry-mcp-server/uv.lock
+++ b/src/oci-registry-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-registry-mcp-server"
-version = "3.0.1"
+version = "3.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-resource-search-mcp-server/CHANGELOG.md
+++ b/src/oci-resource-search-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.3
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 3.0.2
 
 ### Changed

--- a/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/__init__.py
+++ b/src/oci-resource-search-mcp-server/oracle/oci_resource_search_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-resource-search-mcp-server"
-__version__ = "3.0.2"
+__version__ = "3.0.3"

--- a/src/oci-resource-search-mcp-server/pyproject.toml
+++ b/src/oci-resource-search-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-resource-search-mcp-server"
-version = "3.0.2"
+version = "3.0.3"
 description = "OCI Resource Search Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -33,6 +33,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-resource-search-mcp-server/uv.lock
+++ b/src/oci-resource-search-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-resource-search-mcp-server"
-version = "3.0.2"
+version = "3.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-support-mcp-server/CHANGELOG.md
+++ b/src/oci-support-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.3
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 2.0.2
 
 ### Changed

--- a/src/oci-support-mcp-server/oracle/oci_support_mcp_server/__init__.py
+++ b/src/oci-support-mcp-server/oracle/oci_support_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-support-mcp-server"
-__version__ = "2.0.2"
+__version__ = "2.0.3"

--- a/src/oci-support-mcp-server/pyproject.toml
+++ b/src/oci-support-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-support-mcp-server"
-version = "2.0.2"
+version = "2.0.3"
 description = "OCI Support Service MCP server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -35,6 +35,31 @@ build-backend = "hatchling.build"
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
 include = ["oracle"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-support-mcp-server/uv.lock
+++ b/src/oci-support-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-support-mcp-server"
-version = "2.0.2"
+version = "2.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oci-usage-mcp-server/CHANGELOG.md
+++ b/src/oci-usage-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 2.0.1
 
 ### Changed

--- a/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/__init__.py
+++ b/src/oci-usage-mcp-server/oracle/oci_usage_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.oci-usage-mcp-server"
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/src/oci-usage-mcp-server/pyproject.toml
+++ b/src/oci-usage-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.oci-usage-mcp-server"
-version = "2.0.1"
+version = "2.0.2"
 description = "OCI Usage MCP server"
 readme = "README.md"
 license = "UPL-1.0"
@@ -33,6 +33,31 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
 exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
 
 [dependency-groups]
 dev = [

--- a/src/oci-usage-mcp-server/uv.lock
+++ b/src/oci-usage-mcp-server/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "oracle-oci-usage-mcp-server"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/src/oracle-data-studio-mcp-server/CHANGELOG.md
+++ b/src/oracle-data-studio-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.2
+
+### Changed
+
+- Excluded development artifacts, local configuration, and container build files from source-distribution packages.
+
 ## 1.0.1
 
 ### Changed

--- a/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/__init__.py
+++ b/src/oracle-data-studio-mcp-server/oracle/data_studio_mcp_server/__init__.py
@@ -5,4 +5,4 @@ https://oss.oracle.com/licenses/upl.
 """
 
 __project__ = "oracle.data-studio-mcp-server"
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/oracle-data-studio-mcp-server/pyproject.toml
+++ b/src/oracle-data-studio-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oracle.data-studio-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 description = "Oracle Data Studio MCP server — Essbase, ADP (Autonomous Database Data Platform), and Data Transforms with Oracle 23ai annotation-aware query routing"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -35,6 +35,33 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["oracle"]
+exclude = ["/oracle/**/tests/**"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.coverage*",
+  "/htmlcov/**",
+  "/.pytest_cache/**",
+  "/.ruff_cache/**",
+  "/.venv/**",
+  "/venv/**",
+  "/dist/**",
+  "/build/**",
+  "/uv.lock",
+  "**/__pycache__/**",
+  "**/*.py[cod]",
+  "/.DS_Store",
+  "/.env",
+  "/.env.*",
+  "/.claude/**",
+  "/.cline/**",
+  "/.roo/**",
+  "/.cursor/**",
+  "/mcp_settings*.json",
+  "/Containerfile",
+  "/.containerignore",
+]
+
 
 [dependency-groups]
 dev = [

--- a/src/oracle-data-studio-mcp-server/uv.lock
+++ b/src/oracle-data-studio-mcp-server/uv.lock
@@ -832,7 +832,7 @@ wheels = [
 
 [[package]]
 name = "oracle-data-studio-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
# Description

Standardize release packaging across the Python MCP servers.

- Add consistent Hatch sdist exclusions so generated files, local environments, caches, lockfiles, container configuration, and local editor settings are not shipped in source distributions.
- Bump affected package patch versions and align package `__version__` metadata, changelogs, and lockfiles.
- Update the shared dependency constraint to `oracle-mcp-common>=0.1.0,<0.2.0`.
- Make release Makefile metadata reads use isolated Python 3.13 `tomllib`, avoiding reliance on a host Python or `tomlq`.
- Make OCI API and OCI Cloud container dependency syncs install published artifacts rather than editable/local sources.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

No test results were recorded for commit `85227b1e7bc3626bb84bcd0cecba7c8edd4ece6d`.

**Test Configuration**:
* Firmware version: Not applicable
* Hardware: Not applicable
* Toolchain: Not applicable
* SDK: Not applicable

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules