### PR TITLE
fix: new sha for the java17 image

### DIFF
--- a/src/oracle-db-mcp-java-toolkit/Dockerfile
+++ b/src/oracle-db-mcp-java-toolkit/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN mvn -B -q -DskipTests clean package
 
 # ---------- 2) Runtime stage ----------
-FROM container-registry.oracle.com/java/openjdk:17@sha256:82cc9efbe316236933eb4fb8c0606c536dfbfc545f2e728ebed728b729f3eb1b
+FROM container-registry.oracle.com/java/openjdk:17@sha256:854a4b5d81a6962f589c86e96f65500d9f1f151d7fbcb4bb0d90020f581bdfdb
 
 RUN useradd -r -u 10001 appuser && \
     mkdir -p /app /ext && chown -R appuser:appuser /app /ext


### PR DESCRIPTION
# Fix the java17 image sha to the one which is available

We were unable to pull image sha which was committed to the repository. I have pulled the new image and changed image sha.

Fixes :
```
podman pull container-registry.oracle.com/java/openjdk:17@sha256:82cc9efbe316236933eb4fb8c0606c536dfbfc545f2e728ebed728b729f3eb1b
Trying to pull container-registry.oracle.com/java/openjdk@sha256:82cc9efbe316236933eb4fb8c0606c536dfbfc545f2e728ebed728b729f3eb1b...
Error: unable to copy from source docker://container-registry.oracle.com/java/openjdk@sha256:82cc9efbe316236933eb4fb8c0606c536dfbfc545f2e728ebed728b729f3eb1b: initializing source docker://container-registry.oracle.com/java/openjdk@sha256:82cc9efbe316236933eb4fb8c0606c536dfbfc545f2e728ebed728b729f3eb1b: reading manifest sha256:82cc9efbe316236933eb4fb8c0606c536dfbfc545f2e728ebed728b729f3eb1b in container-registry.oracle.com/java/openjdk: manifest unknown

 podman inspect container-registry.oracle.com/java/openjdk:17 -f {{.Digest}}
sha256:854a4b5d81a6962f589c86e96f65500d9f1f151d7fbcb4bb0d90020f581bdfdb


```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested via our github actions workflow build.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
